### PR TITLE
Change language code used for extract translations

### DIFF
--- a/src/zmb/features/languages/generated/client/client.json
+++ b/src/zmb/features/languages/generated/client/client.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "lang": "en-US",
+      "lang": "en",
       "displayName": "English",
       "messages": {
         "form.section.child.name": "Child",

--- a/src/zmb/features/languages/generated/notification/notification.json
+++ b/src/zmb/features/languages/generated/notification/notification.json
@@ -1,7 +1,7 @@
 {
   "data": [
     {
-      "lang": "en-US",
+      "lang": "en",
       "displayName": "English",
       "messages": {
         "birthInProgressNotification": "Birth registration tracking ID is {{trackingId}}. You must visit {{crvsOffice}} to complete the application",


### PR DESCRIPTION
OpenCRVS core is set up to use [ISO 639-1 language codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes) like this:

English = "en"

In December 2020 we configured OpenCRVS to optionally use a CMS like [Contentful](https://www.contentful.com/).

Contentful is set up to use an ISO 639-1 language code followed by a hyphen then an [Alpha-2 country code](https://www.iban.com/country-codes) like this:

U.S. English = "en-US"

When writing the import process to Contentful, we temporarily changed the language codes in the fallback langauge JSON files to the Contentful style and forgot to change it back.  This caused a bug where languages were not loading properly.  

This change is to revert the fallback language code to the correct OpenCRVS compatible standard.