### PR TITLE
ocrvs-1908 nid validation moved from core to country config, for zambia nid lenth is set to 9 digit.

### DIFF
--- a/src/zmb/config/client-config.js
+++ b/src/zmb/config/client-config.js
@@ -53,5 +53,10 @@ window.config = {
       startForm: 4,  
       endBefore: 2
     }
+  },
+  NID_NUMBER_PATTERN: {
+    pattern: /^[0-9]{9}$/,
+    example: '4837281940',
+    num: '9'
   }
 }

--- a/src/zmb/config/client-config.prod.js
+++ b/src/zmb/config/client-config.prod.js
@@ -53,6 +53,11 @@ window.config = {
       startForm: 4,  
       endBefore: 2
     }
+  },
+  NID_NUMBER_PATTERN: {
+    pattern: /^[0-9]{9}$/,
+    example: '4837281940',
+    num: '9'
   }
 }
 

--- a/src/zmb/features/forms/user/userSection.ts
+++ b/src/zmb/features/forms/user/userSection.ts
@@ -143,7 +143,7 @@ export const userSectionFormType: IFormSection = {
           name: 'nid',
           type: TEXT,
           label: messages.NID,
-          required: true,
+          required: false,
           initialValue: '',
           validate: [
             {


### PR DESCRIPTION
![nid-validation](https://user-images.githubusercontent.com/43314141/144424897-43dc9d53-7a99-4a7e-80b7-ec37912bddc7.gif)
