### PR TITLE
ocrvs-1937 'deviceId' renamed as 'device', to fix device not storing in db

### DIFF
--- a/src/zmb/features/employees/model/user.ts
+++ b/src/zmb/features/employees/model/user.ts
@@ -83,7 +83,7 @@ export interface IUser {
   signature: ISignature
   localRegistrar: ILocalRegistrar
   status: string
-  deviceId?: string
+  device?: string
   securityQuestionAnswers?: ISecurityQuestionAnswer[]
   creationDate: number
   auditHistory?: IAuditHistory[]
@@ -172,7 +172,7 @@ const userSchema = new Schema({
     default: statuses.PENDING
   },
   securityQuestionAnswers: [SecurityQuestionAnswerSchema],
-  deviceId: String,
+  device: String,
   creationDate: { type: Number, default: Date.now },
   auditHistory: [AuditHistory]
 })


### PR DESCRIPTION
![device-not-storing](https://user-images.githubusercontent.com/43314141/144597194-b245d8d3-7b20-4cd4-8a8a-9ee45fb7020e.gif)
