### PR TITLE
ocrvs-1936: time period represented using '-'

### DIFF
--- a/src/zmb/features/languages/generated/client/client.json
+++ b/src/zmb/features/languages/generated/client/client.json
@@ -227,7 +227,7 @@
         "constants.week": "Week",
         "constants.within45Days": "Within 45 days",
         "constants.within45DaysTo1Year": "45 days - 1 year",
-        "constants.within1YearTo5Years": "1 year to 5 years",
+        "constants.within1YearTo5Years": "1 year - 5 years",
         "countries.ABW": "Aruba",
         "countries.AFG": "Afghanistan",
         "countries.AGO": "Angola",


### PR DESCRIPTION
![Screenshot from 2021-12-22 14-12-24](https://user-images.githubusercontent.com/43314141/147059073-5844e77a-e97d-4be4-88c4-0a8341692128.png)
