### PR TITLE
Validate CSV files used for populating the database before starting

### DIFF
--- a/createReferenceData.sh
+++ b/createReferenceData.sh
@@ -8,6 +8,7 @@
 #
 # Copyright (C) The OpenCRVS Authors. OpenCRVS and the OpenCRVS
 # graphic logo are (registered/a) trademark(s) of Plan International.
+set -e
 
 if [ -z "$1" ]
   then
@@ -51,7 +52,7 @@ docker run --rm --network=$NETWORK appropriate/curl curl -X POST 'http://influxd
 
 
 ## Populate new application data
-
+ts-node -r tsconfig-paths/register src/scripts/validate-source-files.ts
 ts-node -r tsconfig-paths/register src/features/administrative/scripts/prepare-locations.ts
 ts-node -r tsconfig-paths/register src/features/administrative/scripts/assign-admin-structure-to-locations.ts
 ts-node -r tsconfig-paths/register src/features/facilities/scripts/prepare-source-facilities.ts

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "dotenv": "^6.1.0",
     "json2csv": "^4.3.0",
     "jsonwebtoken": "^8.3.0",
-    "niceware": "^2.0.2"
+    "niceware": "^2.0.2",
+    "zod": "^3.17.3"
   },
   "dependencies": {
     "@faker-js/faker": "^6.0.0-alpha.5",

--- a/src/data-generator/certify.ts
+++ b/src/data-generator/certify.ts
@@ -14,7 +14,6 @@ import {
 } from './gateway'
 import { omit } from 'lodash'
 import { GATEWAY_HOST } from './constants'
-import { markDeathAsRegistered } from './register'
 import { MARK_BIRTH_AS_CERTIFIED, MARK_DEATH_AS_CERTIFIED } from './queries'
 import { differenceInDays } from 'date-fns'
 import { ConfigResponse } from './config'

--- a/src/features/administrative/statistics.ts
+++ b/src/features/administrative/statistics.ts
@@ -1,7 +1,6 @@
-import * as csv2json from 'csv2json'
-import { createReadStream } from 'fs'
 import { sumBy, uniq } from 'lodash'
 import { join } from 'path'
+import { readCSVToJSON } from '../../utils'
 
 type Year = {
   year: number
@@ -26,10 +25,10 @@ type LocationItem = {
 
 export async function getStatisticsForStates() {
   const districts = await readCSVToJSON<LocationItem[]>(
-    './source/districts.csv'
+    join(__dirname, './source/districts.csv')
   )
   const states = await readCSVToJSON<LocationItem[]>(
-    './source/states.csv'
+    join(__dirname, './source/states.csv')
   )
   const districtStatistics = await getStatistics()
 
@@ -70,7 +69,7 @@ export async function getStatisticsForStates() {
 export async function getStatistics() {
   const data = await readCSVToJSON<
     Array<Record<string, string> & { statisticalID: string }>
-  >('./source/statistics.csv')
+  >(join(__dirname, './source/statistics.csv'))
 
   return data.map<LocationStatistic>(item => {
     const { statisticalID, ...yearKeys } = item
@@ -88,21 +87,5 @@ export async function getStatistics() {
           crude_birth_rate: parseFloat(yearKeys[`crude_birth_rate_${year}`])
         }))
     }
-  })
-}
-async function readCSVToJSON<T>(filename: string) {
-  return await new Promise<T>((resolve, reject) => {
-    const chunks: string[] = []
-    createReadStream(join(__dirname, filename))
-      .pipe(
-        csv2json({
-          separator: ','
-        })
-      )
-      .on('data', chunk => chunks.push(chunk))
-      .on('error', reject)
-      .on('end', () => {
-        resolve(JSON.parse(chunks.join('')))
-      })
   })
 }

--- a/src/scripts/validate-source-files.ts
+++ b/src/scripts/validate-source-files.ts
@@ -1,0 +1,301 @@
+import {
+  ADMIN_STRUCTURE_SOURCE,
+  EMPLOYEES_SOURCE,
+  FACILITIES_SOURCE
+} from '@countryconfig/constants'
+import { range } from 'lodash'
+import { z } from 'zod'
+import chalk from 'chalk'
+import { basename } from 'path'
+import { readCSVToJSON } from '@countryconfig/utils'
+
+const Location = z.object({
+  statisticalID: z.string(),
+  name: z.string(),
+  partOf: z
+    .string()
+    .regex(
+      /^Location\//,
+      'Invalid format: partOf needs to be in Location/<id> format e.g. Location/KozcEjeTyuD'
+    ),
+  code: z.enum(['ADMIN_STRUCTURE'], {
+    required_error:
+      'Field "code" missing, make sure all rows define all required fields'
+  }),
+  physicalType: z.enum(['Jurisdiction'], {
+    required_error:
+      'Field "physicalType" missing, make sure all rows define all required fields'
+  })
+})
+
+const Facility = Location.extend({
+  physicalType: z.undefined(),
+  code: z.enum(['HEALTH_FACILITY'], {
+    required_error:
+      'Field "code" missing, make sure all rows define all required fields'
+  })
+})
+
+const CRVSFacility = Facility.extend({
+  code: z.enum(['CRVS_OFFICE'], {
+    required_error:
+      'Field "code" missing, make sure all rows define all required fields'
+  }),
+  district: z.string({
+    required_error:
+      "CRVS Facility's district name is missing. This will be shown in the facility's address details"
+  }),
+  state: z.string({
+    required_error:
+      "CRVS Facility's state name is missing. This will be shown in the facility's address details"
+  }),
+  physicalType: z.enum(['Building'], {
+    required_error:
+      'Field "physicalType" missing, make sure all rows define all required fields'
+  })
+})
+
+const Employee = z.object({
+  facilityId: z
+    .string()
+    .regex(
+      /^CRVS_OFFICE_/,
+      'Invalid format: facilityId needs to be in a CRVS_OFFICE_<id> format e.g. CRVS_OFFICE_oEBf29y8JP8'
+    ),
+  environment: z.enum(['development', 'production']),
+  username: z.string(),
+  givenNames: z.string(),
+  familyName: z.string(),
+  gender: z.string(),
+  role: z.enum([
+    'FIELD_AGENT',
+    'REGISTRATION_AGENT',
+    'LOCAL_REGISTRAR',
+    'LOCAL_SYSTEM_ADMIN',
+    'NATIONAL_SYSTEM_ADMIN',
+    'PERFORMANCE_MANAGEMENT',
+    'NATIONAL_REGISTRAR'
+  ]),
+  type: z.enum([
+    'DATA_ENTRY_CLERK',
+    'DISTRICT_REGISTRAR',
+    'POLICE_OFFICER',
+    'SOCIAL_WORKER',
+    'LOCAL_LEADER',
+    'HEALTHCARE_WORKER',
+    'DNRPC',
+    'ENTREPENEUR',
+    ''
+  ]),
+  mobile: z.string(),
+  email: z.string(),
+  signature: z
+    .string()
+    .regex(
+      /^$|^data:image\/png;base64,/, // Empty or base64 encoded image
+      'Invalid format: signature needs to be in a base64-format, starting with data:image/png;base64,'
+    )
+    .nullable()
+    .optional()
+})
+
+const parsedNumber = z
+  .string()
+  .regex(
+    /^[+-]?([0-9]*[.])?[0-9]+$/,
+    'Numbers can only contain digits (0-9) and dots (.)'
+  )
+  .transform(parseFloat)
+  .refine((val: number) => !Number.isNaN(val), 'Failed to parse number')
+
+const Statistic = z.object({
+  statisticalID: z.string(),
+  name: z.string(),
+  ...Object.fromEntries(
+    range(2007, 2021).flatMap(year => [
+      [`male_population_${year}`, parsedNumber],
+      [`female_population_${year}`, parsedNumber],
+      [`population_${year}`, parsedNumber],
+      [`crude_birth_rate_${year}`, parsedNumber]
+    ])
+  )
+})
+
+function printIssue(issue: z.ZodIssue) {
+  console.log(
+    chalk.red(
+      chalk.bold(
+        `Line ${(issue.path[0] as number) + 2}, column "${issue.path[1]}":`
+      )
+    ),
+    chalk.red(issue.message)
+  )
+}
+
+function log(...params: any[]) {
+  console.log(...params)
+}
+
+function error(...params: any[]) {
+  console.error(...params.map(p => chalk.red(p)))
+}
+
+const DISTRICTS = `${ADMIN_STRUCTURE_SOURCE}source/districts.csv`
+const STATISTICS = `${ADMIN_STRUCTURE_SOURCE}source/statistics.csv`
+const STATES = `${ADMIN_STRUCTURE_SOURCE}source/states.csv`
+const EMPLOYEES = `${EMPLOYEES_SOURCE}source/test-employees.csv`
+const CRVS_FACILITIES = `${FACILITIES_SOURCE}source/crvs-facilities.csv`
+const HEALTH_FACILITIES = `${FACILITIES_SOURCE}source/health-facilities.csv`
+
+async function main() {
+  log(chalk.yellow('Validating file:'), chalk.bold(STATES))
+  const rawStates = await readCSVToJSON(STATES)
+  const states = Location.array().parse(rawStates)
+  log(chalk.green('File is valid'), '✅', '\n')
+
+  log(chalk.yellow('Validating file:'), chalk.bold(DISTRICTS))
+
+  const rawDistricts = await readCSVToJSON(DISTRICTS)
+
+  const districts = Location.array().parse(rawDistricts)
+
+  for (const district of districts) {
+    const state = states.find(
+      state => district.partOf === `Location/${state.statisticalID}`
+    )
+    if (!state) {
+      error(
+        DISTRICTS,
+        `Line ${districts.indexOf(district) + 2}`,
+        'District',
+        district.name,
+        'is not part of any known state'
+      )
+      process.exit(1)
+    }
+  }
+  log(chalk.green('File is valid'), '✅', '\n')
+  log(chalk.yellow('Validating file:'), chalk.bold(STATISTICS))
+  const rawStatistics = await readCSVToJSON(STATISTICS)
+
+  const statistics = Statistic.array().parse(rawStatistics)
+
+  for (const district of districts) {
+    const state = states.find(
+      state => district.partOf === `Location/${state.statisticalID}`
+    )
+    if (!state) {
+      error(
+        DISTRICTS,
+        chalk.yellow(`Line ${districts.indexOf(district) + 2}`),
+        'District',
+        district.name,
+        'is not part of any known state'
+      )
+      process.exit(1)
+    }
+  }
+
+  for (const statistic of statistics) {
+    const district = districts.find(
+      district => district.statisticalID === statistic.statisticalID
+    )
+    if (!district) {
+      error(
+        chalk.blue(basename(STATISTICS)),
+        chalk.yellow(`Line ${statistics.indexOf(statistic) + 2}`),
+        'District',
+        statistic.name,
+        'is not part of any known district'
+      )
+      process.exit(1)
+    }
+  }
+  log(chalk.green('File is valid'), '✅', '\n')
+
+  log(chalk.yellow('Validating file:'), chalk.bold(HEALTH_FACILITIES))
+  const rawFacilities = await readCSVToJSON(HEALTH_FACILITIES)
+
+  const facilities = Facility.array().parse(rawFacilities)
+
+  for (const facility of facilities) {
+    const district = districts.find(
+      district => facility.partOf === `Location/${district.statisticalID}`
+    )
+    if (!district) {
+      error(
+        chalk.blue(basename(HEALTH_FACILITIES)),
+        chalk.yellow(`Line ${facilities.indexOf(facility) + 2}`),
+        'Facility',
+        facility.name,
+        'is not part of any known district'
+      )
+      process.exit(1)
+    }
+  }
+  log(chalk.green('File is valid'), '✅', '\n')
+
+  log(chalk.yellow('Validating file:'), chalk.bold(CRVS_FACILITIES))
+  const rawCRVSFacilities = await readCSVToJSON(CRVS_FACILITIES)
+
+  const crvsFacilities = CRVSFacility.array().parse(rawCRVSFacilities)
+
+  for (const facility of crvsFacilities) {
+    const partOf = districts
+      .concat(states)
+      .find(
+        district => facility.partOf === `Location/${district.statisticalID}`
+      )
+    if (!partOf) {
+      error(
+        chalk.yellow(chalk.bold(basename(CRVS_FACILITIES))),
+        chalk.yellow(`Line ${crvsFacilities.indexOf(facility) + 2}`),
+        'CRVS Facility',
+        facility.name,
+        'is not part of any known state or district'
+      )
+      process.exit(1)
+    }
+  }
+  log(chalk.green('File is valid'), '✅', '\n')
+  log(chalk.yellow('Validating file:'), chalk.bold(EMPLOYEES))
+  const rawEmployees = await readCSVToJSON(EMPLOYEES)
+
+  const employees = Employee.array().parse(rawEmployees)
+
+  for (const employee of employees) {
+    const facility = crvsFacilities.find(
+      facility =>
+        employee.facilityId === `CRVS_OFFICE_${facility.statisticalID}`
+    )
+    if (!facility) {
+      error(
+        chalk.blue(EMPLOYEES),
+        chalk.yellow(`Line ${employees.indexOf(employee) + 2}`),
+        'Employee',
+        employee.username,
+        `has an invalid or unknown facilityId (${employee.facilityId}). Make sure facility the id after CRVS_OFFICE_ matches one of the facilities in crvs-facilities.csv`
+      )
+      process.exit(1)
+    }
+  }
+  log(chalk.green('File is valid'), '✅', '\n')
+}
+
+main().catch(err => {
+  if (err instanceof z.ZodError) {
+    err.issues.forEach(printIssue)
+    process.exit(1)
+  }
+
+  if (err.code === 'ENOENT') {
+    error(
+      chalk.red('File not found'),
+      chalk.bold(basename(err.path)),
+      chalk.red('Please make sure the file is located in'),
+      chalk.bold(err.path)
+    )
+    process.exit(1)
+  }
+  throw err
+})

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,6 +12,8 @@
 import { callingCountries } from 'country-data'
 import { createHash } from 'crypto'
 import * as uuid from 'uuid/v4'
+import * as csv2json from 'csv2json'
+import { createReadStream } from 'fs'
 
 export interface ISaltedHash {
   hash: string
@@ -60,4 +62,22 @@ export const convertToMSISDN = (phone: string, countryAlpha3: string) => {
   return phone.startsWith('0')
     ? `${countryCode}${phone.substring(1)}`
     : `${countryCode}${phone}`
+}
+
+export async function readCSVToJSON<T>(filename: string) {
+  return new Promise<T>((resolve, reject) => {
+    const chunks: string[] = []
+    createReadStream(filename)
+      .on('error', reject)
+      .pipe(
+        csv2json({
+          separator: ','
+        })
+      )
+      .on('data', chunk => chunks.push(chunk))
+      .on('error', reject)
+      .on('end', () => {
+        resolve(JSON.parse(chunks.join('')))
+      })
+  })
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,7 @@
     "noImplicitReturns": true,
     "noImplicitThis": true,
     "noImplicitAny": true,
+    "skipLibCheck": true,
     "strictNullChecks": true,
     "suppressImplicitAnyIndexErrors": true,
     "noUnusedLocals": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -9663,3 +9663,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.17.3:
+  version "3.17.3"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.17.3.tgz#86abbc670ff0063a4588d85a4dcc917d6e4af2ba"
+  integrity sha512-4oKP5zvG6GGbMlqBkI5FESOAweldEhSOZ6LI6cG+JzUT7ofj1ZOC0PJudpQOpT1iqOFpYYtX5Pw0+o403y4bcg==


### PR DESCRIPTION
The populate script now first validates all the input CSV files. It checks:

- That all required columns are there and data looks about right format-wise
- Checks that all district -> state references are correct
- Checks all facility -> district/state references are correct
- Checks all employee facilityId references are correct