### PR TITLE
User Audit: Ensure that x-real-* headers are kept as is when registration validation goes through country config

### DIFF
--- a/src/features/validate/handler.ts
+++ b/src/features/validate/handler.ts
@@ -30,19 +30,13 @@ export async function validateRegistrationHandler(
     fetch(CONFIRM_REGISTRATION_URL, {
       method: 'POST',
       body: JSON.stringify(webHookResponse),
-      headers: {
-        Authorization: request.headers.authorization,
-        'Content-Type': 'application/json'
-      }
+      headers: request.headers
     })
   } catch (err) {
     fetch(CONFIRM_REGISTRATION_URL, {
       method: 'POST',
       body: JSON.stringify({ error: err.message }),
-      headers: {
-        Authorization: request.headers.authorization,
-        'Content-Type': 'application/json'
-      }
+      headers: request.headers
     })
 
     logger.error(err)


### PR DESCRIPTION
Related to this PR: https://github.com/opencrvs/opencrvs-core/pull/3949

For User Audit, we need to show the IP address and user-agent of whoever triggered the action. We're using two special headers for persisting that information through our stack called `x-real-ip` and `x-real-user-agent`. We noticed `REGISTERED` always being shown as a local IP and user-agent as node-fetch. After debugging for a while, I noticed it's actually because country config won't pass these headers forward, which breaks the chain.