### PR TITLE
Validate sensicality of locations in import script

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,7 @@
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
-  plugins: [
-    '@typescript-eslint'
-  ],
+  plugins: ['@typescript-eslint'],
   extends: [
     'eslint:recommended',
     'plugin:prettier/recommended',
@@ -16,9 +14,10 @@ module.exports = {
     'no-undef': 'warn'
   },
   globals: {
-    'NodeJS': true
+    NodeJS: true
   },
   env: {
-    'node': true
+    node: true,
+    jest: true
   }
-};
+}

--- a/src/scripts/humdata-validation.ts
+++ b/src/scripts/humdata-validation.ts
@@ -1,0 +1,60 @@
+import { z } from 'zod'
+
+export const zodValidateDuplicates =
+  (column: string) =>
+  (list: Array<Record<string, any>>, ctx: z.RefinementCtx) => {
+    const existingColumnValues: string[] = []
+
+    for (let i = 0; i < list.length; i++) {
+      if (existingColumnValues.includes(list[i][column])) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Duplicate value "${list[i][column]}"`,
+          path: [i, column]
+        })
+        return false
+      }
+      existingColumnValues.push(list[i][column])
+    }
+
+    return true
+  }
+
+/** Validates location data by Map<Location, ParentLocation>. If there are locations that have different parent location than previously added ones, an error will be thrown */
+export const validateSensicalityOfLocationTree =
+  (options: { maxAdminLevel: number }) =>
+  (data: Array<Record<string, any>>, ctx: z.RefinementCtx) => {
+    type Location = string
+    type ParentLocation = string
+
+    const locationMap: Map<Location, ParentLocation> = new Map()
+
+    for (let i = 0; i < data.length; i++) {
+      const row = data[i]
+
+      for (
+        let adminLevel = options.maxAdminLevel;
+        adminLevel >= 0;
+        adminLevel--
+      ) {
+        const column = `admin${adminLevel}Pcode`
+        const locationId = row[column]
+        const parentColumn = `admin${adminLevel - 1}Pcode`
+
+        if (!locationMap.get(locationId)) {
+          locationMap.set(locationId, row[parentColumn])
+        } else {
+          if (row[parentColumn] !== locationMap.get(locationId)) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: `Conflicting value "${locationId}". The same location might have different parent locations in a different row. Please see rows using the same value.`,
+              path: [i, column]
+            })
+            return false
+          }
+        }
+      }
+    }
+
+    return true
+  }

--- a/src/scripts/validate-source-files.ts
+++ b/src/scripts/validate-source-files.ts
@@ -3,6 +3,16 @@ import { z } from 'zod'
 import chalk from 'chalk'
 import { basename } from 'path'
 import { readCSVToJSON } from '@countryconfig/features/utils'
+import {
+  validateSensicalityOfLocationTree,
+  zodValidateDuplicates
+} from './humdata-validation'
+
+const Locations = (options: { maxAdminLevel: number }) =>
+  z
+    .array(z.unknown())
+    .superRefine(zodValidateDuplicates(`admin${options.maxAdminLevel}Pcode`))
+    .superRefine(validateSensicalityOfLocationTree(options))
 
 const Facility = z.object({
   adminPcode: z.string(),
@@ -23,6 +33,10 @@ const HealthFacility = Facility.extend({
   })
 })
 
+const HealthFacilities = HealthFacility.array().superRefine(
+  zodValidateDuplicates('adminPcode')
+)
+
 const CRVSFacility = HealthFacility.extend({
   code: z.enum(['CRVS_OFFICE'], {
     required_error:
@@ -41,6 +55,10 @@ const CRVSFacility = HealthFacility.extend({
       'Field "physicalType" missing, make sure all rows define all required fields'
   })
 })
+
+const CRVSFacilities = CRVSFacility.array().superRefine(
+  zodValidateDuplicates('adminPcode')
+)
 
 const Employee = z.object({
   facilityId: z
@@ -86,6 +104,10 @@ const Employee = z.object({
     .optional()
 })
 
+const Employees = Employee.array().superRefine(
+  zodValidateDuplicates('username')
+)
+
 const parsedNumber = z
   .string()
   .regex(
@@ -108,7 +130,12 @@ const Statistic = z.object({
   )
 })
 
+const Statistics = Statistic.array().superRefine(
+  zodValidateDuplicates('adminPcode')
+)
+
 function printIssue(issue: z.ZodIssue) {
+  // eslint-disable-next-line no-console
   console.log(
     chalk.red(
       chalk.bold(
@@ -120,10 +147,12 @@ function printIssue(issue: z.ZodIssue) {
 }
 
 function log(...params: any[]) {
+  // eslint-disable-next-line no-console
   console.log(...params)
 }
 
 function error(...params: any[]) {
+  // eslint-disable-next-line no-console
   console.error(...params.map((p) => chalk.red(p)))
 }
 
@@ -157,10 +186,11 @@ async function main() {
     }
   }
 
+  /** The most granular admin level, bigger number = lower level of administration */
   let MAX_ADMIN_LEVEL = 0
 
   for (const header of csvLocationHeaders) {
-    const currentLevel = /^admin(\d+)pcode/i.exec(header)
+    const currentLevel = pcodeExpression.exec(header)
     if (currentLevel) {
       MAX_ADMIN_LEVEL < Number(currentLevel[1])
         ? (MAX_ADMIN_LEVEL = Number(currentLevel[1]))
@@ -168,11 +198,13 @@ async function main() {
     }
   }
 
+  Locations({ maxAdminLevel: MAX_ADMIN_LEVEL }).parse(rawLocations)
+
   log(chalk.green('Admin levels parsed'), '✅', '\n')
 
   log(chalk.yellow('Validating statistics file.'))
   const rawStatistics = await readCSVToJSON(process.argv[6])
-  const statistics = Statistic.array().parse(rawStatistics)
+  const statistics = Statistics.parse(rawStatistics)
 
   for (const statistic of statistics) {
     let location
@@ -186,7 +218,9 @@ async function main() {
     }
     if (!location) {
       error(
-        chalk.blue(`LOCATIONS ERROR!: Parsed ADMIN_LEVELS: ${ADMIN_LEVELS}`),
+        chalk.blue(
+          `LOCATIONS ERROR!: Parsed MAX_ADMIN_LEVEL: ${MAX_ADMIN_LEVEL}`
+        ),
         chalk.yellow(`Line ${statistics.indexOf(statistic) + 2}`),
         statistic.name,
         'is not part of any known location'
@@ -198,7 +232,7 @@ async function main() {
 
   log(chalk.yellow('Validating health facilities file.'))
   const rawFacilities = await readCSVToJSON(process.argv[4])
-  const facilities = HealthFacility.array().parse(rawFacilities)
+  const facilities = HealthFacilities.parse(rawFacilities)
 
   for (const facility of facilities) {
     const location = rawLocations.find(
@@ -221,7 +255,7 @@ async function main() {
 
   log(chalk.yellow('Validating crvs offices file.'))
   const rawCRVSFacilities = await readCSVToJSON(process.argv[3])
-  const crvsFacilities = CRVSFacility.array().parse(rawCRVSFacilities)
+  const crvsFacilities = CRVSFacilities.parse(rawCRVSFacilities)
 
   for (const facility of crvsFacilities) {
     const partOf = rawLocations.find(
@@ -244,7 +278,7 @@ async function main() {
   log(chalk.yellow('Validating employees file.'))
   const rawEmployees = await readCSVToJSON(process.argv[5])
 
-  const employees = Employee.array().parse(rawEmployees)
+  const employees = Employees.parse(rawEmployees)
 
   for (const employee of employees) {
     const facility = crvsFacilities.find(

--- a/src/scripts/validate-source-files.ts
+++ b/src/scripts/validate-source-files.ts
@@ -135,7 +135,7 @@ async function main() {
   const aliasExpression = /^admin(\d+)name_alias$/i
   const pcodeExpression = /^admin(\d+)Pcode$/i
   const csvLocationHeaders = [...new Set(rawLocations.flatMap(Object.keys))]
-  csvLocationHeaders.map((header: string) => {
+  for (const header of csvLocationHeaders) {
     let headersOK: RegExpExecArray | null
     headersOK = countryExpression.exec(header)
     if (!headersOK) {
@@ -155,6 +155,7 @@ async function main() {
         }
       }
     }
+  }
 
   let MAX_ADMIN_LEVEL = 0
 

--- a/src/scripts/validate-source-files.ts
+++ b/src/scripts/validate-source-files.ts
@@ -155,18 +155,19 @@ async function main() {
         }
       }
     }
-  })
-  let ADMIN_LEVELS = 0
 
-  csvLocationHeaders.find((header: string) => {
+  let MAX_ADMIN_LEVEL = 0
+
+  for (const header of csvLocationHeaders) {
     const currentLevel = /^admin(\d+)pcode/i.exec(header)
     if (currentLevel) {
-      ADMIN_LEVELS < Number(currentLevel[1])
-        ? (ADMIN_LEVELS = Number(currentLevel[1]))
-        : ADMIN_LEVELS
+      MAX_ADMIN_LEVEL < Number(currentLevel[1])
+        ? (MAX_ADMIN_LEVEL = Number(currentLevel[1]))
+        : MAX_ADMIN_LEVEL
     }
-  })
-  log(chalk.green('ADMIN_LEVELS parsed'), '✅', '\n')
+  }
+
+  log(chalk.green('Admin levels parsed'), '✅', '\n')
 
   log(chalk.yellow('Validating statistics file.'))
   const rawStatistics = await readCSVToJSON(process.argv[6])
@@ -174,7 +175,7 @@ async function main() {
 
   for (const statistic of statistics) {
     let location
-    for (let i = ADMIN_LEVELS; i > 0; i--) {
+    for (let i = MAX_ADMIN_LEVEL; i > 0; i--) {
       if (!location) {
         location = rawLocations.find(
           (locationData) =>
@@ -202,7 +203,7 @@ async function main() {
     const location = rawLocations.find(
       (locationData) =>
         facility.partOf ===
-        `Location/${locationData[`admin${ADMIN_LEVELS}Pcode`]}`
+        `Location/${locationData[`admin${MAX_ADMIN_LEVEL}Pcode`]}`
     )
     if (!location) {
       error(
@@ -225,7 +226,7 @@ async function main() {
     const partOf = rawLocations.find(
       (locationData) =>
         facility.partOf ===
-        `Location/${locationData[`admin${ADMIN_LEVELS}Pcode`]}`
+        `Location/${locationData[`admin${MAX_ADMIN_LEVEL}Pcode`]}`
     )
     if (!partOf) {
       error(


### PR DESCRIPTION
- [x] Validate there not being duplicates in locations
- [x] Validate that location tree makes sense. For example, "kansas_city,texas,united_states" and "helsinki,texas,finland" would conflict as identifier "texas" cannot be in 2 different places

**When reviewing, please test:**
- [x] Import a location CSV with duplicate locations. Check error message exists, check the sanity of the text of it
- [x] Import a non-sensical location pattern, like described above in task 2. Check error message exists, check the sanity of the text of it