### PR TITLE
Remove all port exposing configuration from docker compose

### DIFF
--- a/infrastructure/docker-compose.deploy.yml
+++ b/infrastructure/docker-compose.deploy.yml
@@ -257,8 +257,6 @@ services:
       - discovery.type=single-node
       - xpack.security.enabled=true
       - xpack.security.authc.api_key.enabled=true
-    ports:
-      - 9200:9200
     networks:
       - overlay_net
     logging:
@@ -357,9 +355,6 @@ services:
     command: logstash -f /etc/logstash/logstash.conf --verbose
     depends_on:
       - elasticsearch
-    ports:
-      - '12201:12201'
-      - '12201:12201/udp'
     configs:
       - source: logstash-pipeline.{{ts}}
         target: /etc/logstash/logstash.conf
@@ -385,8 +380,6 @@ services:
     cap_add: ['CHOWN', 'DAC_OVERRIDE', 'SETGID', 'SETUID']
     cap_drop: ['ALL']
     restart: always
-    ports:
-      - 8200:8200
     networks:
       - overlay_net
     deploy:


### PR DESCRIPTION
There’s a known security issue with Docker and UFW:

https://github.com/chaifeng/ufw-docker

TLDR is no matter if you’ve blocked a port (let’s say 9200) in UFW, it’s still visible to the public internet if it’s exposed in docker compose’s:

ports:
  - 9200:9200