### PR TITLE
Upgrade Traefik to v2.9 to upgrade default minimum TLS to 1.2

### DIFF
--- a/infrastructure/docker-compose.deploy.yml
+++ b/infrastructure/docker-compose.deploy.yml
@@ -14,7 +14,7 @@ services:
   # Note: these published port will override UFW rules as Docker manages it's own iptables
   # Only publish the exact ports that are required for OpenCRVS to work
   traefik:
-    image: 'traefik:v2.8'
+    image: 'traefik:v2.9'
     ports:
       - target: 80
         published: 80


### PR DESCRIPTION
https://github.com/opencrvs/opencrvs-core/issues/5606

I have deployed this branch to staging and it seems to work fine. 

The deployed environments have TLS 1.3 enabled though even before this PR is merged:
<img width="546" alt="image" src="https://github.com/opencrvs/opencrvs-farajaland/assets/1322608/8fc1f55a-6fa8-4d35-92cf-e2d36380e39a">
