### PR TITLE
Fixed query mapping bug

### DIFF
--- a/src/form/addresses/address-fields.ts
+++ b/src/form/addresses/address-fields.ts
@@ -20,6 +20,8 @@ import {
   yesNoRadioOptions
 } from '../common/select-options'
 import { ADMIN_LEVELS } from '.'
+import { getPlaceOfBirthFields } from '../birth/required-fields'
+import { getPlaceOfDeathFields } from '../death/required-fields'
 
 // A radio group field that allows you to select an address from another section
 export const getXAddressSameAsY = (
@@ -162,6 +164,21 @@ function getAdminLevelSelects(
   }
 }
 
+// Place of birth and death fields require a select option to choose a hospital from health facility databases
+// We recommend that you do not edit this function
+function getPlaceOfEventFields(useCase: EventLocationAddressCases) {
+  switch (useCase) {
+    case EventLocationAddressCases.PLACE_OF_BIRTH:
+      return [...getPlaceOfBirthFields()]
+    case EventLocationAddressCases.PLACE_OF_DEATH:
+      return [...getPlaceOfDeathFields()]
+    case EventLocationAddressCases.PLACE_OF_MARRIAGE:
+      return []
+    default:
+      return []
+  }
+}
+
 // The fields that appear whenever an address is rendered
 
 // ====================== WARNING REGARDING ADDRESS CONFIGURATION ======================
@@ -178,11 +195,17 @@ export function getAddressFields(
   addressCase: EventLocationAddressCases | AddressCases
 ): SerializedFormField[] {
   let useCase = addressCase as string
+  let placeOfEventFields: SerializedFormField[] = []
   if (addressCase in AddressCases) {
     useCase = useCase === AddressCases.PRIMARY_ADDRESS ? 'primary' : 'secondary'
+  } else {
+    placeOfEventFields = getPlaceOfEventFields(
+      useCase as EventLocationAddressCases
+    )
   }
 
   return [
+    ...placeOfEventFields,
     {
       name: `country${sentenceCase(useCase)}${sentenceCase(section)}`,
       type: 'SELECT_WITH_OPTIONS',

--- a/src/form/addresses/index.ts
+++ b/src/form/addresses/index.ts
@@ -50,10 +50,12 @@ export const defaultAddressConfiguration: IAddressConfiguration[] = [
     // THE "configurations" ARRAY LISTS THE AVAILABLE FIELDSET CONFIGURATIONS THAT WILL RENDER
     // OPTIONS ARE THE FULL PLACE OF EVENT FIELDS, STANDARD ADDRESS FIELDS, ADDRESS SUBSECTION DIVIDERS, OR RADIO BUTTONS TO SIMPLIFY FORM ENTRY
 
-    precedingFieldId: 'birth.child.child-view-group.birthLocation',
+    // PLACE OF BIRTH ADDRESS FIELDS
+    precedingFieldId: 'birth.child.child-view-group.childBirthDate',
     configurations: [{ config: EventLocationAddressCases.PLACE_OF_BIRTH }]
   },
   {
+    // INFORMANT ADDRESS FIELDS
     precedingFieldId:
       'birth.informant.informant-view-group.informant-nid-seperator',
     configurations: [
@@ -85,6 +87,7 @@ export const defaultAddressConfiguration: IAddressConfiguration[] = [
     ]
   },
   {
+    // MOTHER ADDRESS FIELDS
     precedingFieldId: 'birth.mother.mother-view-group.mother-nid-seperator',
     configurations: [
       {
@@ -108,6 +111,7 @@ export const defaultAddressConfiguration: IAddressConfiguration[] = [
     ]
   },
   {
+    // FATHER ADDRESS FIELDS
     precedingFieldId: 'birth.father.father-view-group.father-nid-seperator',
     configurations: [
       {
@@ -138,10 +142,12 @@ export const defaultAddressConfiguration: IAddressConfiguration[] = [
     ]
   },
   {
-    precedingFieldId: 'death.deathEvent.death-event-details.deathLocation',
+    // PLACE OF DEATH ADDRESS FIELDS
+    precedingFieldId: 'death.deathEvent.death-event-details.deathDescription',
     configurations: [{ config: EventLocationAddressCases.PLACE_OF_DEATH }]
   },
   {
+    // DECEASED ADDRESS FIELDS
     precedingFieldId: 'death.deceased.deceased-view-group.maritalStatus',
     configurations: [
       {
@@ -159,6 +165,7 @@ export const defaultAddressConfiguration: IAddressConfiguration[] = [
     ]
   },
   {
+    // INFORMANT ADDRESS FIELDS
     precedingFieldId: 'death.informant.informant-view-group.informantID',
     configurations: [
       {
@@ -186,11 +193,13 @@ export const defaultAddressConfiguration: IAddressConfiguration[] = [
     ]
   },
   {
+    // PLACE OF MARRIAGE ADDRESS FIELDS
     precedingFieldId:
       'marriage.marriageEvent.marriage-event-details.place-of-marriage-seperator',
     configurations: [{ config: EventLocationAddressCases.PLACE_OF_MARRIAGE }]
   },
   {
+    // GRROM ADDRESS FIELDS
     precedingFieldId: 'marriage.groom.groom-view-group.marriedLastNameEng',
     configurations: [
       {
@@ -210,6 +219,7 @@ export const defaultAddressConfiguration: IAddressConfiguration[] = [
     ]
   },
   {
+    // BRIDE ADDRESS FIELDS
     precedingFieldId: 'marriage.bride.bride-view-group.marriedLastNameEng',
     configurations: [
       {
@@ -229,6 +239,7 @@ export const defaultAddressConfiguration: IAddressConfiguration[] = [
     ]
   },
   {
+    // INFORMANT ADDRESS FIELDS
     precedingFieldId:
       'marriage.informant.who-is-applying-view-group.informantID',
     configurations: [

--- a/src/form/birth/index.ts
+++ b/src/form/birth/index.ts
@@ -15,7 +15,6 @@ import { formMessageDescriptors } from '../common/messages'
 import {
   getDetailsExist,
   getReasonNotExisting,
-  getPlaceOfBirthFields,
   informantType
 } from './required-fields'
 import {
@@ -52,19 +51,16 @@ import {
 import {
   isValidChildBirthDate,
   hideIfInformantMotherOrFather,
-  hideIfNidIntegrationDisabled,
   mothersDetailsExistConditionals,
   mothersBirthDateConditionals,
   parentsBirthDateValidators,
   detailsExist,
   motherFirstNameConditionals,
   motherFamilyNameConditionals,
-  motherNationalIDVerfication,
   fathersDetailsExistConditionals,
   fathersBirthDateConditionals,
   fatherFirstNameConditionals,
   fatherFamilyNameConditionals,
-  fatherNationalIDVerfication,
   informantNotMotherOrFather,
   detailsExistConditional
 } from '../common/default-validation-conditionals'
@@ -194,7 +190,7 @@ export const birthForm: ISerializedForm = {
               isValidChildBirthDate,
               certificateHandlebars.eventDate
             ), // Required field.
-            ...getPlaceOfBirthFields(), // Required fields.
+            // PLACE OF BIRTH FIELDS WILL RENDER HERE
             divider('place-of-birth-seperator'),
             attendantAtBirth,
             birthType,
@@ -274,6 +270,7 @@ export const birthForm: ISerializedForm = {
                 expression: informantNotMotherOrFather
               }
             ]),
+            // ADDRESS FIELDS WILL RENDER HERE
             divider('informant-address-seperator', [
               {
                 action: 'hide',
@@ -339,6 +336,7 @@ export const birthForm: ISerializedForm = {
             ),
             // preceding field of address fields
             divider('mother-nid-seperator', detailsExist),
+            // ADDRESS FIELDS WILL RENDER HERE
             divider('mother-address-seperator', detailsExist),
             getMaritalStatus(certificateHandlebars.motherMaritalStatus, [
               {
@@ -414,6 +412,7 @@ export const birthForm: ISerializedForm = {
             ),
             // preceding field of address fields
             divider('father-nid-seperator', detailsExist),
+            // ADDRESS FIELDS WILL RENDER HERE
             divider('father-address-seperator', detailsExist),
             getMaritalStatus(certificateHandlebars.fatherMaritalStatus, [
               {

--- a/src/form/death/index.ts
+++ b/src/form/death/index.ts
@@ -33,8 +33,7 @@ import {
   getCauseOfDeathMethod,
   getDeathDate,
   getDeathDescription,
-  getMannerOfDeath,
-  getPlaceOfDeathFields
+  getMannerOfDeath
 } from './required-fields'
 import { formMessageDescriptors } from '../common/messages'
 import { Event, ISerializedForm } from '../types/types'
@@ -209,8 +208,8 @@ export const deathForm = {
             getMannerOfDeath,
             getCauseOfDeath,
             getCauseOfDeathMethod,
-            getDeathDescription,
-            ...getPlaceOfDeathFields()
+            getDeathDescription
+            // PLACE OF DEATH FIELDS WILL RENDER HERE
           ]
         }
       ]
@@ -263,7 +262,8 @@ export const deathForm = {
               getNationalIDValidators('informant'),
               certificateHandlebars.informantNID
             ),
-            divider('place-of-death'),
+            // ADDRESS FIELDS WILL RENDER HERE
+            divider('informant-address-separator'),
             registrationPhone,
             registrationEmail
           ],

--- a/src/form/marriage/index.ts
+++ b/src/form/marriage/index.ts
@@ -141,6 +141,7 @@ export const marriageForm: ISerializedForm = {
               getNationalIDValidators('informant'),
               certificateHandlebars.informantNID
             ),
+            // ADDRESS FIELDS WILL RENDER HERE
             registrationPhone,
             registrationEmail
           ],
@@ -168,6 +169,7 @@ export const marriageForm: ISerializedForm = {
               [],
               certificateHandlebars.groomFamilyName
             ), // Required field
+            // ADDRESS FIELDS WILL RENDER HERE
             getBirthDate(
               'groomBirthDate',
               [
@@ -216,6 +218,7 @@ export const marriageForm: ISerializedForm = {
               [],
               certificateHandlebars.brideFamilyName
             ), // Required field
+            // ADDRESS FIELDS WILL RENDER HERE
             getBirthDate(
               'brideBirthDate',
               [
@@ -260,6 +263,7 @@ export const marriageForm: ISerializedForm = {
             getTypeOfMarriage,
             placeOfMarriageSubsection,
             divider('place-of-marriage-seperator')
+            // PLACE OF MARRIAGE FIELDS WILL RENDER HERE
           ]
         }
       ]

--- a/src/utils/address-utils.ts
+++ b/src/utils/address-utils.ts
@@ -37,7 +37,7 @@ import { getPreviewGroups } from '../form/common/preview-groups'
 import { cloneDeep } from 'lodash'
 
 // Use this function to edit the visibility of fields depending on user input
-function getRuralOrUrbanConditionals(
+function getLocationLevelConditionals(
   section: string,
   useCase: string,
   defaultConditionals: Conditional[]
@@ -312,7 +312,7 @@ export function getPlaceOfEventConditionals(
         }
       ]
     case 'ruralOrUrban':
-      return getRuralOrUrbanConditionals(section, useCase, [
+      return getLocationLevelConditionals(section, useCase, [
         {
           action: 'hide',
           expression: `!values.country${sentenceCase(useCase)}${sentenceCase(
@@ -334,7 +334,7 @@ export function getPlaceOfEventConditionals(
         }
       ])
     case 'urban':
-      return getRuralOrUrbanConditionals(section, useCase, [
+      return getLocationLevelConditionals(section, useCase, [
         {
           action: 'hide',
           expression: `!values.country${sentenceCase(useCase)}${sentenceCase(
@@ -362,7 +362,7 @@ export function getPlaceOfEventConditionals(
         }
       ])
     case 'rural':
-      return getRuralOrUrbanConditionals(section, useCase, [
+      return getLocationLevelConditionals(section, useCase, [
         {
           action: 'hide',
           expression: `!values.country${sentenceCase(useCase)}${sentenceCase(
@@ -564,7 +564,7 @@ export function getAddressConditionals(
         }
       ]
     case 'ruralOrUrban':
-      return getRuralOrUrbanConditionals(section, useCase, [
+      return getLocationLevelConditionals(section, useCase, [
         {
           action: 'hide',
           expression: `!values.country${sentenceCase(useCase)}${sentenceCase(
@@ -579,7 +579,7 @@ export function getAddressConditionals(
         }
       ])
     case 'urban':
-      return getRuralOrUrbanConditionals(section, useCase, [
+      return getLocationLevelConditionals(section, useCase, [
         {
           action: 'hide',
           expression: `!values.country${sentenceCase(useCase)}${sentenceCase(
@@ -600,7 +600,7 @@ export function getAddressConditionals(
         }
       ])
     case 'rural':
-      return getRuralOrUrbanConditionals(section, useCase, [
+      return getLocationLevelConditionals(section, useCase, [
         {
           action: 'hide',
           expression: `!values.country${sentenceCase(useCase)}${sentenceCase(
@@ -778,6 +778,8 @@ function getQueryMapping(
           fieldName ===
             `city${sentenceCase(useCase)}${sentenceCase(section)}` ||
           fieldName ===
+            `postalCode${sentenceCase(useCase)}${sentenceCase(section)}` ||
+          fieldName ===
             `internationalState${sentenceCase(useCase)}${sentenceCase(
               section
             )}` ||
@@ -818,27 +820,15 @@ function getQueryMapping(
     : locationIndex || locationIndex === 0
     ? {
         operation: 'addressQueryTransformer',
-        parameters:
-          type === 'SELECT_WITH_OPTIONS' ||
-          type === 'SELECT_WITH_DYNAMIC_OPTIONS'
-            ? [
-                {
-                  useCase:
-                    useCase.toUpperCase() === 'PRIMARY'
-                      ? AddressCases.PRIMARY_ADDRESS
-                      : AddressCases.SECONDARY_ADDRESS,
-                  lineNumber: locationIndex
-                }
-              ]
-            : [
-                {
-                  useCase:
-                    useCase.toUpperCase() === 'PRIMARY'
-                      ? AddressCases.PRIMARY_ADDRESS
-                      : AddressCases.SECONDARY_ADDRESS,
-                  lineNumber: locationIndex
-                }
-              ]
+        parameters: [
+          {
+            useCase:
+              useCase.toUpperCase() === 'PRIMARY'
+                ? AddressCases.PRIMARY_ADDRESS
+                : AddressCases.SECONDARY_ADDRESS,
+            lineNumber: locationIndex
+          }
+        ]
       }
     : {
         operation: 'addressQueryTransformer',

--- a/src/utils/address-utils.ts
+++ b/src/utils/address-utils.ts
@@ -776,6 +776,8 @@ function getQueryMapping(
           type === 'SELECT_WITH_OPTIONS' ||
           type === 'SELECT_WITH_DYNAMIC_OPTIONS' ||
           fieldName ===
+            `city${sentenceCase(useCase)}${sentenceCase(section)}` ||
+          fieldName ===
             `internationalState${sentenceCase(useCase)}${sentenceCase(
               section
             )}` ||


### PR DESCRIPTION
Address configuration and v1.2 form migration documentation became much easier to explain if these 2 methods are moved into the address-fields files.

Also I noticed that the query mapping for place of event wasnt working properly for postcode, city and number fields