### PR TITLE
Make sure Minio is always deployed to the data1 node

### DIFF
--- a/infrastructure/docker-compose.deploy.yml
+++ b/infrastructure/docker-compose.deploy.yml
@@ -283,6 +283,10 @@ services:
       - '/data/minio:/data'
     command: server --console-address ":9001" /data
     deploy:
+      replicas: 1
+      placement:
+        constraints:
+          - node.labels.data1 == true
       labels:
         - 'traefik.enable=true'
         - 'traefik.docker.network=opencrvs_overlay_net'


### PR DESCRIPTION
This setting ensures that the Minio container always writes data to the same node. It prevents the scenario where the container starts on one server, writes data, and then is transferred to another server where the data isn't available.

**Bug we encountered:**
<img width="1714" alt="image" src="https://github.com/opencrvs/opencrvs-farajaland/assets/1206987/f7426858-c683-41e7-bade-7ecdcd68dc1a">

The client not loading for any user, multiple errors stating files were not found in the blog storage. Upon checking the server, it was clear that the /data/minio directory had no data.

**Root cause:**
The Docker swarm configuration for Minio was missing. Since the service isn't set to replicate, it must remain on the node where its data is saved. Without a placement restriction, Docker might shift the container to a different node in the cluster. This would result in the data directory appearing empty.