### PR TITLE
feat: inform client which administrative level is leaf level

### DIFF
--- a/src/form/addresses/address-fields.ts
+++ b/src/form/addresses/address-fields.ts
@@ -77,15 +77,16 @@ export function getAddressLocationSelect({
   section,
   location,
   useCase,
-  locationIndex,
-  isLeafLevel
+  fhirLineArrayPosition,
+  isLowestAdministrativeLevel
 }: {
   section: string
   location: string
   useCase: string
-  locationIndex?: number
-  /** If the structure the smallest possible level. Allows saving Address.partOf in FHIR. */
-  isLeafLevel?: boolean
+  /** Position where the location gets mapped into within a fhir.Address line-array */
+  fhirLineArrayPosition?: number
+  /** If the structure the smallest possible level. Allows saving fhir.Address.partOf */
+  isLowestAdministrativeLevel?: boolean
 }): SerializedFormField {
   const fieldName = `${location}${sentenceCase(useCase)}${sentenceCase(
     section
@@ -127,8 +128,8 @@ export function getAddressLocationSelect({
       location,
       useCase,
       fieldName,
-      locationIndex,
-      isLeafLevel
+      fhirLineArrayPosition,
+      isLowestAdministrativeLevel
     })
   }
 }
@@ -146,7 +147,7 @@ function getAdminLevelSelects(
           section,
           location: 'state',
           useCase,
-          isLeafLevel: true
+          isLowestAdministrativeLevel: true
         })
       ]
     case 2:
@@ -156,7 +157,7 @@ function getAdminLevelSelects(
           section,
           location: 'district',
           useCase,
-          isLeafLevel: true
+          isLowestAdministrativeLevel: true
         })
       ]
     case 3:
@@ -167,8 +168,8 @@ function getAdminLevelSelects(
           section,
           location: 'locationLevel3',
           useCase,
-          locationIndex: 10,
-          isLeafLevel: true
+          fhirLineArrayPosition: 10,
+          isLowestAdministrativeLevel: true
         })
       ]
     case 4:
@@ -179,14 +180,14 @@ function getAdminLevelSelects(
           section,
           location: 'locationLevel3',
           useCase,
-          locationIndex: 10
+          fhirLineArrayPosition: 10
         }),
         getAddressLocationSelect({
           section,
           location: 'locationLevel4',
           useCase,
-          locationIndex: 11,
-          isLeafLevel: true
+          fhirLineArrayPosition: 11,
+          isLowestAdministrativeLevel: true
         })
       ]
     case 5:
@@ -197,20 +198,20 @@ function getAdminLevelSelects(
           section,
           location: 'locationLevel3',
           useCase,
-          locationIndex: 10
+          fhirLineArrayPosition: 10
         }),
         getAddressLocationSelect({
           section,
           location: 'locationLevel4',
           useCase,
-          locationIndex: 11
+          fhirLineArrayPosition: 11
         }),
         getAddressLocationSelect({
           section,
           location: 'locationLevel5',
           useCase,
-          locationIndex: 12,
-          isLeafLevel: true
+          fhirLineArrayPosition: 12,
+          isLowestAdministrativeLevel: true
         })
       ]
   }
@@ -319,7 +320,7 @@ export function getAddressFields(
         location: '',
         useCase,
         fieldName: `country${sentenceCase(useCase)}${sentenceCase(section)}`,
-        locationIndex: 5 // The selected index in the FHIR Address line array to store this value
+        fhirLineArrayPosition: 5 // The selected index in the FHIR Address line array to store this value
       })
     },
     {
@@ -376,7 +377,7 @@ export function getAddressFields(
         fieldName: `addressLine1UrbanOption${sentenceCase(
           useCase
         )}${sentenceCase(section)}`,
-        locationIndex: 2
+        fhirLineArrayPosition: 2
       })
     },
     {
@@ -407,7 +408,7 @@ export function getAddressFields(
         fieldName: `addressLine2UrbanOption${sentenceCase(
           useCase
         )}${sentenceCase(section)}`,
-        locationIndex: 1
+        fhirLineArrayPosition: 1
       })
     },
     {
@@ -438,7 +439,7 @@ export function getAddressFields(
         fieldName: `addressLine3UrbanOption${sentenceCase(
           useCase
         )}${sentenceCase(section)}`,
-        locationIndex: 0
+        fhirLineArrayPosition: 0
       })
     },
     {
@@ -495,7 +496,7 @@ export function getAddressFields(
         fieldName: `addressLine1RuralOption${sentenceCase(
           useCase
         )}${sentenceCase(section)}`,
-        locationIndex: 4
+        fhirLineArrayPosition: 4
       })
     },
     // INTERNATIONAL ADDRESSES ARE SUPPLIED BECAUSE INFORMANTS & CITIZENS MAY LIVE ABROAD & REGISTER AN EVENT AT ONE OF YOUR FOREIGN EMBASSIES
@@ -616,7 +617,7 @@ export function getAddressFields(
         fieldName: `internationalAddressLine1${sentenceCase(
           useCase
         )}${sentenceCase(section)}`,
-        locationIndex: 6
+        fhirLineArrayPosition: 6
       })
     },
     {
@@ -647,7 +648,7 @@ export function getAddressFields(
         fieldName: `internationalAddressLine2${sentenceCase(
           useCase
         )}${sentenceCase(section)}`,
-        locationIndex: 7
+        fhirLineArrayPosition: 7
       })
     },
     {
@@ -678,7 +679,7 @@ export function getAddressFields(
         fieldName: `internationalAddressLine3${sentenceCase(
           useCase
         )}${sentenceCase(section)}`,
-        locationIndex: 8
+        fhirLineArrayPosition: 8
       })
     },
     {

--- a/src/form/addresses/index.ts
+++ b/src/form/addresses/index.ts
@@ -24,6 +24,7 @@ import {
   AddressCases,
   AddressCopyConfigCases,
   AddressSubsections,
+  AdministrativeLevel,
   EventLocationAddressCases,
   IAddressConfiguration
 } from '../types/types'
@@ -34,7 +35,7 @@ import {
 // THEREFORE OUR ADMIN_LEVELS PROPERTY IS 2.
 // YOU CAN SET UP TO 5 SUPPORTED ADMINISTRATIVE LEVELS.
 
-export const ADMIN_LEVELS: Number = 2
+export const ADMIN_LEVELS: AdministrativeLevel = 2
 
 // ADDRESSES TAKE UP A LOT OF REPEATED CODE IN THE FORMS, MAKING THE BIRTH, MARRIAGE AND DEATH FORM CODE LONG AND DIFFICULT TO READ
 // THEREFORE WE DECORATE THE ADDRESSES DYNAMICALLY TO SECTIONS OF THE FORM USING THIS CONFIGURATION CONSTANT

--- a/src/form/types/types.ts
+++ b/src/form/types/types.ts
@@ -68,7 +68,7 @@ type IAddressLineMapper = {
   transformedFieldName?: string
   useCase?: string
   lineNumber?: number
-  isLeafLevel?: boolean
+  isLowestAdministrativeLevel?: boolean
 }
 
 export type IQueryMapper = {

--- a/src/form/types/types.ts
+++ b/src/form/types/types.ts
@@ -68,6 +68,7 @@ type IAddressLineMapper = {
   transformedFieldName?: string
   useCase?: string
   lineNumber?: number
+  isLeafLevel?: boolean
 }
 
 export type IQueryMapper = {
@@ -930,3 +931,5 @@ export type AllowedAddressConfigurations = {
   yComparisonSection?: string
   conditionalCase?: string
 }
+
+export type AdministrativeLevel = 1 | 2 | 3 | 4 | 5

--- a/src/form/types/validators.ts
+++ b/src/form/types/validators.ts
@@ -11,7 +11,7 @@
 
 import * as customValidators from '../common/custom-validation-conditionals/custom-validators'
 
-/** Validators that are built in to core. You can create your own ones, or override these ones in `src/features/config/form/validators.ts` */
+/** Validators that are built in to core. You can create your own ones, or override these ones in the custom validators file imported above */
 type CoreValidator =
   | 'requiredBasic'
   | 'requiredSymbol'

--- a/src/utils/address-utils.ts
+++ b/src/utils/address-utils.ts
@@ -668,21 +668,21 @@ function getTemplateMapping(
   location: string,
   useCase: string,
   fieldName: string,
-  locationIndex?: number
+  fhirLineArrayPosition?: number
 ): IHandlebarTemplates {
   return isUseCaseForPlaceOfEvent(useCase)
-    ? locationIndex
+    ? fhirLineArrayPosition
       ? {
           fieldName,
           operation: 'eventLocationAddressLineTemplateTransformer',
-          parameters: [locationIndex, fieldName, location]
+          parameters: [fhirLineArrayPosition, fieldName, location]
         }
       : {
           fieldName,
           operation: 'eventLocationAddressFHIRPropertyTemplateTransformer',
           parameters: [location]
         }
-    : locationIndex
+    : fhirLineArrayPosition
     ? {
         fieldName,
         operation: 'addressLineTemplateTransformer',
@@ -690,7 +690,7 @@ function getTemplateMapping(
           useCase.toUpperCase() === 'PRIMARY'
             ? AddressCases.PRIMARY_ADDRESS
             : AddressCases.SECONDARY_ADDRESS,
-          locationIndex,
+          fhirLineArrayPosition,
           fieldName,
           location
         ]
@@ -711,25 +711,37 @@ function getTemplateMapping(
 function getMutationMapping({
   location,
   useCase,
-  locationIndex,
-  isLeafLevel
+  fhirLineArrayPosition,
+  isLowestAdministrativeLevel
 }: {
   location: string
   useCase: string
-  locationIndex?: number
-  isLeafLevel?: boolean
+  fhirLineArrayPosition?: number
+  isLowestAdministrativeLevel?: boolean
 }): IMutationMapper {
   return isUseCaseForPlaceOfEvent(useCase)
-    ? locationIndex || locationIndex === 0
+    ? fhirLineArrayPosition || fhirLineArrayPosition === 0
       ? {
           operation: 'eventLocationMutationTransformer',
-          parameters: [{ useCase, lineNumber: locationIndex, isLeafLevel }]
+          parameters: [
+            {
+              useCase,
+              lineNumber: fhirLineArrayPosition,
+              isLowestAdministrativeLevel
+            }
+          ]
         }
       : {
           operation: 'eventLocationMutationTransformer',
-          parameters: [{ useCase, transformedFieldName: location, isLeafLevel }]
+          parameters: [
+            {
+              useCase,
+              transformedFieldName: location,
+              isLowestAdministrativeLevel
+            }
+          ]
         }
-    : locationIndex || locationIndex === 0
+    : fhirLineArrayPosition || fhirLineArrayPosition === 0
     ? {
         operation: 'addressMutationTransformer',
         parameters: [
@@ -738,8 +750,8 @@ function getMutationMapping({
               useCase.toUpperCase() === 'PRIMARY'
                 ? AddressCases.PRIMARY_ADDRESS
                 : AddressCases.SECONDARY_ADDRESS,
-            lineNumber: locationIndex,
-            isLeafLevel
+            lineNumber: fhirLineArrayPosition,
+            isLowestAdministrativeLevel
           }
         ]
       }
@@ -752,7 +764,7 @@ function getMutationMapping({
                 ? AddressCases.PRIMARY_ADDRESS
                 : AddressCases.SECONDARY_ADDRESS,
             transformedFieldName: location,
-            isLeafLevel
+            isLowestAdministrativeLevel
           }
         ]
       }
@@ -769,7 +781,7 @@ function getQueryMapping(
   location: string,
   useCase: string,
   fieldName: string,
-  locationIndex?: number
+  fhirLineArrayPosition?: number
 ): IQueryMapper {
   return isUseCaseForPlaceOfEvent(useCase)
     ? {
@@ -792,7 +804,10 @@ function getQueryMapping(
           fieldName ===
             `internationalCity${sentenceCase(useCase)}${sentenceCase(section)}`
             ? [
-                { transformedFieldName: location, lineNumber: locationIndex },
+                {
+                  transformedFieldName: location,
+                  lineNumber: fhirLineArrayPosition
+                },
                 {
                   fieldsToIgnoreForLocalAddress: [
                     `internationalDistrict${sentenceCase(
@@ -817,9 +832,9 @@ function getQueryMapping(
                   ]
                 }
               ]
-            : [{ lineNumber: locationIndex }]
+            : [{ lineNumber: fhirLineArrayPosition }]
       }
-    : locationIndex || locationIndex === 0
+    : fhirLineArrayPosition || fhirLineArrayPosition === 0
     ? {
         operation: 'addressQueryTransformer',
         parameters: [
@@ -828,7 +843,7 @@ function getQueryMapping(
               useCase.toUpperCase() === 'PRIMARY'
                 ? AddressCases.PRIMARY_ADDRESS
                 : AddressCases.SECONDARY_ADDRESS,
-            lineNumber: locationIndex
+            lineNumber: fhirLineArrayPosition
           }
         ]
       }
@@ -853,8 +868,8 @@ export function getMapping({
   location,
   useCase,
   fieldName,
-  locationIndex,
-  isLeafLevel
+  fhirLineArrayPosition,
+  isLowestAdministrativeLevel
 }: {
   section: string
   type:
@@ -865,17 +880,22 @@ export function getMapping({
   location: string
   useCase: string
   fieldName: string
-  locationIndex?: number
-  isLeafLevel?: boolean
+  fhirLineArrayPosition?: number
+  isLowestAdministrativeLevel?: boolean
 }): IFormFieldMapping {
   if (type !== 'RADIO_GROUP') {
     return {
-      template: getTemplateMapping(location, useCase, fieldName, locationIndex),
+      template: getTemplateMapping(
+        location,
+        useCase,
+        fieldName,
+        fhirLineArrayPosition
+      ),
       mutation: getMutationMapping({
         location,
         useCase,
-        locationIndex,
-        isLeafLevel
+        fhirLineArrayPosition,
+        isLowestAdministrativeLevel
       }),
       query: getQueryMapping(
         section,
@@ -883,7 +903,7 @@ export function getMapping({
         location,
         useCase,
         fieldName,
-        locationIndex
+        fhirLineArrayPosition
       )
     }
   } else {
@@ -892,8 +912,8 @@ export function getMapping({
       mutation: getMutationMapping({
         location,
         useCase,
-        locationIndex,
-        isLeafLevel
+        fhirLineArrayPosition,
+        isLowestAdministrativeLevel
       }),
       query: getQueryMapping(
         section,
@@ -901,7 +921,7 @@ export function getMapping({
         location,
         useCase,
         fieldName,
-        locationIndex
+        fhirLineArrayPosition
       )
     }
   }


### PR DESCRIPTION
https://github.com/opencrvs/opencrvs-core/pull/6105

I've added a "isLeafLevel" to the fields that define the smallest level of administration. This gets passed to client, which then populates `partOf` extension or if it's an addressLocation, `partOf` field directly.