### PR TITLE
Update auth to go through gateway

### DIFF
--- a/src/client-config.js
+++ b/src/client-config.js
@@ -12,7 +12,7 @@ window.config = {
   API_GATEWAY_URL: 'http://localhost:7070/',
   CONFIG_API_URL: 'http://localhost:2021',
   LOGIN_URL: 'http://localhost:3020',
-  AUTH_URL: 'http://localhost:4040',
+  AUTH_URL: 'http://localhost:7070/auth',
   MINIO_BUCKET: 'ocrvs',
   COUNTRY_CONFIG_URL: 'http://localhost:3040',
   // Country code in uppercase ALPHA-3 format

--- a/src/client-config.prod.js
+++ b/src/client-config.prod.js
@@ -12,7 +12,7 @@ window.config = {
   API_GATEWAY_URL: 'https://gateway.{{hostname}}/',
   CONFIG_API_URL: 'https://config.{{hostname}}',
   LOGIN_URL: 'https://login.{{hostname}}',
-  AUTH_URL: 'https://auth.{{hostname}}',
+  AUTH_URL: 'https://gateway.{{hostname}}/auth',
   MINIO_BUCKET: 'ocrvs',
   COUNTRY_CONFIG_URL: 'https://countryconfig.{{hostname}}',
   // Country code in uppercase ALPHA-3 format

--- a/src/login-config.js
+++ b/src/login-config.js
@@ -9,7 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 window.config = {
-  AUTH_API_URL: 'http://localhost:4040/',
+  AUTH_API_URL: 'http://localhost:7070/auth/',
   CONFIG_API_URL: 'http://localhost:2021',
   // Country code in uppercase ALPHA-3 format
   COUNTRY: 'FAR',

--- a/src/login-config.prod.js
+++ b/src/login-config.prod.js
@@ -9,7 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 window.config = {
-  AUTH_API_URL: 'https://auth.{{hostname}}/',
+  AUTH_API_URL: 'https://gateway.{{hostname}}/auth/',
   CONFIG_API_URL: 'https://config.{{hostname}}',
   // Country code in uppercase ALPHA-3 format
   COUNTRY: 'FAR',


### PR DESCRIPTION
Proxying auth requests through gateway allows us to have 1 less service exposed to public network, and it allows us to do rate limiting in gateway. 