### PR TITLE
ocrvs-6363 use the new id handlebars with the "location" helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,58 @@
 
 ## New features
 
+- #### Greater customizability of location data in certificates
+    The various admin level handlebars e.g. **statePlaceofbirth**,
+    **districtPrimaryMother** only contained the name of that location which was
+    not able to take advantage of all the information OpenCRVS had available
+    about the various admin levels e.g. the name of that location in the
+    secondary language. So we are introducing a new set of admin level
+    handlebars that would contain the **id** of that location which we can
+    resolve into a value of the shape 
+    ```
+    {
+      name: string
+      alias: string
+    }
+    ```
+    using the new **"location"** handlebar helper. Here name is the primary
+    label of the location and alias being the secondary one. Currently only
+    these 2 fields are available but we will be adding more fields depending on
+    various countries requirements. If previously the certificate svg used to
+    contain `{{districtPlaceofbirth}}` then now we can replace it with
+    `{{location districtPlaceofbirthId 'name'}}`. To access alias, the `'name'`
+    needs to be replaced with `'alias'`.
+
+    Below is a list of all the new handlebars that are meant to be used with the
+    "location" handlebar helper.
+
+    - statePrimaryInformantId  
+    - districtPrimaryInformantId  
+    - statePlaceofbirthId  
+    - districtPlaceofbirthId  
+    - statePrimaryMotherId  
+    - districtPrimaryMotherId  
+    - statePrimaryFatherId  
+    - districtPrimaryFatherId  
+    - statePrimaryDeceasedId  
+    - districtPrimaryDeceasedId  
+    - statePlaceofdeathId  
+    - districtPlaceofdeathId  
+    - statePrimaryGroomId  
+    - districtPrimaryGroomId  
+    - statePrimaryBrideId  
+    - districtPrimaryBrideId  
+    - statePlaceofmarriageId  
+    - districtPlaceofmarriageId  
+    - registrar.stateId  
+    - registrar.districtId  
+    - registrar.officeId  
+    - registrationAgent.stateId  
+    - registrationAgent.districtId  
+    - registrationAgent.officeId  
+
+    ##### We will be deprecating the counterpart of the above mentioned handlebars that contains only the label of the specified location in a future version so we highly recommend that implementers update their certificates to use these new ones.
+
 ## Bug fixes
 
 See [Releases](https://github.com/opencrvs/opencrvs-farajaland/releases) for release notes of older releases.

--- a/src/data-seeding/certificates/source/BirthCertificate.svg
+++ b/src/data-seeding/certificates/source/BirthCertificate.svg
@@ -13,7 +13,7 @@
   <tspan x="50%" y="445.552" text-anchor="middle">&#10;</tspan>
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px">
-  <tspan x="50%" y="429.552" text-anchor="middle">This event was registered at {{location registrar.office 'name'}}, {{location registrar.district 'name'}}, {{location registrar.state 'name'}}&#10;</tspan>
+  <tspan x="50%" y="429.552" text-anchor="middle">This event was registered at {{location registrar.officeId 'name'}}, {{location registrar.districtId 'name'}}, {{location registrar.stateId 'name'}}&#10;</tspan>
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="12" font-weight="600" letter-spacing="0px">
   <tspan x="50%" y="308.828" text-anchor="middle">{{eventDate}}&#10;</tspan>
@@ -31,7 +31,7 @@
 {{#ifCond placeOfBirth '===' 'HEALTH_FACILITY' }}
 <tspan x="50%" y="367.828" text-anchor="middle">{{placeOfBirth}}&#10;</tspan>
     {{else}}
-<tspan x="50%" y="367.828" text-anchor="middle">{{location districtPlaceofbirth 'name'}}{{internationalDistrictPlaceofbirth}}, {{location statePlaceofbirth 'name'}}{{internationalStatePlaceofbirth}}, {{countryPlaceofbirth}}&#10;</tspan>
+<tspan x="50%" y="367.828" text-anchor="middle">{{location districtPlaceofbirthId 'name'}}{{internationalDistrictPlaceofbirth}}, {{location statePlaceofbirthId 'name'}}{{internationalStatePlaceofbirth}}, {{countryPlaceofbirth}}&#10;</tspan>
 {{/ifCond}}
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="12" font-weight="600" letter-spacing="0px">

--- a/src/data-seeding/certificates/source/BirthCertificate.svg
+++ b/src/data-seeding/certificates/source/BirthCertificate.svg
@@ -13,7 +13,7 @@
   <tspan x="50%" y="445.552" text-anchor="middle">&#10;</tspan>
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px">
-  <tspan x="50%" y="429.552" text-anchor="middle">This event was registered at {{registrationLocation}}&#10;</tspan>
+  <tspan x="50%" y="429.552" text-anchor="middle">This event was registered at {{location registrar.office 'name'}}, {{location registrar.district 'name'}}, {{location registrar.state 'name'}}&#10;</tspan>
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="12" font-weight="600" letter-spacing="0px">
   <tspan x="50%" y="308.828" text-anchor="middle">{{eventDate}}&#10;</tspan>
@@ -31,7 +31,7 @@
 {{#ifCond placeOfBirth '===' 'HEALTH_FACILITY' }}
 <tspan x="50%" y="367.828" text-anchor="middle">{{placeOfBirth}}&#10;</tspan>
     {{else}}
-<tspan x="50%" y="367.828" text-anchor="middle">{{districtPlaceofbirth}}{{internationalDistrictPlaceofbirth}}, {{statePlaceofbirth}}{{internationalStatePlaceofbirth}}, {{countryPlaceofbirth}}&#10;</tspan>
+<tspan x="50%" y="367.828" text-anchor="middle">{{location districtPlaceofbirth 'name'}}{{internationalDistrictPlaceofbirth}}, {{location statePlaceofbirth 'name'}}{{internationalStatePlaceofbirth}}, {{countryPlaceofbirth}}&#10;</tspan>
 {{/ifCond}}
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="12" font-weight="600" letter-spacing="0px">

--- a/src/data-seeding/certificates/source/DeathCertificate.svg
+++ b/src/data-seeding/certificates/source/DeathCertificate.svg
@@ -13,7 +13,7 @@
   <tspan x="50%" y="445.552" text-anchor="middle">&#10;</tspan>
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px">
-  <tspan x="50%" y="429.552" text-anchor="middle">This event was registered at {{registrationLocation}}&#10;</tspan>
+  <tspan x="50%" y="429.552" text-anchor="middle">This event was registered at {{location registrar.office 'name'}}, {{location registrar.district 'name'}}, {{location registrar.state 'name'}}&#10;</tspan>
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="12" font-weight="600" letter-spacing="0px">
   <tspan x="50%" y="308.828" text-anchor="middle">{{eventDate}}&#10;</tspan>
@@ -31,7 +31,7 @@
 {{#ifCond placeOfBirth '===' 'HEALTH_FACILITY' }}
 <tspan x="50%" y="367.828" text-anchor="middle">{{placeOfDeath}}&#10;</tspan>
     {{else}}
-<tspan x="50%" y="367.828" text-anchor="middle">{{districtPlaceofdeath}}{{internationalDistrictPlaceofdeath}}, {{statePlaceofdeath}}{{internationalStatePlaceofdeath}}, {{countryPlaceofdeath}}&#10;</tspan>
+<tspan x="50%" y="367.828" text-anchor="middle">{{location districtPlaceofdeath 'name'}}{{internationalDistrictPlaceofdeath}}, {{location statePlaceofdeath 'name'}}{{internationalStatePlaceofdeath}}, {{countryPlaceofdeath}}&#10;</tspan>
 {{/ifCond}}
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="12" font-weight="600" letter-spacing="0px">

--- a/src/data-seeding/certificates/source/DeathCertificate.svg
+++ b/src/data-seeding/certificates/source/DeathCertificate.svg
@@ -13,7 +13,7 @@
   <tspan x="50%" y="445.552" text-anchor="middle">&#10;</tspan>
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="8" letter-spacing="0px">
-  <tspan x="50%" y="429.552" text-anchor="middle">This event was registered at {{location registrar.office 'name'}}, {{location registrar.district 'name'}}, {{location registrar.state 'name'}}&#10;</tspan>
+  <tspan x="50%" y="429.552" text-anchor="middle">This event was registered at {{location registrar.officeId 'name'}}, {{location registrar.districtId 'name'}}, {{location registrar.stateId 'name'}}&#10;</tspan>
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="12" font-weight="600" letter-spacing="0px">
   <tspan x="50%" y="308.828" text-anchor="middle">{{eventDate}}&#10;</tspan>
@@ -31,7 +31,7 @@
 {{#ifCond placeOfBirth '===' 'HEALTH_FACILITY' }}
 <tspan x="50%" y="367.828" text-anchor="middle">{{placeOfDeath}}&#10;</tspan>
     {{else}}
-<tspan x="50%" y="367.828" text-anchor="middle">{{location districtPlaceofdeath 'name'}}{{internationalDistrictPlaceofdeath}}, {{location statePlaceofdeath 'name'}}{{internationalStatePlaceofdeath}}, {{countryPlaceofdeath}}&#10;</tspan>
+<tspan x="50%" y="367.828" text-anchor="middle">{{location districtPlaceofdeathId 'name'}}{{internationalDistrictPlaceofdeath}}, {{location statePlaceofdeathId 'name'}}{{internationalStatePlaceofdeath}}, {{countryPlaceofdeath}}&#10;</tspan>
 {{/ifCond}}
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="12" font-weight="600" letter-spacing="0px">

--- a/src/data-seeding/certificates/source/MarriageCertificate.svg
+++ b/src/data-seeding/certificates/source/MarriageCertificate.svg
@@ -26,9 +26,9 @@
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="10" font-weight="300" letter-spacing="0px">
   <tspan x="50%" y="328.69" text-anchor="middle">Place of Marriage&#10;</tspan>
 </text>
-<text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans Bengali" font-size="12" font-weight="500" letter-spacing="0px"><tspan x="210" y="367.004">&#10;</tspan></text>
+<text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="12" font-weight="500" letter-spacing="0px"><tspan x="210" y="367.004">&#10;</tspan></text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="12" font-weight="600" letter-spacing="0px">
-  <tspan x="50%" y="350.828" text-anchor="middle">{{districtPlaceofmarriage}}{{internationalDistrictPlaceofmarriage}}, {{statePlaceofmarriage}}{{internationalStatePlaceofmarriage}}, {{countryPlaceofmarriage}}&#10;</tspan>
+  <tspan x="50%" y="350.828" text-anchor="middle">{{location districtPlaceofmarriage 'name'}}{{internationalDistrictPlaceofmarriage}}, {{location statePlaceofmarriage 'name'}}{{internationalStatePlaceofmarriage}}, {{countryPlaceofmarriage}}&#10;</tspan>
 </text>
 <line x1="43.4985" y1="367.75" x2="376.499" y2="365.75" stroke="#EEEEEE" stroke-width="0.5"/>
 <line x1="43.4985" y1="173.75" x2="376.499" y2="171.75" stroke="#EEEEEE" stroke-width="0.5"/>

--- a/src/data-seeding/certificates/source/MarriageCertificate.svg
+++ b/src/data-seeding/certificates/source/MarriageCertificate.svg
@@ -9,7 +9,7 @@
   <tspan x="50%" y="387.552" text-anchor="middle">This event was registered at&#10;</tspan>
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="8" font-weight="600" letter-spacing="0px">
-  <tspan x="50%" y="403.552" text-anchor="middle">{{registrationLocation}}&#10;</tspan>
+  <tspan x="50%" y="403.552" text-anchor="middle">{{location registrar.officeId 'name'}}, {{location registrar.districtId 'name'}}, {{location registrar.stateId 'name'}}&#10;</tspan>
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="12" font-weight="600" letter-spacing="0px">
   <tspan x="50%" y="218.828" text-anchor="middle">{{groomFirstName}} {{groomFamilyName}} &amp;</tspan><tspan x="50%" y="236.828" text-anchor="middle">{{brideFirstName}} {{brideFamilyName}}&#10;</tspan>
@@ -28,7 +28,7 @@
 </text>
 <text fill="#222222" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="12" font-weight="500" letter-spacing="0px"><tspan x="210" y="367.004">&#10;</tspan></text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="12" font-weight="600" letter-spacing="0px">
-  <tspan x="50%" y="350.828" text-anchor="middle">{{location districtPlaceofmarriage 'name'}}{{internationalDistrictPlaceofmarriage}}, {{location statePlaceofmarriage 'name'}}{{internationalStatePlaceofmarriage}}, {{countryPlaceofmarriage}}&#10;</tspan>
+  <tspan x="50%" y="350.828" text-anchor="middle">{{location districtPlaceofmarriageId 'name'}}{{internationalDistrictPlaceofmarriage}}, {{location statePlaceofmarriageId 'name'}}{{internationalStatePlaceofmarriage}}, {{countryPlaceofmarriage}}&#10;</tspan>
 </text>
 <line x1="43.4985" y1="367.75" x2="376.499" y2="365.75" stroke="#EEEEEE" stroke-width="0.5"/>
 <line x1="43.4985" y1="173.75" x2="376.499" y2="171.75" stroke="#EEEEEE" stroke-width="0.5"/>

--- a/src/data-seeding/certificates/source/test/UsingAddressHandlebars.svg
+++ b/src/data-seeding/certificates/source/test/UsingAddressHandlebars.svg
@@ -14,8 +14,8 @@
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="10" font-weight="400" letter-spacing="0px">
 <tspan x="10%" y="90" >{{countryPrimaryInformant}}&#10;</tspan>
-<tspan x="10%" y="102" >{{statePrimaryInformant}}{{internationalStatePrimaryInformant}}&#10;</tspan>
-<tspan x="10%" y="114" >{{districtPrimaryInformant}}{{internationalDistrictPrimaryInformant}}&#10;</tspan>
+<tspan x="10%" y="102" >{{location statePrimaryInformant 'name'}}{{internationalStatePrimaryInformant}}&#10;</tspan>
+<tspan x="10%" y="114" >{{location districtPrimaryInformant 'name'}}{{internationalDistrictPrimaryInformant}}&#10;</tspan>
 <tspan x="10%" y="126" >{{cityPrimaryInformant}}{{internationalCityPrimaryInformant}}{{addressLine1RuralOptionPrimaryInformant}}&#10;</tspan>
 <tspan x="10%" y="138" >{{addressLine1UrbanOptionPrimaryInformant}}{{internationalAddressLine1PrimaryInformant}}&#10;</tspan>
 <tspan x="10%" y="150" >{{addressLine2UrbanOptionPrimaryInformant}}{{internationalAddressLine2PrimaryInformant}}&#10;</tspan>
@@ -27,8 +27,8 @@
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="10" font-weight="400" letter-spacing="0px">
 <tspan x="10%" y="210" >{{countryPlaceofbirth}}{{countryPlaceofdeath}}{{countryPlaceofmarriage}}&#10;</tspan>
-<tspan x="10%" y="222" >{{statePlaceofbirth}}{{internationalStatePlaceofbirth}}{{statePlaceofdeath}}{{internationalStatePlaceofdeath}}{{statePlaceofmarriage}}{{internationalStatePlaceofmarriage}}&#10;</tspan>
-<tspan x="10%" y="234" >{{districtPlaceofbirth}}{{internationalDistrictPlaceofbirth}}{{districtPlaceofdeath}}{{internationalDistrictPlaceofdeath}}{{districtPlaceofmarriage}}{{internationalDistrictPlaceofmarriage}}&#10;</tspan>
+<tspan x="10%" y="222" >{{location statePlaceofbirth 'name'}}{{internationalStatePlaceofbirth}}{{location statePlaceofdeath 'name'}}{{internationalStatePlaceofdeath}}{{location statePlaceofmarriage 'name'}}{{internationalStatePlaceofmarriage}}&#10;</tspan>
+<tspan x="10%" y="234" >{{location districtPlaceofbirth 'name'}}{{internationalDistrictPlaceofbirth}}{{location districtPlaceofdeath 'name'}}{{internationalDistrictPlaceofdeath}}{{location districtPlaceofmarriage 'name'}}{{internationalDistrictPlaceofmarriage}}&#10;</tspan>
 <tspan x="10%" y="246" >{{cityPlaceofbirth}}{{internationalCityPlaceofbirth}}{{cityPlaceofdeath}}{{internationalCityPlaceofdeath}}{{cityPlaceofmarriage}}{{internationalCityPlaceofmarriage}}{{addressLine1RuralOptionPlaceofbirth}}{{addressLine1RuralOptionPlaceofdeath}}{{addressLine1RuralOptionPlaceofmarriage}}&#10;</tspan>
 <tspan x="10%" y="258" >{{addressLine1UrbanOptionPlaceofbirth}}{{internationalAddressLine1Placeofbirth}}{{addressLine1UrbanOptionPlaceofdeath}}{{internationalAddressLine1Placeofdeath}}{{addressLine1UrbanOptionPlaceofmarriage}}{{internationalAddressLine1Placeofmarriage}}&#10;</tspan>
 <tspan x="10%" y="270" >{{addressLine2UrbanOptionPlaceofbirth}}{{internationalAddressLine2Placeofbirth}}{{addressLine2UrbanOptionPlaceofdeath}}{{internationalAddressLine2Placeofdeath}}{{addressLine2UrbanOptionPlaceofmarriage}}{{internationalAddressLine2Placeofmarriage}}&#10;</tspan>
@@ -40,8 +40,8 @@
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="10" font-weight="400" letter-spacing="0px">
 <tspan x="50%" y="90" >{{countryPrimaryMother}}{{countryPrimaryBride}}&#10;</tspan>
-<tspan x="50%" y="102" >{{statePrimaryMother}}{{internationalStatePrimaryMother}}{{statePrimaryBride}}{{internationalStatePrimaryBride}}&#10;</tspan>
-<tspan x="50%" y="114" >{{districtPrimaryMother}}{{internationalDistrictPrimaryMother}}{{districtPrimaryBride}}{{internationalDistrictPrimaryBride}}&#10;</tspan>
+<tspan x="50%" y="102" >{{location statePrimaryMother 'name'}}{{internationalStatePrimaryMother}}{{location statePrimaryBride 'name'}}{{internationalStatePrimaryBride}}&#10;</tspan>
+<tspan x="50%" y="114" >{{location districtPrimaryMother 'name'}}{{internationalDistrictPrimaryMother}}{{location districtPrimaryBride 'name'}}{{internationalDistrictPrimaryBride}}&#10;</tspan>
 <tspan x="50%" y="126" >{{cityPrimaryMother}}{{internationalCityPrimaryMother}}{{addressLine1RuralOptionPrimaryMother}}{{cityPrimaryBride}}{{internationalCityPrimaryBride}}{{addressLine1RuralOptionPrimaryBride}}&#10;</tspan>
 <tspan x="50%" y="138" >{{addressLine1UrbanOptionPrimaryMother}}{{internationalAddressLine1PrimaryMother}}{{addressLine1UrbanOptionPrimaryBride}}{{internationalAddressLine1PrimaryBride}}&#10;</tspan>
 <tspan x="50%" y="150" >{{addressLine2UrbanOptionPrimaryMother}}{{internationalAddressLine2PrimaryMother}}{{addressLine2UrbanOptionPrimaryBride}}{{internationalAddressLine2PrimaryBride}}&#10;</tspan>
@@ -53,8 +53,8 @@
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="10" font-weight="400" letter-spacing="0px">
 <tspan x="50%" y="210" >{{countryPrimaryFather}}{{countryPrimaryGroom}}&#10;</tspan>
-<tspan x="50%" y="222" >{{statePrimaryFather}}{{internationalStatePrimaryFather}}{{statePrimaryGroom}}{{internationalStatePrimaryGroom}}&#10;</tspan>
-<tspan x="50%" y="234" >{{districtPrimaryFather}}{{internationalDistrictPrimaryFather}}{{districtPrimaryGroom}}{{internationalDistrictPrimaryGroom}}&#10;</tspan>
+<tspan x="50%" y="222" >{{location statePrimaryFather 'name'}}{{internationalStatePrimaryFather}}{{location statePrimaryGroom 'name'}}{{internationalStatePrimaryGroom}}&#10;</tspan>
+<tspan x="50%" y="234" >{{location districtPrimaryFather 'name'}}{{internationalDistrictPrimaryFather}}{{location districtPrimaryGroom 'name'}}{{internationalDistrictPrimaryGroom}}&#10;</tspan>
 <tspan x="50%" y="246" >{{cityPrimaryFather}}{{internationalCityPrimaryFather}}{{addressLine1RuralOptionPrimaryFather}}{{cityPrimaryGroom}}{{internationalCityPrimaryGroom}}{{addressLine1RuralOptionPrimaryGroom}}&#10;</tspan>
 <tspan x="50%" y="258" >{{addressLine1UrbanOptionPrimaryFather}}{{internationalAddressLine1PrimaryFather}}{{addressLine1UrbanOptionPrimaryGroom}}{{internationalAddressLine1PrimaryGroom}}&#10;</tspan>
 <tspan x="50%" y="270" >{{addressLine2UrbanOptionPrimaryFather}}{{internationalAddressLine2PrimaryFather}}{{addressLine2UrbanOptionPrimaryGroom}}{{internationalAddressLine2PrimaryGroom}}&#10;</tspan>

--- a/src/data-seeding/certificates/source/test/UsingAddressHandlebars.svg
+++ b/src/data-seeding/certificates/source/test/UsingAddressHandlebars.svg
@@ -14,8 +14,8 @@
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="10" font-weight="400" letter-spacing="0px">
 <tspan x="10%" y="90" >{{countryPrimaryInformant}}&#10;</tspan>
-<tspan x="10%" y="102" >{{location statePrimaryInformant 'name'}}{{internationalStatePrimaryInformant}}&#10;</tspan>
-<tspan x="10%" y="114" >{{location districtPrimaryInformant 'name'}}{{internationalDistrictPrimaryInformant}}&#10;</tspan>
+<tspan x="10%" y="102" >{{location statePrimaryInformantId 'name'}}{{internationalStatePrimaryInformant}}&#10;</tspan>
+<tspan x="10%" y="114" >{{location districtPrimaryInformantId 'name'}}{{internationalDistrictPrimaryInformant}}&#10;</tspan>
 <tspan x="10%" y="126" >{{cityPrimaryInformant}}{{internationalCityPrimaryInformant}}{{addressLine1RuralOptionPrimaryInformant}}&#10;</tspan>
 <tspan x="10%" y="138" >{{addressLine1UrbanOptionPrimaryInformant}}{{internationalAddressLine1PrimaryInformant}}&#10;</tspan>
 <tspan x="10%" y="150" >{{addressLine2UrbanOptionPrimaryInformant}}{{internationalAddressLine2PrimaryInformant}}&#10;</tspan>
@@ -27,8 +27,8 @@
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="10" font-weight="400" letter-spacing="0px">
 <tspan x="10%" y="210" >{{countryPlaceofbirth}}{{countryPlaceofdeath}}{{countryPlaceofmarriage}}&#10;</tspan>
-<tspan x="10%" y="222" >{{location statePlaceofbirth 'name'}}{{internationalStatePlaceofbirth}}{{location statePlaceofdeath 'name'}}{{internationalStatePlaceofdeath}}{{location statePlaceofmarriage 'name'}}{{internationalStatePlaceofmarriage}}&#10;</tspan>
-<tspan x="10%" y="234" >{{location districtPlaceofbirth 'name'}}{{internationalDistrictPlaceofbirth}}{{location districtPlaceofdeath 'name'}}{{internationalDistrictPlaceofdeath}}{{location districtPlaceofmarriage 'name'}}{{internationalDistrictPlaceofmarriage}}&#10;</tspan>
+<tspan x="10%" y="222" >{{location statePlaceofbirthId 'name'}}{{internationalStatePlaceofbirth}}{{location statePlaceofdeathId 'name'}}{{internationalStatePlaceofdeath}}{{location statePlaceofmarriageId 'name'}}{{internationalStatePlaceofmarriage}}&#10;</tspan>
+<tspan x="10%" y="234" >{{location districtPlaceofbirthId 'name'}}{{internationalDistrictPlaceofbirth}}{{location districtPlaceofdeathId 'name'}}{{internationalDistrictPlaceofdeath}}{{location districtPlaceofmarriageId 'name'}}{{internationalDistrictPlaceofmarriage}}&#10;</tspan>
 <tspan x="10%" y="246" >{{cityPlaceofbirth}}{{internationalCityPlaceofbirth}}{{cityPlaceofdeath}}{{internationalCityPlaceofdeath}}{{cityPlaceofmarriage}}{{internationalCityPlaceofmarriage}}{{addressLine1RuralOptionPlaceofbirth}}{{addressLine1RuralOptionPlaceofdeath}}{{addressLine1RuralOptionPlaceofmarriage}}&#10;</tspan>
 <tspan x="10%" y="258" >{{addressLine1UrbanOptionPlaceofbirth}}{{internationalAddressLine1Placeofbirth}}{{addressLine1UrbanOptionPlaceofdeath}}{{internationalAddressLine1Placeofdeath}}{{addressLine1UrbanOptionPlaceofmarriage}}{{internationalAddressLine1Placeofmarriage}}&#10;</tspan>
 <tspan x="10%" y="270" >{{addressLine2UrbanOptionPlaceofbirth}}{{internationalAddressLine2Placeofbirth}}{{addressLine2UrbanOptionPlaceofdeath}}{{internationalAddressLine2Placeofdeath}}{{addressLine2UrbanOptionPlaceofmarriage}}{{internationalAddressLine2Placeofmarriage}}&#10;</tspan>
@@ -40,8 +40,8 @@
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="10" font-weight="400" letter-spacing="0px">
 <tspan x="50%" y="90" >{{countryPrimaryMother}}{{countryPrimaryBride}}&#10;</tspan>
-<tspan x="50%" y="102" >{{location statePrimaryMother 'name'}}{{internationalStatePrimaryMother}}{{location statePrimaryBride 'name'}}{{internationalStatePrimaryBride}}&#10;</tspan>
-<tspan x="50%" y="114" >{{location districtPrimaryMother 'name'}}{{internationalDistrictPrimaryMother}}{{location districtPrimaryBride 'name'}}{{internationalDistrictPrimaryBride}}&#10;</tspan>
+<tspan x="50%" y="102" >{{location statePrimaryMotherId 'name'}}{{internationalStatePrimaryMother}}{{location statePrimaryBrideId 'name'}}{{internationalStatePrimaryBride}}&#10;</tspan>
+<tspan x="50%" y="114" >{{location districtPrimaryMotherId 'name'}}{{internationalDistrictPrimaryMother}}{{location districtPrimaryBrideId 'name'}}{{internationalDistrictPrimaryBride}}&#10;</tspan>
 <tspan x="50%" y="126" >{{cityPrimaryMother}}{{internationalCityPrimaryMother}}{{addressLine1RuralOptionPrimaryMother}}{{cityPrimaryBride}}{{internationalCityPrimaryBride}}{{addressLine1RuralOptionPrimaryBride}}&#10;</tspan>
 <tspan x="50%" y="138" >{{addressLine1UrbanOptionPrimaryMother}}{{internationalAddressLine1PrimaryMother}}{{addressLine1UrbanOptionPrimaryBride}}{{internationalAddressLine1PrimaryBride}}&#10;</tspan>
 <tspan x="50%" y="150" >{{addressLine2UrbanOptionPrimaryMother}}{{internationalAddressLine2PrimaryMother}}{{addressLine2UrbanOptionPrimaryBride}}{{internationalAddressLine2PrimaryBride}}&#10;</tspan>
@@ -53,8 +53,8 @@
 </text>
 <text fill="#222222" xml:space="default" style="white-space: pre" font-family="Noto Sans" font-size="10" font-weight="400" letter-spacing="0px">
 <tspan x="50%" y="210" >{{countryPrimaryFather}}{{countryPrimaryGroom}}&#10;</tspan>
-<tspan x="50%" y="222" >{{location statePrimaryFather 'name'}}{{internationalStatePrimaryFather}}{{location statePrimaryGroom 'name'}}{{internationalStatePrimaryGroom}}&#10;</tspan>
-<tspan x="50%" y="234" >{{location districtPrimaryFather 'name'}}{{internationalDistrictPrimaryFather}}{{location districtPrimaryGroom 'name'}}{{internationalDistrictPrimaryGroom}}&#10;</tspan>
+<tspan x="50%" y="222" >{{location statePrimaryFatherId 'name'}}{{internationalStatePrimaryFather}}{{location statePrimaryGroomId 'name'}}{{internationalStatePrimaryGroom}}&#10;</tspan>
+<tspan x="50%" y="234" >{{location districtPrimaryFatherId 'name'}}{{internationalDistrictPrimaryFather}}{{location districtPrimaryGroomId 'name'}}{{internationalDistrictPrimaryGroom}}&#10;</tspan>
 <tspan x="50%" y="246" >{{cityPrimaryFather}}{{internationalCityPrimaryFather}}{{addressLine1RuralOptionPrimaryFather}}{{cityPrimaryGroom}}{{internationalCityPrimaryGroom}}{{addressLine1RuralOptionPrimaryGroom}}&#10;</tspan>
 <tspan x="50%" y="258" >{{addressLine1UrbanOptionPrimaryFather}}{{internationalAddressLine1PrimaryFather}}{{addressLine1UrbanOptionPrimaryGroom}}{{internationalAddressLine1PrimaryGroom}}&#10;</tspan>
 <tspan x="50%" y="270" >{{addressLine2UrbanOptionPrimaryFather}}{{internationalAddressLine2PrimaryFather}}{{addressLine2UrbanOptionPrimaryGroom}}{{internationalAddressLine2PrimaryGroom}}&#10;</tspan>

--- a/src/form/birth/certificate-handlebars.ts
+++ b/src/form/birth/certificate-handlebars.ts
@@ -17,11 +17,11 @@ export const certificateHandlebars = {
   certificateDate: 'certificateDate',
   registrar: 'registrar',
   registrationAgent: 'registrationAgent',
-  registrarName: 'registrarName',
-  role: 'role',
-  registrarSignature: 'registrarSignature',
+  registrarName: 'registrarName', // @deprecated use registrar.name instead
+  role: 'role', // @deprecated use registrar.role instead
+  registrarSignature: 'registrarSignature', // @deprecated use registrar.signature instead
   registrationDate: 'registrationDate',
-  registrationLocation: 'registrationLocation',
+  registrationLocation: 'registrationLocation', // @deprecated use registrar.office/state/district instead
   contactEmail: 'contactEmail',
   contactPhoneNumber: 'contactPhoneNumber',
   mosipAid: 'mosipAid',
@@ -62,8 +62,10 @@ export const certificateHandlebars = {
   fatherOccupation: 'fatherOccupation',
   fatherEducationalAttainment: 'fatherEducationalAttainment',
   countryPlaceofbirth: 'countryPlaceofbirth',
-  statePlaceofbirth: 'statePlaceofbirth',
-  districtPlaceofbirth: 'districtPlaceofbirth',
+  statePlaceofbirth: 'statePlaceofbirth', // @deprecated use statePlaceofbirthId instead
+  statePlaceofbirthId: 'statePlaceofbirthId',
+  districtPlaceofbirth: 'districtPlaceofbirth', // @deprecated use districtPlaceofbirthId instead
+  districtPlaceofbirthId: 'districtPlaceofbirthId',
   cityPlaceofbirth: 'cityPlaceofbirth',
   addressLine3UrbanOptionPlaceofbirth: 'addressLine3UrbanOptionPlaceofbirth',
   addressLine2UrbanOptionPlaceofbirth: 'addressLine2UrbanOptionPlaceofbirth',
@@ -81,8 +83,10 @@ export const certificateHandlebars = {
     'internationalAddressLine3Placeofbirth',
   internationalPostalCodePlaceofbirth: 'internationalPostalCodePlaceofbirth',
   countryPrimaryInformant: 'countryPrimaryInformant',
-  statePrimaryInformant: 'statePrimaryInformant',
-  districtPrimaryInformant: 'districtPrimaryInformant',
+  statePrimaryInformant: 'statePrimaryInformant', // @deprecated use statePrimaryInformantId instead
+  statePrimaryInformantId: 'statePrimaryInformantId',
+  districtPrimaryInformant: 'districtPrimaryInformant', // @deprecated use districtPrimaryInformantId instead
+  districtPrimaryInformantId: 'districtPrimaryInformantId',
   cityPrimaryInformant: 'cityPrimaryInformant',
   addressLine3UrbanOptionPrimaryInformant:
     'addressLine3UrbanOptionPrimaryInformant',
@@ -106,8 +110,10 @@ export const certificateHandlebars = {
   internationalPostalCodePrimaryInformant:
     'internationalPostalCodePrimaryInformant',
   countryPrimaryMother: 'countryPrimaryMother',
-  statePrimaryMother: 'statePrimaryMother',
-  districtPrimaryMother: 'districtPrimaryMother',
+  statePrimaryMother: 'statePrimaryMother', // @deprecated use statePrimaryMotherId instead
+  statePrimaryMotherId: 'statePrimaryMotherId',
+  districtPrimaryMother: 'districtPrimaryMother', // @deprecated use districtPrimaryMotherId instead
+  districtPrimaryMotherId: 'districtPrimaryMotherId',
   cityPrimaryMother: 'cityPrimaryMother',
   addressLine3UrbanOptionPrimaryMother: 'addressLine3UrbanOptionPrimaryMother',
   addressLine2UrbanOptionPrimaryMother: 'addressLine2UrbanOptionPrimaryMother',
@@ -126,8 +132,10 @@ export const certificateHandlebars = {
   internationalPostalCodePrimaryMother: 'internationalPostalCodePrimaryMother',
   fatherReasonNotApplying: 'fatherReasonNotApplying',
   countryPrimaryFather: 'countryPrimaryFather',
-  statePrimaryFather: 'statePrimaryFather',
-  districtPrimaryFather: 'districtPrimaryFather',
+  statePrimaryFather: 'statePrimaryFather', // @deprecated use statePrimaryFatherId instead
+  statePrimaryFatherId: 'statePrimaryFatherId',
+  districtPrimaryFather: 'districtPrimaryFather', // @deprecated use districtPrimaryFatherId instead
+  districtPrimaryFatherId: 'districtPrimaryFatherId',
   cityPrimaryFather: 'cityPrimaryFather',
   addressLine3UrbanOptionPrimaryFather: 'addressLine3UrbanOptionPrimaryFather',
   addressLine2UrbanOptionPrimaryFather: 'addressLine2UrbanOptionPrimaryFather',

--- a/src/form/death/certficate-handlebars.ts
+++ b/src/form/death/certficate-handlebars.ts
@@ -17,11 +17,11 @@ export const certificateHandlebars = {
   certificateDate: 'certificateDate',
   registrar: 'registrar',
   registrationAgent: 'registrationAgent',
-  registrarName: 'registrarName',
-  role: 'role',
-  registrarSignature: 'registrarSignature',
+  registrarName: 'registrarName', // @deprecated use registrar.name instead
+  role: 'role', // @deprecated use registrar.role instead
+  registrarSignature: 'registrarSignature', // @deprecated use registrar.signature instead
   registrationDate: 'registrationDate',
-  registrationLocation: 'registrationLocation',
+  registrationLocation: 'registrationLocation', // @deprecated use registrar.office/state/district instead
   contactEmail: 'contactEmail',
   contactPhoneNumber: 'contactPhoneNumber',
   eventDate: 'eventDate',
@@ -33,8 +33,10 @@ export const certificateHandlebars = {
   deceasedNID: 'deceasedNID',
   deceasedMaritalStatus: 'deceasedMaritalStatus',
   countryPrimaryDeceased: 'countryPrimaryDeceased',
-  statePrimaryDeceased: 'statePrimaryDeceased',
-  districtPrimaryDeceased: 'districtPrimaryDeceased',
+  statePrimaryDeceased: 'statePrimaryDeceased', // @deprecated use statePrimaryDeceasedId instead
+  statePrimaryDeceasedId: 'statePrimaryDeceasedId',
+  districtPrimaryDeceased: 'districtPrimaryDeceased', // @deprecated use districtPrimaryDeceasedId instead
+  districtPrimaryDeceasedId: 'districtPrimaryDeceasedId',
   cityPrimaryDeceased: 'cityPrimaryDeceased',
   addressLine3UrbanOptionPrimaryDeceased:
     'addressLine3UrbanOptionPrimaryDeceased',
@@ -62,8 +64,10 @@ export const certificateHandlebars = {
   deathDescription: 'deathDescription',
   placeOfDeath: 'placeOfDeath',
   countryPlaceofdeath: 'countryPlaceofdeath',
-  statePlaceofdeath: 'statePlaceofdeath',
-  districtPlaceofdeath: 'districtPlaceofdeath',
+  statePlaceofdeath: 'statePlaceofdeath', // @deprecated use statePlaceofdeathId instead
+  statePlaceofdeathId: 'statePlaceofdeathId',
+  districtPlaceofdeath: 'districtPlaceofdeath', // @deprecated use districtPlaceofdeathId instead
+  districtPlaceofdeathId: 'districtPlaceofdeathId',
   cityPlaceofdeath: 'cityPlaceofdeath',
   addressLine3UrbanOptionPlaceofdeath: 'addressLine3UrbanOptionPlaceofdeath',
   addressLine2UrbanOptionPlaceofdeath: 'addressLine2UrbanOptionPlaceofdeath',
@@ -87,8 +91,10 @@ export const certificateHandlebars = {
   informantNationality: 'informantNationality',
   informantNID: 'informantNID',
   countryPrimaryInformant: 'countryPrimaryInformant',
-  statePrimaryInformant: 'statePrimaryInformant',
-  districtPrimaryInformant: 'districtPrimaryInformant',
+  statePrimaryInformant: 'statePrimaryInformant', // @deprecated use statePrimaryInformantId instead
+  statePrimaryInformantId: 'statePrimaryInformantId',
+  districtPrimaryInformant: 'districtPrimaryInformant', // @deprecated use districtPrimaryInformantId instead
+  districtPrimaryInformantId: 'districtPrimaryInformantId',
   cityPrimaryInformant: 'cityPrimaryInformant',
   addressLine3UrbanOptionPrimaryInformant:
     'addressLine3UrbanOptionPrimaryInformant',
@@ -120,8 +126,10 @@ export const certificateHandlebars = {
   spouseOccupation: 'spouseOccupation',
   spouseEducationalAttainment: 'spouseEducationalAttainment',
   countryPrimarySpouse: 'countryPrimarySpouse',
-  statePrimarySpouse: 'statePrimarySpouse',
-  districtPrimarySpouse: 'districtPrimarySpouse',
+  statePrimarySpouse: 'statePrimarySpouse', // @deprecated use statePrimarySpouseId instead
+  statePrimarySpouseId: 'statePrimarySpouseId',
+  districtPrimarySpouse: 'districtPrimarySpouse', // @deprecated use districtPrimarySpouseId instead
+  districtPrimarySpouseId: 'districtPrimarySpouseId',
   cityPrimarySpouse: 'cityPrimarySpouse',
   addressLine3UrbanOptionPrimarySpouse: 'addressLine3UrbanOptionPrimarySpouse',
   addressLine2UrbanOptionPrimarySpouse: 'addressLine2UrbanOptionPrimarySpouse',
@@ -156,8 +164,10 @@ export const certificateHandlebars = {
   fatherOccupation: 'fatherOccupation',
   fatherEducationalAttainment: 'fatherEducationalAttainment',
   countryPrimaryMother: 'countryPrimaryMother',
-  statePrimaryMother: 'statePrimaryMother',
-  districtPrimaryMother: 'districtPrimaryMother',
+  statePrimaryMother: 'statePrimaryMother', // @deprecated use statePrimaryMotherId instead
+  statePrimaryMotherId: 'statePrimaryMotherId',
+  districtPrimaryMother: 'districtPrimaryMother', // @deprecated use districtPrimaryMotherId instead
+  districtPrimaryMotherId: 'districtPrimaryMotherId',
   cityPrimaryMother: 'cityPrimaryMother',
   addressLine3UrbanOptionPrimaryMother: 'addressLine3UrbanOptionPrimaryMother',
   addressLine2UrbanOptionPrimaryMother: 'addressLine2UrbanOptionPrimaryMother',
@@ -176,8 +186,10 @@ export const certificateHandlebars = {
   internationalPostalCodePrimaryMother: 'internationalPostalCodePrimaryMother',
   fatherReasonNotApplying: 'fatherReasonNotApplying',
   countryPrimaryFather: 'countryPrimaryFather',
-  statePrimaryFather: 'statePrimaryFather',
-  districtPrimaryFather: 'districtPrimaryFather',
+  statePrimaryFather: 'statePrimaryFather', // @deprecated use statePrimaryFatherId instead
+  statePrimaryFatherId: 'statePrimaryFatherId',
+  districtPrimaryFather: 'districtPrimaryFather', // @deprecated use districtPrimaryFatherId instead
+  districtPrimaryFatherId: 'districtPrimaryFatherId',
   cityPrimaryFather: 'cityPrimaryFather',
   addressLine3UrbanOptionPrimaryFather: 'addressLine3UrbanOptionPrimaryFather',
   addressLine2UrbanOptionPrimaryFather: 'addressLine2UrbanOptionPrimaryFather',

--- a/src/form/marriage/certificate-handlebars.ts
+++ b/src/form/marriage/certificate-handlebars.ts
@@ -17,11 +17,11 @@ export const certificateHandlebars = {
   certificateDate: 'certificateDate',
   registrar: 'registrar',
   registrationAgent: 'registrationAgent',
-  registrarName: 'registrarName',
-  role: 'role',
-  registrarSignature: 'registrarSignature',
+  registrarName: 'registrarName', // @deprecated use registrar.name instead
+  role: 'role', // @deprecated use registrar.role instead
+  registrarSignature: 'registrarSignature', // @deprecated use registrar.signature instead
   registrationDate: 'registrationDate',
-  registrationLocation: 'registrationLocation',
+  registrationLocation: 'registrationLocation', // @deprecated use registrar.office/state/district instead
   contactEmail: 'contactEmail',
   contactPhoneNumber: 'contactPhoneNumber',
   eventDate: 'eventDate',
@@ -32,8 +32,10 @@ export const certificateHandlebars = {
   informantNationality: 'informantNationality',
   informantNID: 'informantNID',
   countryPrimaryInformant: 'countryPrimaryInformant',
-  statePrimaryInformant: 'statePrimaryInformant',
-  districtPrimaryInformant: 'districtPrimaryInformant',
+  statePrimaryInformant: 'statePrimaryInformant', // @deprecated use statePrimaryInformantId instead
+  statePrimaryInformantId: 'statePrimaryInformantId',
+  districtPrimaryInformant: 'districtPrimaryInformant', // @deprecated use districtPrimaryInformantId instead
+  districtPrimaryInformantId: 'districtPrimaryInformantId',
   cityPrimaryInformant: 'cityPrimaryInformant',
   addressLine3UrbanOptionPrimaryInformant:
     'addressLine3UrbanOptionPrimaryInformant',
@@ -67,8 +69,10 @@ export const certificateHandlebars = {
   groomNID: 'groomNID',
   groomMarriedLastNameEng: 'groomMarriedLastNameEng',
   countryPrimaryGroom: 'countryPrimaryGroom',
-  statePrimaryGroom: 'statePrimaryGroom',
-  districtPrimaryGroom: 'districtPrimaryGroom',
+  statePrimaryGroom: 'statePrimaryGroom', // @deprecated use statePrimaryGroomId instead
+  statePrimaryGroomId: 'statePrimaryGroomId',
+  districtPrimaryGroom: 'districtPrimaryGroom', // @deprecated use districtPrimaryGroomId instead
+  districtPrimaryGroomId: 'districtPrimaryGroomId',
   cityPrimaryGroom: 'cityPrimaryGroom',
   addressLine3UrbanOptionPrimaryGroom: 'addressLine3UrbanOptionPrimaryGroom',
   addressLine2UrbanOptionPrimaryGroom: 'addressLine2UrbanOptionPrimaryGroom',
@@ -92,8 +96,10 @@ export const certificateHandlebars = {
   brideNID: 'brideNID',
   brideMarriedLastNameEng: 'brideMarriedLastNameEng',
   countryPrimaryBride: 'countryPrimaryBride',
-  statePrimaryBride: 'statePrimaryBride',
-  districtPrimaryBride: 'districtPrimaryBride',
+  statePrimaryBride: 'statePrimaryBride', // @deprecated use statePrimaryBrideId instead
+  statePrimaryBrideId: 'statePrimaryBrideId',
+  districtPrimaryBride: 'districtPrimaryBride', // @deprecated use districtPrimaryBrideId instead
+  districtPrimaryBrideId: 'districtPrimaryBrideId',
   cityPrimaryBride: 'cityPrimaryBride',
   addressLine3UrbanOptionPrimaryBride: 'addressLine3UrbanOptionPrimaryBride',
   addressLine2UrbanOptionPrimaryBride: 'addressLine2UrbanOptionPrimaryBride',
@@ -112,8 +118,10 @@ export const certificateHandlebars = {
   internationalPostalCodePrimaryBride: 'internationalPostalCodePrimaryBride',
   typeOfMarriage: 'typeOfMarriage',
   countryPlaceofmarriage: 'countryPlaceofmarriage',
-  statePlaceofmarriage: 'statePlaceofmarriage',
-  districtPlaceofmarriage: 'districtPlaceofmarriage',
+  statePlaceofmarriage: 'statePlaceofmarriage', // @deprecated use statePlaceofmarriageId instead
+  statePlaceofmarriageId: 'statePlaceofmarriageId',
+  districtPlaceofmarriage: 'districtPlaceofmarriage', // @deprecated use districtPlaceofmarriageId instead
+  districtPlaceofmarriageId: 'districtPlaceofmarriageId',
   cityPlaceofmarriage: 'cityPlaceofmarriage',
   addressLine3UrbanOptionPlaceofmarriage:
     'addressLine3UrbanOptionPlaceofmarriage',


### PR DESCRIPTION
The goal of this PR is to consolidate all the location related handlebars that we provide in the certificates to enable a country to customize the certificates according to their needs. Also introduce the "location" handlebar helper that gives us greater flexibility in using the location data.

The various admin level handlebars e.g. **statePlaceofbirth**, **districtPrimaryMother** only contained the name of that location which was not able to take advantage of all the information OpenCRVS had available about the various admin levels e.g. the name of that location in the secondary language. So we are introducing a new set of admin level handlebars that would contain the **id** of that location which we can resolve into a value of the shape 
```
{
  name: string
  alias: string
}
```
using the new handlebar helper. Here name is the primary label of the location and alias being the secondary one. Currently only these 2 fields are available but we will be adding more fields depending on various countries requirements. Using the handlebar helper is also very simple, if previously the certificate svg used to contain `{{districtPlaceofbirth}}` then now we just need to replace it with `{{location districtPlaceofbirthId 'name'}}`. To access alias, just the `'name'` needs to be replaced with `'alias'`.

Below is a list of all the new handlebars that can be used with the "location" handlebar helper.

statePrimaryInformantId
districtPrimaryInformantId
statePlaceofbirthId
districtPlaceofbirthId
statePrimaryMotherId
districtPrimaryMotherId
statePrimaryFatherId
districtPrimaryFatherId
statePrimaryDeceasedId
districtPrimaryDeceasedId
statePlaceofdeathId
districtPlaceofdeathId
statePrimaryGroomId
districtPrimaryGroomId
statePrimaryBrideId
districtPrimaryBrideId
statePlaceofmarriageId
districtPlaceofmarriageId
registrar.stateId
registrar.districtId
registrar.officeId
registrationAgent.stateId
registrationAgent.districtId
registrationAgent.officeId

#### We will be deprecating the counterpart of the above mentioned handlebars that contains only the label of the specified location in a future version so we highly recommend that implementers update their certificates to use these new ones.
