### PR TITLE
Fix APM logs not showing 

### DIFF
--- a/infrastructure/monitoring/kibana/README.md
+++ b/infrastructure/monitoring/kibana/README.md
@@ -1,0 +1,7 @@
+# Kibana saved objects export
+
+When exporting a new config.ndjson from Kibana UI, make sure you only select the following items to export:
+
+- alert
+- config
+- infrastructure-ui-source


### PR DESCRIPTION
In the end, the issue was an incorrect log index definition in the index pattern. Not sure at what point did the wrong configuration get to the `config.ndjson` file 🤔 

<img width="879" alt="image" src="https://github.com/opencrvs/opencrvs-farajaland/assets/1206987/1a1ec828-05f5-4a0e-95a1-8e43805de98c">


**After**
<img width="884" alt="image" src="https://github.com/opencrvs/opencrvs-farajaland/assets/1206987/726f02e8-4ac9-4e10-85f8-49ea20457182">
