### PR TITLE
Move some of the jobs that dont need history in to using a shallow clone

### DIFF
--- a/.github/workflows/clear-environment.yml
+++ b/.github/workflows/clear-environment.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Clone country config resource package
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           path: './${{ github.event.repository.name }}'
 
       - name: Read known hosts

--- a/.github/workflows/reset-2fa.yml
+++ b/.github/workflows/reset-2fa.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Clone country config resource package
         uses: actions/checkout@v3
         with:
-          fetch-depth: 0
+          fetch-depth: 1
           path: './${{ github.event.repository.name }}'
 
       - name: Read known hosts


### PR DESCRIPTION
Couple easy improvements to use shallow clones (and spend less time waiting on GH actions).

I'll follow up also improving https://github.com/opencrvs/opencrvs-farajaland/blob/aeeb129a9cfb703545832233663a8ac87b522bad/.github/workflows/deploy.yml#L37-L59 which i think can be made to use shallow ( https://github.com/opencrvs/opencrvs-core/issues/6734 )