### PR TITLE
removes copy from supporitng docs page

### DIFF
--- a/src/form/birth/required-sections.ts
+++ b/src/form/birth/required-sections.ts
@@ -49,13 +49,6 @@ export const documentsSection = {
       id: 'documents-view-group',
       fields: [
         {
-          name: 'paragraph',
-          type: 'PARAGRAPH',
-          label: formMessageDescriptors.documentsParagraph,
-          initialValue: '',
-          validator: []
-        },
-        {
           name: 'uploadDocForChildDOB',
           type: 'DOCUMENT_UPLOADER_WITH_OPTION',
           label: formMessageDescriptors.proofOfBirth,

--- a/src/form/common/messages.ts
+++ b/src/form/common/messages.ts
@@ -431,11 +431,6 @@ export const formMessageDescriptors = {
     description: 'Form section name for Documents',
     id: 'form.section.documents.name'
   },
-  documentsParagraph: {
-    defaultMessage: 'The following documents are required',
-    description: 'Documents Paragraph text',
-    id: 'form.section.documents.birth.requirements'
-  },
   proofOfBirth: {
     defaultMessage: 'Proof of birth',
     description: 'Label for list item Proof of birth',

--- a/src/form/death/required-sections.ts
+++ b/src/form/death/required-sections.ts
@@ -45,13 +45,6 @@ export const documentsSection = {
       id: 'documents-view-group',
       fields: [
         {
-          name: 'paragraph',
-          type: 'PARAGRAPH',
-          label: formMessageDescriptors.deceasedParagraph,
-          initialValue: '',
-          validator: []
-        },
-        {
           name: 'uploadDocForDeceased',
           type: 'DOCUMENT_UPLOADER_WITH_OPTION',
           label: formMessageDescriptors.deceasedIDProof,

--- a/src/form/marriage/required-sections.ts
+++ b/src/form/marriage/required-sections.ts
@@ -56,13 +56,6 @@ export const documentsSection = {
     {
       id: 'documents-view-group',
       fields: [
-        {
-          name: 'paragraph',
-          type: 'PARAGRAPH',
-          label: formMessageDescriptors.documentsParagraph,
-          initialValue: '',
-          validator: []
-        },
         getDocUploaderForMarriage(
           'uploadDocForMarriageProof',
           'proofOfMarriageNotice',


### PR DESCRIPTION
Copy not required. Existing copy does not accurately describe the required action on these pages

If supporting copy is required on a form page in the future. It should use 'supporting-copy prop in the Contents component