### PR TITLE
fix: advanced search end to end test 

### DIFF
--- a/cypress/e2e/advancedsearch.spec.ts
+++ b/cypress/e2e/advancedsearch.spec.ts
@@ -242,9 +242,9 @@ context('Advanced Search Integration Test', () => {
       eventLocationLevel1,
       eventLocationLevel2
     })
-
-    cy.login('registrar')
-    cy.createPin()
+    cy.registerDeclaration()
+    //WAIT FOR OUTBOX TO BE READY
+    cy.get('#navigation_outbox').should('have.text', 'Outbox')
     //OPEN ADVANCED SEARCH
     cy.get('#searchType').click()
     cy.get('#advanced-search').click()

--- a/cypress/e2e/advancedsearch.spec.ts
+++ b/cypress/e2e/advancedsearch.spec.ts
@@ -243,8 +243,7 @@ context('Advanced Search Integration Test', () => {
       eventLocationLevel2
     })
     cy.registerDeclaration()
-    //WAIT FOR OUTBOX TO BE READY
-    cy.get('#navigation_outbox').should('have.text', 'Outbox')
+    cy.waitForOutboxToClear()
     //OPEN ADVANCED SEARCH
     cy.get('#searchType').click()
     cy.get('#advanced-search').click()


### PR DESCRIPTION
Issue on my machine was that the pin input was not being found. I think more realistic in this E2E test is that the registrar wouldn't log out, but rather just wait for the Outbox to clear and then search for the record, so I changed it to work like this.