### PR TITLE
Fix Correct item names in update modal for marriage declaration

### DIFF
--- a/src/form/marriage/index.ts
+++ b/src/form/marriage/index.ts
@@ -84,7 +84,7 @@ export const marriageForm: ISerializedForm = {
     {
       id: 'informant',
       viewType: 'form',
-      name: formMessageDescriptors.registrationName,
+      name: formMessageDescriptors.informantName,
       title: formMessageDescriptors.informantTitle,
       groups: [
         {

--- a/src/translations/client.csv
+++ b/src/translations/client.csv
@@ -1296,7 +1296,7 @@ form.section.accountDetails,,Account details,Coordonnées du compte
 form.section.assignedRegistrationOffice,,Assign to a registration office,A quel bureau voulez-vous affecter un nouvel utilisateur ?
 form.section.assignedRegistrationOfficeGroupTitle,,Assigned registration office,Bureau d'enregistrement assigné
 form.section.bride.headOfBrideFamily,,Head of bride's family,Chef de la famille de la mariée
-form.section.bride.name,,Print and issue to bride,Imprimer et envoyer à la mariée
+form.section.bride.name,,Bride,Mariée
 form.section.bride.title,,Bride's details,Détails de la mariée
 form.section.causeOfDeath.name,,Cause of Death,Cause du décès
 form.section.causeOfDeath.title,,What is the medically certified cause of death?,Quelle est la cause de décès médicalement certifiée ?
@@ -1333,7 +1333,7 @@ form.section.documents.uploadImage,,Upload a photo of the supporting document,T�
 form.section.father.name,,Father,Père
 form.section.father.title,,Father's details,Information du père
 form.section.groom.headOfGroomFamily,,Head of groom's family,Chef de la famille du marié
-form.section.groom.name,,Print and issue to groom,Imprimer et envoyer au marié
+form.section.groom.name,,Groom,Marié
 form.section.groom.title,,Groom's details,Détails du marié
 form.section.informant.name,,Informant,Informateur
 form.section.informant.title,,Informant's details,information de l'informateur

--- a/src/translations/client.csv
+++ b/src/translations/client.csv
@@ -1297,6 +1297,7 @@ form.section.assignedRegistrationOffice,,Assign to a registration office,A quel 
 form.section.assignedRegistrationOfficeGroupTitle,,Assigned registration office,Bureau d'enregistrement assigné
 form.section.bride.headOfBrideFamily,,Head of bride's family,Chef de la famille de la mariée
 form.section.bride.name,,Bride,Mariée
+form.section.bride.printAndIssueToBride,,Print and issue to bride,Imprimer et envoyer à la mariée
 form.section.bride.title,,Bride's details,Détails de la mariée
 form.section.causeOfDeath.name,,Cause of Death,Cause du décès
 form.section.causeOfDeath.title,,What is the medically certified cause of death?,Quelle est la cause de décès médicalement certifiée ?
@@ -1334,6 +1335,7 @@ form.section.father.name,,Father,Père
 form.section.father.title,,Father's details,Information du père
 form.section.groom.headOfGroomFamily,,Head of groom's family,Chef de la famille du marié
 form.section.groom.name,,Groom,Marié
+form.section.groom.printAndIssueToGroom,,Print and issue to groom,Imprimer et envoyer au marié
 form.section.groom.title,,Groom's details,Détails du marié
 form.section.informant.name,,Informant,Informateur
 form.section.informant.title,,Informant's details,information de l'informateur


### PR DESCRIPTION
Updated the item names in the update modal for marriage declarations to:
- 'Informant' in place of 'Registration name'
- 'Bride' in place of 'Print and issue to bride'
- 'Groom' in place of 'Print and issue to Groom'


related core pull request: https://github.com/opencrvs/opencrvs-core/pull/7066