### PR TITLE
Fix/birth e2e tests

### DIFF
--- a/e2e/testcases/birth/1-birth-event-declaration.spec.ts
+++ b/e2e/testcases/birth/1-birth-event-declaration.spec.ts
@@ -99,7 +99,7 @@ test.describe('1. Birth event declaration', () => {
          * Expected result: should show
          * - I am going to help you make a declaration of birth.
          * - As the legal Informant it is important that all the information provided by you is accurate.
-         * - Once the declaration is processed you will receive you will receive an email to tell you
+         * - Once the declaration is processed you will receive an email to tell you
          *   when to visit the office to collect the certificate - Take your ID with you.
          * - Make sure you collect the certificate. A birth certificate is critical for this child,
          *   especially to make their life easy later on. It will help to access health services, school examinations and government benefits.
@@ -114,7 +114,7 @@ test.describe('1. Birth event declaration', () => {
         ).toBeVisible()
         await expect(
           page.getByText(
-            'Once the declaration is processed you will receive you will receive an email to tell you when to visit the office to collect the certificate - Take your ID with you.'
+            'Once the declaration is processed you will receive an email to tell you when to visit the office to collect the certificate - Take your ID with you.'
           )
         ).toBeVisible()
         await expect(

--- a/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
@@ -1243,8 +1243,8 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Father's address
        * - Change button
        */
-      await expect(page.locator('#father-content #Usual')).toContainText('Yes')
-      await expect(page.locator('#father-content #Usual')).toContainText(
+      await expect(page.locator('#father-content #Same')).toContainText('Yes')
+      await expect(page.locator('#father-content #Same')).toContainText(
         'Change'
       )
     })
@@ -1572,8 +1572,8 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Father's address
        * - Change button
        */
-      await expect(page.locator('#father-content #Usual')).toContainText('Yes')
-      await expect(page.locator('#father-content #Usual')).toContainText(
+      await expect(page.locator('#father-content #Same')).toContainText('Yes')
+      await expect(page.locator('#father-content #Same')).toContainText(
         'Change'
       )
     })

--- a/e2e/testcases/birth/declarations/birth-declaration-1.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-1.spec.ts
@@ -503,7 +503,7 @@ test.describe.serial('1. Birth declaration case - 1', () => {
        * Expected result: should include
        * - Father's address
        */
-      await expect(page.locator('#father-content #Usual')).toContainText('Yes')
+      await expect(page.locator('#father-content #Same')).toContainText('Yes')
     })
 
     test('1.1.7 Send for review', async () => {
@@ -798,7 +798,7 @@ test.describe.serial('1. Birth declaration case - 1', () => {
        * Expected result: should include
        * - Father's address
        */
-      await expect(page.locator('#father-content #Usual')).toContainText('Yes')
+      await expect(page.locator('#father-content #Same')).toContainText('Yes')
     })
   })
 })

--- a/e2e/testcases/birth/declarations/birth-declaration-2.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-2.spec.ts
@@ -538,7 +538,6 @@ test.describe.serial('2. Birth declaration case - 2', () => {
        * Expected result: should include
        * - Father's address
        */
-      await expect(page.locator('#father-content #Usual')).toContainText('No')
 
       await expect(page.locator('#father-content #Usual')).toContainText(
         declaration.father.address.country
@@ -845,7 +844,6 @@ test.describe.serial('2. Birth declaration case - 2', () => {
        * Expected result: should include
        * - Father's address
        */
-      await expect(page.locator('#father-content #Usual')).toContainText('No')
 
       await expect(page.locator('#father-content #Usual')).toContainText(
         declaration.father.address.country

--- a/e2e/testcases/birth/declarations/birth-declaration-3.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-3.spec.ts
@@ -684,7 +684,7 @@ test.describe.serial('3. Birth declaration case - 3', () => {
        * Expected result: should include
        * - Father's address
        */
-      await expect(page.locator('#father-content #Usual')).toContainText('No')
+
       await expect(page.locator('#father-content #Usual')).toContainText(
         declaration.father.address.country
       )
@@ -1055,7 +1055,7 @@ test.describe.serial('3. Birth declaration case - 3', () => {
        * Expected result: should include
        * - Father's address
        */
-      await expect(page.locator('#father-content #Usual')).toContainText('No')
+
       await expect(page.locator('#father-content #Usual')).toContainText(
         declaration.father.address.country
       )

--- a/e2e/testcases/birth/declarations/birth-declaration-4.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-4.spec.ts
@@ -675,7 +675,6 @@ test.describe.serial('4. Birth declaration case - 4', () => {
        * Expected result: should include
        * - Father's address
        */
-      await expect(page.locator('#father-content #Usual')).toContainText('No')
       await expect(page.locator('#father-content #Usual')).toContainText(
         declaration.father.address.country
       )
@@ -1043,7 +1042,6 @@ test.describe.serial('4. Birth declaration case - 4', () => {
        * Expected result: should include
        * - Father's address
        */
-      await expect(page.locator('#father-content #Usual')).toContainText('No')
       await expect(page.locator('#father-content #Usual')).toContainText(
         declaration.father.address.country
       )

--- a/e2e/testcases/death/1-death-event-declaration.spec.ts
+++ b/e2e/testcases/death/1-death-event-declaration.spec.ts
@@ -96,7 +96,7 @@ test.describe('1. Death event declaration', () => {
          * Expected result: should show
          * - I am going to help you make a declaration of death.
          * - As the legal Informant it is important that all the information provided by you is accurate.
-         * - Once the declaration is processed you will receive you will receive an email to tell you
+         * - Once the declaration is processed you will receive an email to tell you
          *   when to visit the office to collect the certificate - Take your ID with you.
          * - Make sure you collect the certificate. A death certificate is critical to support with
          *   inheritance claims and to resolve the affairs of the deceased e.g. closing bank accounts and setting loans.
@@ -111,7 +111,7 @@ test.describe('1. Death event declaration', () => {
         ).toBeVisible()
         await expect(
           page.getByText(
-            'Once the declaration is processed you will receive you will receive an email to tell you when to visit the office to collect the certificate - Take your ID with you.'
+            'Once the declaration is processed you will receive an email to tell you when to visit the office to collect the certificate - Take your ID with you.'
           )
         ).toBeVisible()
         await expect(

--- a/e2e/testcases/death/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/death/8-validate-declaration-review-page.spec.ts
@@ -929,7 +929,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Spouse's address
        * - Change button
        */
-      await expect(page.locator('#spouse-content #Usual')).toContainText('Yes')
+      await expect(page.locator('#spouse-content #Same')).toContainText('Yes')
     })
 
     test.describe('8.2.2 Click any "Change" link', async () => {
@@ -1466,7 +1466,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Spouse's address
        * - Change button
        */
-      await expect(page.locator('#spouse-content #Usual')).toContainText('Yes')
+      await expect(page.locator('#spouse-content #Same')).toContainText('Yes')
     })
 
     test.describe('8.3.2 Click any "Change" link', async () => {

--- a/e2e/testcases/death/declaration/death-declaration-1.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-1.spec.ts
@@ -501,7 +501,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Spouse's address
        * - Change button
        */
-      await expect(page.locator('#spouse-content #Usual')).toContainText('Yes')
+      await expect(page.locator('#spouse-content #Same')).toContainText('Yes')
     })
 
     test('1.1.7 Send for review', async () => {
@@ -840,7 +840,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Spouse's address
        * - Change button
        */
-      await expect(page.locator('#spouse-content #Usual')).toContainText('Yes')
+      await expect(page.locator('#spouse-content #Same')).toContainText('Yes')
     })
   })
 })

--- a/e2e/testcases/death/declaration/death-declaration-10.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-10.spec.ts
@@ -255,7 +255,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Spouse's address
        * - Change button
        */
-      await expect(page.locator('#spouse-content #Usual')).toContainText('Yes')
+      await expect(page.locator('#spouse-content #Same')).toContainText('Yes')
     })
 
     test('10.1.6 Send for review', async () => {
@@ -493,7 +493,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Spouse's address
        * - Change button
        */
-      await expect(page.locator('#spouse-content #Usual')).toContainText('Yes')
+      await expect(page.locator('#spouse-content #Same')).toContainText('Yes')
     })
   })
 })

--- a/e2e/testcases/death/declaration/death-declaration-8.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-8.spec.ts
@@ -263,7 +263,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Spouse's address
        * - Change button
        */
-      await expect(page.locator('#spouse-content #Usual')).toContainText('Yes')
+      await expect(page.locator('#spouse-content #Same')).toContainText('Yes')
     })
 
     test('8.1.6 Send for review', async () => {
@@ -503,7 +503,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Spouse's address
        * - Change button
        */
-      await expect(page.locator('#spouse-content #Usual')).toContainText('Yes')
+      await expect(page.locator('#spouse-content #Same')).toContainText('Yes')
     })
   })
 })

--- a/e2e/testcases/death/declaration/death-declaration-9.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-9.spec.ts
@@ -267,7 +267,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Spouse's address
        * - Change button
        */
-      await expect(page.locator('#spouse-content #Usual')).toContainText('Yes')
+      await expect(page.locator('#spouse-content #Same')).toContainText('Yes')
     })
 
     test('9.1.6 Send for review', async () => {
@@ -514,7 +514,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Spouse's address
        * - Change button
        */
-      await expect(page.locator('#spouse-content #Usual')).toContainText('Yes')
+      await expect(page.locator('#spouse-content #Same')).toContainText('Yes')
     })
   })
 })

--- a/src/form/addresses/index.ts
+++ b/src/form/addresses/index.ts
@@ -144,7 +144,7 @@ export const defaultAddressConfiguration: IAddressConfiguration[] = [
             `(${detailsDontExist} || ${mothersDetailsDontExistOnOtherPage}) || ${hideIfMotherAddressNotAvailable[0].expression}`
           ),
           expressionToConditional(
-            `(${detailsDontExist} || ${mothersDetailsDontExistOnOtherPage}) || ${hideIfMotherAddressNotAvailable[0].expression} || !${primaryAddressSameAsOtherPrimaryAddress})`,
+            `(${detailsDontExist} || ${mothersDetailsDontExistOnOtherPage}) || ${hideIfMotherAddressNotAvailable[0].expression} || !${primaryAddressSameAsOtherPrimaryAddress}`,
             'hideInPreview'
           )
         ]


### PR DESCRIPTION
1. Update E2E tests to match right id. 
2. Update copies to match changes (remove duplicates)
3. Remove extra parenthesis from conditional