### PR TITLE
fix(birth): update missing references. Remove checks for #Usual on 'No'

### DIFF
--- a/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
@@ -475,10 +475,8 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Father's address
          * - Change button
          */
-        await expect(page.locator('#father-content #Usual')).toContainText(
-          'Yes'
-        )
-        await expect(page.locator('#father-content #Usual')).toContainText(
+        await expect(page.locator('#father-content #Same')).toContainText('Yes')
+        await expect(page.locator('#father-content #Same')).toContainText(
           'Change'
         )
       })

--- a/e2e/testcases/death/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/death/8-validate-declaration-review-page.spec.ts
@@ -409,9 +409,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Spouse's address
          * - Change button
          */
-        await expect(page.locator('#spouse-content #Usual')).toContainText(
-          'Yes'
-        )
+        await expect(page.locator('#spouse-content #Same')).toContainText('Yes')
       })
     })
 

--- a/e2e/testcases/death/declaration/death-declaration-2.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-2.spec.ts
@@ -543,7 +543,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - informant's address
        * - Change button
        */
-      await expect(page.locator('#informant-content #Usual')).toContainText(
+      await expect(page.locator('#informant-content #Same')).toContainText(
         'Yes'
       )
 
@@ -958,7 +958,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - informant's address
        * - Change button
        */
-      await expect(page.locator('#informant-content #Usual')).toContainText(
+      await expect(page.locator('#informant-content #Same')).toContainText(
         'Yes'
       )
 

--- a/e2e/testcases/death/declaration/death-declaration-3.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-3.spec.ts
@@ -580,9 +580,6 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expect(page.locator('#informant-content #Usual')).toContainText(
-        'No'
-      )
-      await expect(page.locator('#informant-content #Usual')).toContainText(
         declaration.informant.address.country
       )
       await expect(page.locator('#informant-content #Usual')).toContainText(
@@ -1014,9 +1011,6 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - informant's address
        * - Change button
        */
-      await expect(page.locator('#informant-content #Usual')).toContainText(
-        'No'
-      )
       await expect(page.locator('#informant-content #Usual')).toContainText(
         declaration.informant.address.country
       )

--- a/e2e/testcases/death/declaration/death-declaration-4.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-4.spec.ts
@@ -560,9 +560,6 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expect(page.locator('#informant-content #Usual')).toContainText(
-        'No'
-      )
-      await expect(page.locator('#informant-content #Usual')).toContainText(
         declaration.informant.address.country
       )
       await expect(page.locator('#informant-content #Usual')).toContainText(
@@ -973,9 +970,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - informant's address
        * - Change button
        */
-      await expect(page.locator('#informant-content #Usual')).toContainText(
-        'No'
-      )
+
       await expect(page.locator('#informant-content #Usual')).toContainText(
         declaration.informant.address.country
       )

--- a/e2e/testcases/death/declaration/death-declaration-5.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-5.spec.ts
@@ -531,9 +531,6 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expect(page.locator('#informant-content #Usual')).toContainText(
-        'No'
-      )
-      await expect(page.locator('#informant-content #Usual')).toContainText(
         declaration.informant.address.country
       )
       await expect(page.locator('#informant-content #Usual')).toContainText(
@@ -891,9 +888,6 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - informant's address
        * - Change button
        */
-      await expect(page.locator('#informant-content #Usual')).toContainText(
-        'No'
-      )
       await expect(page.locator('#informant-content #Usual')).toContainText(
         declaration.informant.address.country
       )

--- a/e2e/testcases/death/declaration/death-declaration-6.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-6.spec.ts
@@ -505,9 +505,6 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expect(page.locator('#informant-content #Usual')).toContainText(
-        'No'
-      )
-      await expect(page.locator('#informant-content #Usual')).toContainText(
         declaration.informant.address.country
       )
       await expect(page.locator('#informant-content #Usual')).toContainText(
@@ -788,9 +785,6 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * Expected result: should include
        * - informant's address
        */
-      await expect(page.locator('#informant-content #Usual')).toContainText(
-        'No'
-      )
       await expect(page.locator('#informant-content #Usual')).toContainText(
         declaration.informant.address.country
       )

--- a/e2e/testcases/death/declaration/death-declaration-7.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-7.spec.ts
@@ -531,9 +531,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - informant's address
        * - Change button
        */
-      await expect(page.locator('#informant-content #Usual')).toContainText(
-        'No'
-      )
+
       await expect(page.locator('#informant-content #Usual')).toContainText(
         declaration.informant.address.country
       )
@@ -815,9 +813,6 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * Expected result: should include
        * - informant's address
        */
-      await expect(page.locator('#informant-content #Usual')).toContainText(
-        'No'
-      )
       await expect(page.locator('#informant-content #Usual')).toContainText(
         declaration.informant.address.country
       )


### PR DESCRIPTION
- Update remaining id references from 'Usual' to 'Same' when same address is used
- Remove remaining 'No' checks when checking for address content