### PR TITLE
Added filler values for blank address lines in playwright tests

### DIFF
--- a/e2e/testcases/death/helpers.ts
+++ b/e2e/testcases/death/helpers.ts
@@ -306,8 +306,8 @@ const formatAddressLine = (address: typeof declaration.deceased.address) => [
   address.number,
   address.street,
   address.residentialArea,
-  '',
-  '',
+  'line 3',
+  'line 4',
   'URBAN',
   ...new Array(9).fill('')
 ]


### PR DESCRIPTION
Core was changed to not show blank lines, which has broken tests here. Filling in the lines allows the tests to assume the same number of address lines
