### PR TITLE
feat: Add humanName constant for country config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ In order to make the upgrade easier, there are a couple of steps that need to be
 - Update the translations for System user add/edit form, `Last name` to `User's surname` and `First name` to `User's first name` to make them less confusing for system users [#6830](https://github.com/opencrvs/opencrvs-core/issues/6830)
 - **User scopes** Introduce granular scopes to grant specific permissions to a particular role. The specifics about the introduced scopes can be found here: *Link to scopes description file*
 - **Refactored certificate handling:** SVGs are no longer stored in the database; streamlined configurations now include certificate details, and clients request SVGs directly via URLs.
-- Add constant.humanName to allow countries to have custom ordering on their full name e.g. start with `lastName` or `firstName` [#6830](https://github.com/opencrvs/opencrvs-core/issues/6830)
+- Add constant.humanName to allow countries to customise the format of the full name in the sytem for `sytem users` and `citizens` e.g `{LastName} {MiddleName} {Firstname}`, in any case where one of the name is not provided e.g no `MiddleName`, we'll simply render e.g `{LastName} {FirstName}` without any extra spaces if that's the order set in `country-config`. [#6830](https://github.com/opencrvs/opencrvs-core/issues/6830)
 
 ### Improvements
 
@@ -51,6 +51,7 @@ In order to make the upgrade easier, there are a couple of steps that need to be
 ```
 INSERT CSV ROWS IN ENGLISH ONLY
 ```
+
 ## 1.6.1 Release candidate
 
 ### Bug fixes

--- a/src/translations/client.csv
+++ b/src/translations/client.csv
@@ -287,7 +287,7 @@ constants.gender,Gender label,Gender,Sexe
 constants.healthDivision,The description for HEALTH_DIVISION type,Health Division,Division de la santé
 constants.healthcareWorker,The description for Healthcare Worker type,Healthcare Worker,Travailleur de la santé
 constants.history,History heading,History,Histoire
-constants.humanName,Formatted full name, {lastName} {middleName} {firstName},{lastName} {middleName} {firstName}
+constants.humanName,Formatted full name, {firstName} {middleName} {lastName}, {firstName} {middleName} {lastName}
 constants.id,ID Label,ID,ID
 constants.idCheckWithoutVerify,Issuance without the confirmation of proof,Continue without proof of ID?,Continuer sans preuve d'identité?
 constants.inReview.status,A label for In Review,In review,En cours de révision


### PR DESCRIPTION
Fix e2e tests after introducing a way to allow countries to customise the order of a full name. turns out there were alot of other screens that use a full name so the changes to the `formatName()` broke a lot of e2e tests. Instead of fixing the tests we've put temporary logic `fullNameWithFirstNameFirst()` helper function which will get removed once all the screens use the `formatName()` function.

https://github.com/opencrvs/opencrvs-core/issues/6830