### PR TITLE
fix: Add the isAgeInYearsBetween validator

### DIFF
--- a/src/form/birth/index.ts
+++ b/src/form/birth/index.ts
@@ -191,7 +191,13 @@ export const birthForm: ISerializedForm = {
             getBirthDate(
               'childBirthDate',
               [],
-              isValidChildBirthDate,
+              [
+                ...isValidChildBirthDate,
+                {
+                  operation: 'isAgeInYearsBetween',
+                  parameters: [16, 150]
+                }
+              ],
               certificateHandlebars.eventDate
             ), // Required field.
             getReasonForLateRegistration('birth'),
@@ -247,6 +253,10 @@ export const birthForm: ISerializedForm = {
                 {
                   operation: 'dateInPast',
                   parameters: []
+                },
+                {
+                  operation: 'dateIsBetween',
+                  parameters: [20, 25]
                 }
               ],
               certificateHandlebars.informantBirthDate

--- a/src/form/death/index.ts
+++ b/src/form/death/index.ts
@@ -277,6 +277,10 @@ export const deathForm = {
                 {
                   operation: 'dateInPast',
                   parameters: []
+                },
+                {
+                  operation: 'dateIsBetween',
+                  parameters: [20, 25]
                 }
               ],
               certificateHandlebars.informantBirthDate

--- a/src/form/marriage/index.ts
+++ b/src/form/marriage/index.ts
@@ -125,6 +125,10 @@ export const marriageForm: ISerializedForm = {
                 {
                   operation: 'dateInPast',
                   parameters: []
+                },
+                {
+                  operation: 'isAgeInYearsBetween',
+                  parameters: [16, 150]
                 }
               ],
               certificateHandlebars.informantBirthDate

--- a/src/form/types/validators.ts
+++ b/src/form/types/validators.ts
@@ -47,6 +47,9 @@ type CoreValidator =
   | 'duplicateIDNumber'
   | 'isValidDeathOccurrenceDate'
   | 'isMoVisitDateAfterBirthDateAndBeforeDeathDate'
+  /**
+   * @deprecated This validator is deprecated and will be removed in future releases. Use `isAgeInYearsBetween` instead
+   */
   | 'isInformantOfLegalAge'
   | 'greaterThanZero'
   | 'notGreaterThan'

--- a/src/form/types/validators.ts
+++ b/src/form/types/validators.ts
@@ -51,6 +51,7 @@ type CoreValidator =
    * @deprecated This validator is deprecated and will be removed in future releases. Use `isAgeInYearsBetween` instead
    */
   | 'isInformantOfLegalAge'
+  | 'isAgeInYearsBetween'
   | 'greaterThanZero'
   | 'notGreaterThan'
 


### PR DESCRIPTION
Add the isAgeInYearsBetween and deprecate the isInformantOfLegalAge validator To warn countries still using it that it will not be supported in future releases

https://github.com/opencrvs/opencrvs-core/issues/7636