### PR TITLE
fix: wait for assignment to propagate

### DIFF
--- a/e2e/testcases/death/declaration/death-declaration-6.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-6.spec.ts
@@ -538,6 +538,10 @@ test.describe.serial('6. Death declaration case - 6', () => {
         })
         .click()
       await assignRecord(page)
+      // https://github.com/opencrvs/opencrvs-core/blob/f4eebcbaf0e9340783a22cbfb36bd547a3ad13f5/packages/workflow/src/records/handler/download.ts#L28-L80
+      // Assumption is that the optimisation done above causes the test 6.2.2. fail intermittently since we are fetching before the actual changes are propagated to database.
+      await page.waitForTimeout(2500)
+
       await page.getByRole('button', { name: 'Action' }).first().click()
       await getAction(page, 'View record').click()
     })

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "e2e:generate-types": "graphql-codegen --config e2e/codegen.yml && yarn prettier --write e2e/gateway.ts",
     "precommit": "lint-staged",
     "test": "vitest 'src/**/*.test.ts' --passWithNoTests",
-    "test:compilation": "tsc --noEmit",
+    "test:compilation": "tsc --noEmit --resolveJsonModule",
     "lint": "eslint -c .eslintrc.js",
     "start": "cross-env NODE_ENV=development NODE_OPTIONS=--dns-result-order=ipv4first nodemon --exec ts-node -r tsconfig-paths/register src/index.ts",
     "start:prod": "ts-node --transpile-only -r tsconfig-paths/register src/index.ts",


### PR DESCRIPTION
Test case 6.2.2. fails constantly.
Based on investigation, there is 'early return' optimisation made during record assignment. In "real situatitons" it probably not bother anyone. But with speed of e2e tests, we bump to it constantly.