### PR TITLE
fix: revert bad merge environment references

### DIFF
--- a/.github/workflows/clear-environment.yml
+++ b/.github/workflows/clear-environment.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   reset-data:
     name: 'Reset data'
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ inputs.environment }}
     runs-on: ubuntu-24.04
     outputs:
       outcome: ${{ steps.reset-data.outcome }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,7 +51,7 @@ on:
         default: false
 jobs:
   deploy:
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ inputs.environment }}
     runs-on: ubuntu-24.04
     outputs:
       outcome: ${{ steps.deploy.outcome }}
@@ -165,7 +165,7 @@ jobs:
           node-version: 18
           node-version-file: .nvmrc
 
-      - name: Deploy to ${{ github.event.inputs.environment }}
+      - name: Deploy to ${{ inputs.environment }}
         id: deploy
         run: |
           cd ./${{ github.event.repository.name }}

--- a/.github/workflows/seed-data.yml
+++ b/.github/workflows/seed-data.yml
@@ -26,8 +26,10 @@ on:
         description: Core DockerHub image tag
 jobs:
   seed-data:
-    environment: ${{ github.event.inputs.environment }}
+    environment: ${{ inputs.environment }}
     runs-on: ubuntu-24.04
+    outputs:
+      outcome: ${{ steps.seed.outcome }}
     timeout-minutes: 60
     steps:
       - name: Clone core


### PR DESCRIPTION
Automatic merge overwrote `.yml` file references to environment.input. They are intentionally different