### PR TITLE
Add HEARTH_MONGO_URL to docker-compose for config service

### DIFF
--- a/infrastructure/docker-compose.deploy.yml
+++ b/infrastructure/docker-compose.deploy.yml
@@ -871,6 +871,7 @@ services:
       - LOGIN_URL=https://login.{{hostname}}
       - CLIENT_APP_URL=https://register.{{hostname}}
       - DOMAIN={{hostname}}
+      - HEARTH_MONGO_URL=mongodb://hearth:${HEARTH_MONGODB_PASSWORD}@mongo1/hearth-dev?replicaSet=rs0
     deploy:
       labels:
         - 'traefik.enable=true'

--- a/infrastructure/docker-compose.production-deploy.yml
+++ b/infrastructure/docker-compose.production-deploy.yml
@@ -78,6 +78,7 @@ services:
       - NODE_ENV=production
       - SENTRY_DSN=${SENTRY_DSN:-}
       - MONGO_URL=mongodb://config:${CONFIG_MONGODB_PASSWORD}@mongo1,mongo2/application-config?replicaSet=rs0
+      - HEARTH_MONGO_URL=mongodb://hearth:${HEARTH_MONGODB_PASSWORD}@mongo1/hearth-dev?replicaSet=rs0
     deploy:
       replicas: 2
 

--- a/infrastructure/docker-compose.staging-deploy.yml
+++ b/infrastructure/docker-compose.staging-deploy.yml
@@ -78,6 +78,7 @@ services:
       - NODE_ENV=production
       - SENTRY_DSN=${SENTRY_DSN:-}
       - MONGO_URL=mongodb://config:${CONFIG_MONGODB_PASSWORD}@mongo1/application-config?replicaSet=rs0
+      - HEARTH_MONGO_URL=mongodb://hearth:${HEARTH_MONGODB_PASSWORD}@mongo1/hearth-dev?replicaSet=rs0
     deploy:
       replicas: 1
 


### PR DESCRIPTION
Add HEARTH_MONGO_URL to allow config service to call mongo directly

Related PR: https://github.com/opencrvs/opencrvs-core/pull/8667