### PR TITLE
feat: Add playwright-ctrf-json-reporter package

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "node-ssh": "^13.2.0",
     "nodemon": "^2.0.22",
     "pino-pretty": "^11.0.0",
+    "playwright-ctrf-json-reporter": "^0.0.18",
     "prettier": "^3.4.2",
     "react-intl": "^6.4.3",
     "vite-tsconfig-paths": "^3.5.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -20,7 +20,10 @@ export default defineConfig({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: 'html',
+  reporter: [
+    ['html', { open: 'never' }],
+    ['playwright-ctrf-json-reporter', {}],
+  ],
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -6557,6 +6557,11 @@ playwright-core@1.48.0:
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.48.0.tgz#34d209dd4aba8fccd4a96116f1c4f7630f868722"
   integrity sha512-RBvzjM9rdpP7UUFrQzRwR8L/xR4HyC1QXMzGYTbf1vjw25/ya9NRAVnXi/0fvFopjebvyPzsmoK58xxeEOaVvA==
 
+playwright-ctrf-json-reporter@^0.0.18:
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/playwright-ctrf-json-reporter/-/playwright-ctrf-json-reporter-0.0.18.tgz#74b0d6cd53e3860148070db8cbecb789cac766e4"
+  integrity sha512-AjFNpIMKI8zeyaktA2LBphYzy3ffiBjXobBXxEfrVUDov/Z8v5+y9FI0m3cBCr8yauk2brN+Er225vHsZDIu0g==
+
 playwright@1.48.0:
   version "1.48.0"
   resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.48.0.tgz#00855d9a25f1991d422867f1c32af5d90f457b48"


### PR DESCRIPTION
This PR is related to https://github.com/opencrvs/e2e/pull/33

e2e is using Farajaland tests and playwright.config.ts is part of Farajaland repository

Package playwright-ctrf-json-reporter should be installed here instead of e2e