### PR TITLE
new check added for testing production using double node or not(ocrvs-6918)

### DIFF
--- a/infrastructure/server-setup/inventory/backup.yml
+++ b/infrastructure/server-setup/inventory/backup.yml
@@ -17,6 +17,7 @@ all:
   vars:
     amount_of_backups_to_keep: 3
     backup_server_remote_target_directory: /home/backup/backups
+    single_node: true
     users:
       - name: riku
         ssh_keys:

--- a/infrastructure/server-setup/inventory/development.yml
+++ b/infrastructure/server-setup/inventory/development.yml
@@ -8,6 +8,7 @@
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
 all:
   vars:
+    single_node: true
     users:
       # If you need to remove access from someone, do not remove them from this list, but instead set their state: absent
       - name: pyry

--- a/infrastructure/server-setup/inventory/e2e.yml
+++ b/infrastructure/server-setup/inventory/e2e.yml
@@ -8,6 +8,7 @@
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
 all:
   vars:
+    single_node: true
     users:
       # If you need to remove access from someone, do not remove them from this list, but instead set their state: absent
       - name: pyry

--- a/infrastructure/server-setup/inventory/production.yml
+++ b/infrastructure/server-setup/inventory/production.yml
@@ -15,6 +15,7 @@ all:
     # Enable backups
     enable_backups: true
     backup_server_remote_target_directory: /home/backup/backups
+    single_node: false
     # external_backup_server_ssh_port: Defined in --extra-vars by the provisioning pipeline
     # external_backup_server_ip: Defined in --extra-vars by the provisioning pipeline
     users:

--- a/infrastructure/server-setup/inventory/production.yml
+++ b/infrastructure/server-setup/inventory/production.yml
@@ -60,12 +60,11 @@ docker-manager-first:
 # We recommend you add 2-4 workers for a scaled production deployment
 # This should depend on the size of your country and the number of end users.
 # If you are only using one production worker for very small countries or small pilot projects, replace with an empty block like so: docker-workers: {}
-docker-workers: {}
-# docker-workers:
-#   hosts:
-#     farajaland-prod-2:
-#       ansible_host: '49.13.124.87'
-#       data_label: data2
+docker-workers:
+  hosts:
+    farajaland-prod-2:
+      ansible_host: '49.13.124.87'
+      data_label: data2
 
 backups:
   hosts:

--- a/infrastructure/server-setup/inventory/production.yml
+++ b/infrastructure/server-setup/inventory/production.yml
@@ -60,11 +60,12 @@ docker-manager-first:
 # We recommend you add 2-4 workers for a scaled production deployment
 # This should depend on the size of your country and the number of end users.
 # If you are only using one production worker for very small countries or small pilot projects, replace with an empty block like so: docker-workers: {}
-docker-workers:
-  hosts:
-    farajaland-prod-2:
-      ansible_host: '49.13.124.87'
-      data_label: data2
+docker-workers: {}
+# docker-workers:
+#   hosts:
+#     farajaland-prod-2:
+#       ansible_host: '49.13.124.87'
+#       data_label: data2
 
 backups:
   hosts:

--- a/infrastructure/server-setup/inventory/qa.yml
+++ b/infrastructure/server-setup/inventory/qa.yml
@@ -8,6 +8,7 @@
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
 all:
   vars:
+    single_node: true
     users:
       # If you need to remove access from someone, do not remove them from this list, but instead set their state: absent
       - name: pyry

--- a/infrastructure/server-setup/inventory/staging.yml
+++ b/infrastructure/server-setup/inventory/staging.yml
@@ -18,6 +18,7 @@ all:
     backup_server_remote_target_directory: /home/backup/staging-backups
     backup_server_remote_source_directory: /home/backup/backups
     periodic_restore_from_backup: true
+    single_node: true
     # external_backup_server_ssh_port: Defined in --extra-vars by the provisioning pipeline
     # external_backup_server_ip: Defined in --extra-vars by the provisioning pipeline
     users:

--- a/infrastructure/server-setup/tasks/checks.yml
+++ b/infrastructure/server-setup/tasks/checks.yml
@@ -16,3 +16,10 @@
       - elasticsearch_superuser_password is defined
       - disk_encryption_key is defined
       - encrypted_disk_size is defined
+
+- name: 'Check the production environment is using more than one node' 
+  fail:
+    msg: 'The production environment must use more than one node. Please check the inventory file for production.'
+  when: 
+    - groups['docker-workers'] | length == 0
+    - single_node is not defined or single_node == false


### PR DESCRIPTION
production environment must not use a single node cluster
new variable(single_node) introduced which will be false only for prod
and new check is added in ansible task