### PR TITLE
fix test

### DIFF
--- a/e2e/testcases/v2-birth/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/v2-birth/8-validate-declaration-review-page.spec.ts
@@ -74,6 +74,9 @@ test.describe.serial('8. Validate declaration review page', () => {
       address: 'Same as mother'
     }
   }
+
+  let comment = faker.lorem.sentence()
+
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage()
     await loginToV2(page, CREDENTIALS.FIELD_AGENT)
@@ -851,7 +854,7 @@ test.describe.serial('8. Validate declaration review page', () => {
     })
 
     test('8.1.6 Fill up informant signature', async () => {
-      await page.locator('#review____comment').fill(faker.lorem.sentence())
+      await page.locator('#review____comment').fill(comment)
       await page.getByRole('button', { name: 'Sign' }).click()
       await drawSignature(page, true)
       await page
@@ -1132,8 +1135,20 @@ test.describe.serial('8. Validate declaration review page', () => {
       test.skip('Skipped for now', async () => {})
     })
 
-    test('8.2.6 Add signature and comment', async () => {
-      await page.locator('#review____comment').fill(faker.lorem.sentence())
+    test('8.2.6 Validate previous signature and comment, add new signature and comment', async () => {
+      await expect(page.locator('#review____comment')).toContainText(comment)
+      await expect(page.getByAltText('Upload Signature')).toBeVisible()
+
+      comment = faker.lorem.sentence()
+
+      await page.locator('#review____comment').clear()
+      await page.locator('#review____comment').fill(comment)
+
+      await page
+        .locator('#review____signature-form-input')
+        .getByText('Delete')
+        .click()
+
       await page.getByRole('button', { name: 'Sign' }).click()
       await drawSignature(page, true)
       await page
@@ -1428,8 +1443,20 @@ test.describe.serial('8. Validate declaration review page', () => {
       test.skip('Skipped for now', async () => {})
     })
 
-    test('8.3.6 Add signature and comment', async () => {
-      await page.locator('#review____comment').fill(faker.lorem.sentence())
+    test('8.3.6 Validate previous signature and comment, add new signature and comment', async () => {
+      await expect(page.locator('#review____comment')).toContainText(comment)
+      await expect(page.getByAltText('Upload Signature')).toBeVisible()
+
+      comment = faker.lorem.sentence()
+
+      await page.locator('#review____comment').clear()
+      await page.locator('#review____comment').fill(comment)
+
+      await page
+        .locator('#review____signature-form-input')
+        .getByText('Delete')
+        .click()
+
       await page.getByRole('button', { name: 'Sign' }).click()
       await drawSignature(page, true)
       await page

--- a/e2e/testcases/v2-birth/declarations/birth-declaration-10.spec.ts
+++ b/e2e/testcases/v2-birth/declarations/birth-declaration-10.spec.ts
@@ -199,7 +199,8 @@ test.describe.serial('10. Birth declaration case - 10', () => {
       await loginToV2(page, CREDENTIALS.REGISTRATION_AGENT)
       await page
         .getByRole('button', {
-          name: formatName(declaration.child.name)
+          name: formatName(declaration.child.name),
+          exact: true
         })
         .click()
       await page.getByRole('button', { name: 'Action', exact: true }).click()


### PR DESCRIPTION
## Description

Core PR: https://github.com/opencrvs/opencrvs-core/pull/9394

Fix test to assert previous comment and clear out comment and signature before filling in new one.

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
