### PR TITLE
Fix tests after 'EXTERNAL_VALIDATION_WORKQUEUE' env var change

### DIFF
--- a/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
@@ -1105,7 +1105,7 @@ test.describe.serial('Correct record - 2', () => {
       // TODO: remove skip when there is a fix related correction audit history
       test.skip('2.8.4.2 Validate correction requested modal', async () => {
         const correctionRequestedRow = page.locator(
-          '#listTable-task-history #row_4'
+          '#listTable-task-history #row_5'
         )
         await correctionRequestedRow.getByText('Correction requested').click()
 
@@ -1327,7 +1327,7 @@ test.describe.serial('Correct record - 2', () => {
 
       test('2.8.4.3 Validate correction rejected modal', async () => {
         const correctionRejectedRow = page.locator(
-          '#listTable-task-history #row_6'
+          '#listTable-task-history #row_7'
         )
         await correctionRejectedRow.getByText('Correction rejected').click()
 

--- a/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
@@ -792,11 +792,11 @@ test.describe.serial(' Correct record - 4', () => {
   })
   test('4.9 Validate record corrected modal', async () => {
     const correctionRequestedRow = page.locator(
-      '#listTable-task-history #row_4'
+      '#listTable-task-history #row_5'
     )
     await correctionRequestedRow.getByText('Record corrected').click()
 
-    const time = await correctionRequestedRow.locator('span').nth(1).innerText()
+    const date = await correctionRequestedRow.locator('span').nth(1).innerText()
 
     const requester = await correctionRequestedRow
       .locator('span')
@@ -817,7 +817,7 @@ test.describe.serial(' Correct record - 4', () => {
       page.getByRole('heading', { name: 'Record corrected' })
     ).toBeVisible()
 
-    await expect(page.getByText(requester + ' — ' + time)).toBeVisible()
+    await expect(page.getByText(requester + ' — ' + date)).toBeVisible()
 
     await expect(
       page.getByText('Requested by' + 'Legal guardian')

--- a/e2e/testcases/correction-death/correct-death-record-11.spec.ts
+++ b/e2e/testcases/correction-death/correct-death-record-11.spec.ts
@@ -605,7 +605,7 @@ test.describe.serial(' Correct record - 11', () => {
     })
     test('11.8.5 Validate correction requested modal', async () => {
       const correctionRequestedRow = page.locator(
-        '#listTable-task-history #row_4'
+        '#listTable-task-history #row_5'
       )
       await correctionRequestedRow.getByText('Correction requested').click()
 
@@ -714,7 +714,7 @@ test.describe.serial(' Correct record - 11', () => {
     })
     test('11.8.6 Validate correction rejected modal', async () => {
       const correctionRejectedRow = page.locator(
-        '#listTable-task-history #row_6'
+        '#listTable-task-history #row_7'
       )
       await correctionRejectedRow.getByText('Correction rejected').click()
 

--- a/e2e/testcases/correction-death/correct-death-record-15.spec.ts
+++ b/e2e/testcases/correction-death/correct-death-record-15.spec.ts
@@ -552,7 +552,7 @@ test.describe.serial(' Correct record - 15', () => {
     ).toBeVisible()
   })
   test('15.9 Validate record corrected modal', async () => {
-    const correctedRow = page.locator('#listTable-task-history #row_6')
+    const correctedRow = page.locator('#listTable-task-history #row_7')
     await correctedRow.getByText('Record corrected').click()
 
     const time = await correctedRow.locator('span').nth(1).innerText()


### PR DESCRIPTION
## Description

The env var `EXTERNAL_VALIDATION_WORKQUEUE` was switched from `false` -> `true` in [this](https://github.com/opencrvs/opencrvs-farajaland/commit/c74747b89333e9a2e6fc1571fa7ef45705a48579) commit. This broke some tests, as it now displays more items in the record audit history table due to [this](https://github.com/opencrvs/opencrvs-core/blob/develop/packages/client/src/views/RecordAudit/History.tsx#L213) logic.

Fix the locators to expect one more row in history table.

Would be nice to fix these locators to not depend on row amounts, but I was unable to get these tests running locally, so its quite a pain to fix them properly.
