### PR TITLE
fix: Make development environment default for non-approval deployments

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -12,7 +12,7 @@ on:
           - production
           - staging
       core-image-tag:
-        description: Core DockerHub image tag
+        description: Core image tag
         required: true
         default: 'v1.7.0'
       countryconfig-image-tag:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,14 +32,14 @@ on:
         type: choice
         description: Environment to deploy to
         required: true
-        default: 'staging'
+        default: 'development'
         options:
-          - staging
-          - qa
           - development
+          - qa
           - e2e
+          - staging
       core-image-tag:
-        description: Core DockerHub image tag
+        description: Core image tag
         required: true
         default: 'v1.7.0'
       countryconfig-image-tag:


### PR DESCRIPTION
## Description

Goal of this PR is to avoid deployment to staging environment by human mistake like here: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/15138375121

Included fixes:
- staging environment is moved to the bottom of the list
- DockerHub dropped from variable description. Core images aren't hosted on Dockerhub anymore.

## Checklist

N/A