### PR TITLE
feat: disable auto generated fields for informant

### DIFF
--- a/src/form/birth/index.ts
+++ b/src/form/birth/index.ts
@@ -248,25 +248,25 @@ export const birthForm: ISerializedForm = {
             ),
             getFirstNameField(
               'informantNameInEnglish',
-              informantFirstNameConditionals.concat(
-                hideIfInformantMotherOrFather
-              ),
+              informantFirstNameConditionals
+                .concat(hideIfInformantMotherOrFather)
+                .concat(disableIfVerifiedOrAuthenticated),
               certificateHandlebars.informantFirstName,
               getInitialValueFromIDReader('firstName')
             ), // Required field. In Farajaland, we have built the option to integrate with MOSIP. So we have different conditionals for each name to check MOSIP responses.  You could always refactor firstNamesEng for a basic setup
             getFamilyNameField(
               'informantNameInEnglish',
-              informantFamilyNameConditionals.concat(
-                hideIfInformantMotherOrFather
-              ),
+              informantFamilyNameConditionals
+                .concat(hideIfInformantMotherOrFather)
+                .concat(disableIfVerifiedOrAuthenticated),
               certificateHandlebars.informantFamilyName,
               getInitialValueFromIDReader('familyName')
             ), // Required field.
             getBirthDate(
               'informantBirthDate',
-              informantBirthDateConditionals.concat(
-                hideIfInformantMotherOrFather
-              ),
+              informantBirthDateConditionals
+                .concat(hideIfInformantMotherOrFather)
+                .concat(disableIfVerifiedOrAuthenticated),
               [
                 {
                   operation: 'dateFormatIsCorrect',


### PR DESCRIPTION
## Description

After filling up the fields with e-signet data in the informant section, make those fields read-only.


https://github.com/user-attachments/assets/645e6c0f-a636-41b2-bde7-3b7fc3c81a6b



## Checklist

- [ ] ~I have linked the correct Github issue under "Development"~
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] ~I have updated the changelog with this change (if applicable)~
- [x] I have updated the GitHub issue status accordingly
