### PR TITLE
fix: manual e2e trigger accessing deprecated property

### DIFF
--- a/.github/workflows/trigger-e2e-environment.yml
+++ b/.github/workflows/trigger-e2e-environment.yml
@@ -30,6 +30,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Get PR Information (when manually triggered)
+        env:
+          GH_TOKEN: ${{ github.token }}
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           PR_NUMBER=${{ github.event.inputs.pr_number }}

--- a/.github/workflows/trigger-e2e-environment.yml
+++ b/.github/workflows/trigger-e2e-environment.yml
@@ -35,9 +35,9 @@ jobs:
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           PR_NUMBER=${{ github.event.inputs.pr_number }}
-          PR_DATA=$(gh pr view $PR_NUMBER --json headRefName,headSha)
+          PR_DATA=$(gh pr view $PR_NUMBER --json headRefName,headRefOid)
           BRANCH_NAME=$(echo "$PR_DATA" | jq -r '.headRefName')
-          HEAD_COMMIT_HASH=$(echo "$PR_DATA" | jq -r '.headSha' | cut -c1-7)
+          HEAD_COMMIT_HASH=$(echo "$PR_DATA" | jq -r '.headRefOid' | cut -c1-7)
           echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_ENV
           echo "HEAD_COMMIT_HASH=${HEAD_COMMIT_HASH}" >> $GITHUB_ENV
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### New features
 - Added a local virtual machine setup for testing Ansible playbooks locally (on MacOS and Ubuntu ). Check [provision.ipynb](infrastructure/local-development/provision.ipynb) for more details.
 
+### Bug Fixes
+- Fixed `trigger-e2e-environment` workflow failing to run due to a missing env variable & accessing a deprecated property
+
 ## 1.7.2
 
 ### Bug fixes


### PR DESCRIPTION
## Description

- The `GH_TOKEN` env variable was missing which required to run the `gh` cli commands
- The `headSha` property seems to be no longer available from the `gh pr view` command. Link to a failing run: https://github.com/opencrvs/opencrvs-farajaland/actions/runs/15673009484/job/44147325925

## Checklist

- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
