### PR TITLE
fix: resolve protocol at runtime

### DIFF
--- a/src/client-config.prod.js
+++ b/src/client-config.prod.js
@@ -20,8 +20,11 @@ window.config = {
   LOGIN_URL: `${scheme}//login.${hostname}`,
   AUTH_URL: `${scheme}//gateway.${hostname}/auth/`,
   MINIO_URL: `${scheme}//minio.${hostname}/ocrvs/`,
-  /** E2E uses single minio for all the different services. @see start-prod.sh */
-  MINIO_BASE_URL: minioBaseUrl, // URL without path/bucket information, used for file uploads, v2
+  /** E2E uses single minio for all the different services. @see start-prod.sh.  */
+  MINIO_BASE_URL: minioBaseUrl.startsWith('http')
+    ? minioBaseUrl
+    : // Resolve the protocol on the same level as the other URLs.
+      `${scheme}${minioBaseUrl}`, // URL without path/bucket information, used for file uploads, v2
   /** Bucket name is hardcoded as 'ocrvs'. In live system, it cannot be changed without data migration.
    * In E2E environment, buckets are separated from different PR environments to avoid conflicts. @see start-prod.sh
    */

--- a/start-prod.sh
+++ b/start-prod.sh
@@ -19,8 +19,10 @@ sed -i "s={{sentry}}=$SENTRY_DSN=g" src/login-config.prod.js
 DEFAULT_MINIO_BUCKET="ocrvs"
 MINIO_BUCKET="${E2E_MINIO_BUCKET:-$DEFAULT_MINIO_BUCKET}"
 
-# '//' is used to indicate a protocol-relative URL. It shouldn't differ from "const scheme = window.location.protocol; MINIO_URL: ${scheme}//minio.${hostname}/ocrvs/`"
+# '//' is used to indicate a protocol-relative URL. Protocol is resolved at runtime.
 DEFAULT_MINIO_BASE_URL="//minio.$DOMAIN"
+# E2E environment needs to override the MinIO base URL.
+# To keep the configuration experience consistent, all the URL envs are given *with protocol*. This exception is handled in client-config.prod.js.
 MINIO_BASE_URL="${E2E_MINIO_BASE_URL:-$DEFAULT_MINIO_BASE_URL}"
 # Replace the MinIO bucket placeholder. Only e2e should override this without migration.
 sed -i "s/{{minio_bucket}}/$MINIO_BUCKET/g" src/client-config.prod.js


### PR DESCRIPTION
## Description

Even though `//` relative protocol i supported by HTML elements, constructs such as `new URL` require protocol defined or they will throw.

- Resolve protocol at runtime
- Add comments to clarify the why behind the exception


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
