### PR TITLE
[OCRVS-9837] Fix certificate UI issues

### DIFF
--- a/src/api/certificates/source/birth-certificate.svg
+++ b/src/api/certificates/source/birth-certificate.svg
@@ -1,7 +1,7 @@
 <svg width="595" height="842" viewBox="0 0 595 842" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <rect width="595" height="842" fill="white" />
   <g clip-path="url(#clip0_1157_5003)">
-    <text fill="#8D8D8D" xml:space="preserve" style="white-space: pre" font-family="Libre Baskerville" font-size="6" font-weight="bold" letter-spacing="0px">
+    <text fill="#8D8D8D" xml:space="preserve" style="white-space: pre" font-family="Libre Baskerville" font-size="5" font-weight="bold" letter-spacing="0px">
       <tspan x="61.9999" y="780.593">CAUTION : THERE ARE OFFENCES RELATING TO FALSIFYING OR ALTERING A CERTIFICATE AND USING OR POSSESSING A FALSE CERTIFICATE </tspan>
       <tspan x="61.9999" y="790.593">IS NOT PROOF OF IDENTITY / ATTENTION : IL EXISTE DES INFRACTIONS RELATIVES A LA FALSIFIATION OU &#xc0; LA MODIFICATION D&#39;UN </tspan>
       <tspan x="61.9999" y="800.593">CERTIFICAT ET A L&#39;UTILISATION OU LA POSSESSION D&#39;UN FAUX CERTIFICAT. UN CERTIFICAT N&#39;EST PAS UNE PREUVE D&#39;IDENTITE</tspan>

--- a/src/api/certificates/source/death-certificate.svg
+++ b/src/api/certificates/source/death-certificate.svg
@@ -1,7 +1,7 @@
 <svg width="595" height="842" viewBox="0 0 595 842" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <rect width="595" height="842" fill="white" />
   <g clip-path="url(#clip0_1157_5058)">
-    <text fill="#8D8D8D" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="6" font-weight="600" letter-spacing="0px">
+    <text fill="#8D8D8D" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="5" font-weight="600" letter-spacing="0px">
       <tspan x="62" y="780.593">CAUTION : THERE ARE OFFENCES RELATING TO FALSIFYING OR ALTERING A CERTIFICATE AND USING OR POSSESSING A FALSE CERTIFICATE </tspan>
       <tspan x="62" y="790.593">IS NOT PROOF OF IDENTITY / ATTENTION : IL EXISTE DES INFRACTIONS RELATIVES A LA FALSIFIATION OU &#xc0; LA MODIFICATION D&#39;UN </tspan>
       <tspan x="62" y="800.593">CERTIFICAT ET A L&#39;UTILISATION OU LA POSSESSION D&#39;UN FAUX CERTIFICAT. UN CERTIFICAT N&#39;EST PAS UNE PREUVE D&#39;IDENTITE</tspan>

--- a/src/api/certificates/source/marriage-certificate.svg
+++ b/src/api/certificates/source/marriage-certificate.svg
@@ -1,7 +1,7 @@
 <svg width="595" height="842" viewBox="0 0 595 842" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
   <rect width="595" height="842" fill="white" />
   <g clip-path="url(#clip0_1157_5110)">
-    <text fill="#8D8D8D" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="6" font-weight="600" letter-spacing="0px">
+    <text fill="#8D8D8D" xml:space="preserve" style="white-space: pre" font-family="Noto Sans" font-size="5" font-weight="600" letter-spacing="0px">
       <tspan x="62" y="780.593">CAUTION : THERE ARE OFFENCES RELATING TO FALSIFYING OR ALTERING A CERTIFICATE AND USING OR POSSESSING A FALSE CERTIFICATE </tspan>
       <tspan x="62" y="790.593">IS NOT PROOF OF IDENTITY / ATTENTION : IL EXISTE DES INFRACTIONS RELATIVES A LA FALSIFIATION OU &#xc0; LA MODIFICATION D&#39;UN </tspan>
       <tspan x="62" y="800.593">CERTIFICAT ET A L&#39;UTILISATION OU LA POSSESSION D&#39;UN FAUX CERTIFICAT. UN CERTIFICAT N&#39;EST PAS UNE PREUVE D&#39;IDENTITE</tspan>


### PR DESCRIPTION
Fix for https://github.com/opencrvs/opencrvs-core/issues/9837

The issue with the forward slashes in labels are fixed by https://github.com/opencrvs/opencrvs-countryconfig/pull/840

![image](https://github.com/user-attachments/assets/4ec0f613-d98f-4b11-943a-48d4daa046ee)
