### PR TITLE
Disable some system capabilities we dont need(ocrvs-7558)

### DIFF
--- a/infrastructure/server-setup/playbook.yml
+++ b/infrastructure/server-setup/playbook.yml
@@ -40,6 +40,14 @@
       tags:
         - users
 
+    - include_tasks:
+        file: tasks/security-hardening.yml
+        apply:
+          tags:
+            - security-hardening
+      tags:
+        - security-hardening
+
 - import_playbook: jump.yml
 
 - hosts: docker-manager-first:docker-workers

--- a/infrastructure/server-setup/tasks/security-hardening.yml
+++ b/infrastructure/server-setup/tasks/security-hardening.yml
@@ -1,0 +1,16 @@
+- name: Apply security sysctl settings
+  sysctl:
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
+    state: present
+    reload: yes
+    sysctl_file: /etc/sysctl.d/99-security.conf
+  loop:
+    - { name: 'fs.suid_dumpable', value: '0' }
+    - { name: 'net.ipv4.ip_forward', value: '0' }
+    - { name: 'net.ipv4.conf.all.send_redirects', value: '0' }
+    - { name: 'net.ipv4.conf.all.rp_filter', value: '1' }
+    - { name: 'net.ipv4.conf.all.accept_source_route', value: '0' }
+    - { name: 'net.ipv4.conf.all.log_martians', value: '1' }
+    - { name: 'net.ipv4.tcp_syncookies', value: '1' }
+    - { name: 'net.ipv6.conf.all.accept_ra', value: '0' }

--- a/infrastructure/server-setup/tasks/security-hardening.yml
+++ b/infrastructure/server-setup/tasks/security-hardening.yml
@@ -7,7 +7,7 @@
     sysctl_file: /etc/sysctl.d/99-security.conf
   loop:
     - { name: 'fs.suid_dumpable', value: '0' }
-    - { name: 'net.ipv4.ip_forward', value: '0' }
+    - { name: 'net.ipv4.ip_forward', value: '1' }
     - { name: 'net.ipv4.conf.all.send_redirects', value: '0' }
     - { name: 'net.ipv4.conf.all.rp_filter', value: '1' }
     - { name: 'net.ipv4.conf.all.accept_source_route', value: '0' }


### PR DESCRIPTION
## Description

Part of the security evaluation there was a finding that bunch of Ubuntu sysctl defaults are not needed by our service and could potentially be leveraged by hostile attacker. Lets disable these in our scripts as they should be enabled only when needed.

Sysctls in question

- Disable`fs.suid_dumpable` (core dump capability)
- Disable `net.ipv4.ip_forward` (traffic routing, though lets consider wireguard host)
- Enable `net.ipv4.conf.all.send_redirects` ( redirect sending is disabled that can be abused to send invalid packets)
- Enable `net.ipv4.conf.all.rp_filter` ( This ensures the packets being received is valid)
- Disable `net.ipv4.conf.all.accept_source_route`
- Enable `net.ipv4.conf.all.log_martians` (logs suspicious traffic)
- Enable `net.ipv4.tcp_syncookies` (we should ensure syncookies work) 
- Disable `net.ipv6.conf.all.accept_ra` (we dont use ipv6) 
 ISSUE : [#7558](https://github.com/opencrvs/opencrvs-core/issues/7558)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
