### PR TITLE
make validation tests faster by re-using `Page`

### DIFF
--- a/e2e/testcases/v2-birth/2-validate-the-child-details-page.spec.ts
+++ b/e2e/testcases/v2-birth/2-validate-the-child-details-page.spec.ts
@@ -1,33 +1,44 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, Page } from '@playwright/test'
 import { goToSection, loginToV2 } from '../../helpers'
 import { REQUIRED_VALIDATION_ERROR } from './helpers'
 import { trackAndDeleteCreatedEvents } from '../v2-test-data/eventDeletion'
 
+const loginAndBeginBirthDeclaration = async ({ page }: { page: Page }) => {
+  await loginToV2(page)
+
+  await page.click('#header-new-event')
+
+  await expect(page.getByText('New Declaration')).toBeVisible()
+  await expect(
+    page.getByText('What type of event do you want to declare?')
+  ).toBeVisible()
+  await expect(page.getByLabel('Birth')).toBeVisible()
+
+  await page.getByLabel('Birth').click()
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await page.getByRole('button', { name: 'Continue' }).click()
+
+  await expect(page.getByText("Child's details")).toBeVisible()
+}
+
 test.describe.serial("2. Validate the child's details page", () => {
+  let page: Page
+
   trackAndDeleteCreatedEvents()
 
-  test.beforeEach(async ({ page }) => {
-    await loginToV2(page)
-
-    await page.click('#header-new-event')
-
-    await expect(page.getByText('New Declaration')).toBeVisible()
-    await expect(
-      page.getByText('What type of event do you want to declare?')
-    ).toBeVisible()
-    await expect(page.getByLabel('Birth')).toBeVisible()
-
-    await page.getByLabel('Birth').click()
-    await page.getByRole('button', { name: 'Continue' }).click()
-
-    await page.getByRole('button', { name: 'Continue' }).click()
-
-    await expect(page.getByText("Child's details")).toBeVisible()
-  })
-
   test.describe('2.1 Validate "First Name(s)" text field', async () => {
+    test.beforeAll(async ({ browser }) => {
+      page = await browser.newPage()
+      await loginAndBeginBirthDeclaration({ page })
+    })
+
+    test.afterAll(async () => {
+      await page.close()
+    })
+
     test.describe('2.1.1 Enter Non-English characters', async () => {
-      test('Using name: Richard the 3rd', async ({ page }) => {
+      test('Using name: Richard the 3rd', async () => {
         await page.locator('#firstname').fill('Richard the 3rd')
         await page.getByRole('heading', { name: 'Birth' })
 
@@ -37,7 +48,7 @@ test.describe.serial("2. Validate the child's details page", () => {
         await expect(page.locator('#firstname_error')).toBeHidden()
       })
 
-      test('Using name: John_Peter', async ({ page }) => {
+      test('Using name: John_Peter', async () => {
         await page.locator('#firstname').fill('John_Peter')
         await page.getByRole('heading', { name: 'Birth' })
 
@@ -47,7 +58,7 @@ test.describe.serial("2. Validate the child's details page", () => {
         await expect(page.locator('#firstname_error')).toBeHidden()
       })
 
-      test('Using name: John-Peter', async ({ page }) => {
+      test('Using name: John-Peter', async () => {
         await page.locator('#firstname').fill('John-Peter')
         await page.getByRole('heading', { name: 'Birth' })
 
@@ -57,7 +68,7 @@ test.describe.serial("2. Validate the child's details page", () => {
         await expect(page.locator('#firstname_error')).toBeHidden()
       })
 
-      test("Using name: O'Neill", async ({ page }) => {
+      test("Using name: O'Neill", async () => {
         await page.locator('#firstname').fill("O'Neill")
         await page.getByRole('heading', { name: 'Birth' })
 
@@ -68,7 +79,7 @@ test.describe.serial("2. Validate the child's details page", () => {
       })
 
       // @TODO: This validation is not implemented in Events V2 yet
-      test.skip('Using name: &er$on', async ({ page }) => {
+      test.skip('Using name: &er$on', async () => {
         await page.locator('#firstname').fill('&er$on')
         await page.getByRole('heading', { name: 'Birth' })
 
@@ -79,7 +90,7 @@ test.describe.serial("2. Validate the child's details page", () => {
       })
 
       // @TODO: This validation is not implemented in Events V2 yet
-      test.skip('Using name: X Æ A-Xii', async ({ page }) => {
+      test.skip('Using name: X Æ A-Xii', async () => {
         await page.locator('#firstname').fill('X Æ A-Xii')
         await page.getByRole('heading', { name: 'Birth' })
 
@@ -91,7 +102,7 @@ test.describe.serial("2. Validate the child's details page", () => {
       })
     })
 
-    test('2.1.2 Enter less than 33 English characters', async ({ page }) => {
+    test('2.1.2 Enter less than 33 English characters', async () => {
       await page.locator('#firstname').fill('Rakibul Islam')
       await page.getByRole('heading', { name: 'Birth' })
 
@@ -101,7 +112,20 @@ test.describe.serial("2. Validate the child's details page", () => {
       await expect(page.locator('#firstname_error')).toBeHidden()
     })
 
-    test('2.1.3 Enter Field as NULL', async ({ page }) => {
+    test('2.1.4 Enter more than 32 English characters', async () => {
+      const LONG_NAME = 'Ovuvuevuevue Enyetuenwuevue Ugbemugbem Osas'
+      await page.locator('#firstname').fill(LONG_NAME)
+      await page.getByRole('heading', { name: 'Birth' })
+
+      /*
+       * Expected result: should clip the name to first 32 character
+       */
+      await expect(page.locator('#firstname')).toHaveValue(
+        LONG_NAME.slice(0, 32)
+      )
+    })
+
+    test('2.1.3 Enter Field as NULL', async () => {
       await goToSection(page, 'review')
 
       /*
@@ -114,22 +138,13 @@ test.describe.serial("2. Validate the child's details page", () => {
           .getByText(REQUIRED_VALIDATION_ERROR)
       ).toBeVisible()
     })
-
-    test('2.1.4 Enter more than 32 English characters', async ({ page }) => {
-      const LONG_NAME = 'Ovuvuevuevue Enyetuenwuevue Ugbemugbem Osas'
-      await page.locator('#firstname').fill(LONG_NAME)
-      await page.getByRole('heading', { name: 'Birth' })
-
-      /*
-       * Expected result: should clip the name to first 32 character
-       */
-      await expect(page.locator('#firstname')).toHaveValue(
-        LONG_NAME.slice(0, 32)
-      )
-    })
   })
 
   test.describe('2.3 Validate the Sex dropdown field', async () => {
+    test.beforeEach(async ({ page }) => {
+      await loginAndBeginBirthDeclaration({ page })
+    })
+
     test('2.3.1 Select any dropdown value: "Female"', async ({ page }) => {
       await page.locator('#child____gender').click()
       await page.getByText('Female', { exact: true }).click()
@@ -158,6 +173,10 @@ test.describe.serial("2. Validate the child's details page", () => {
   })
 
   test.describe('2.4 Validate the "DOB" field', async () => {
+    test.beforeEach(async ({ page }) => {
+      await loginAndBeginBirthDeclaration({ page })
+    })
+
     test('2.4.1 Enter date less than the current date', async ({ page }) => {
       const yesterday = new Date()
       yesterday.setDate(new Date().getDate() - 1)
@@ -175,7 +194,7 @@ test.describe.serial("2. Validate the child's details page", () => {
     })
 
     // @TODO: This validation is not implemented in Events V2 yet
-    test.skip('2.4.2 Enter invalid date', async ({ page }) => {
+    test.skip('2.4.2 Enter invalid date', async () => {
       await page.getByPlaceholder('dd').fill('0')
       await page.getByPlaceholder('mm').fill('0')
       await page.getByPlaceholder('yyyy').fill('0')
@@ -191,7 +210,7 @@ test.describe.serial("2. Validate the child's details page", () => {
     })
 
     // @TODO: This validation is not implemented in Events V2 yet
-    test.skip('2.4.3 Enter future date', async ({ page }) => {
+    test.skip('2.4.3 Enter future date', async () => {
       const futureDate = new Date()
       futureDate.setDate(new Date().getDate() + 5)
       const [yyyy, mm, dd] = futureDate.toISOString().split('T')[0].split('-')
@@ -227,7 +246,16 @@ test.describe.serial("2. Validate the child's details page", () => {
   })
 
   test.describe('2.5 Validate delayed registration', async () => {
-    test.beforeEach(async ({ page }) => {
+    test.beforeAll(async ({ browser }) => {
+      page = await browser.newPage()
+      loginAndBeginBirthDeclaration({ page })
+    })
+
+    test.afterAll(async () => {
+      await page.close()
+    })
+
+    test.beforeEach(async () => {
       const delayedDate = new Date()
       delayedDate.setDate(new Date().getDate() - 365 - 5)
       const [yyyy, mm, dd] = delayedDate.toISOString().split('T')[0].split('-')
@@ -238,9 +266,7 @@ test.describe.serial("2. Validate the child's details page", () => {
       await page.getByRole('heading', { name: 'Birth' })
     })
 
-    test('2.5.1 Enter date after delayed registration time period', async ({
-      page
-    }) => {
+    test('2.5.1 Enter date after delayed registration time period', async () => {
       const lateDate = new Date()
       lateDate.setDate(new Date().getDate() - 365 + 5)
       const [yyyy, mm, dd] = lateDate.toISOString().split('T')[0].split('-')
@@ -259,9 +285,7 @@ test.describe.serial("2. Validate the child's details page", () => {
       ).toBeHidden()
     })
 
-    test('2.5.2 Enter date before delayed registration time period', async ({
-      page
-    }) => {
+    test('2.5.2 Enter date before delayed registration time period', async () => {
       /*
        * Expected result: should show field:
        * - Reason for delayed registration
@@ -271,7 +295,7 @@ test.describe.serial("2. Validate the child's details page", () => {
       ).toBeVisible()
     })
 
-    test('2.5.3 Enter "Reason for late registration"', async ({ page }) => {
+    test('2.5.3 Enter "Reason for late registration"', async () => {
       await page.locator('#child____reason').fill('Lack of awareness')
 
       /*
@@ -280,7 +304,8 @@ test.describe.serial("2. Validate the child's details page", () => {
       await expect(page.locator('#child____reason_error')).toBeHidden()
     })
 
-    test('2.5.4 Set the field as null', async ({ page }) => {
+    test('2.5.4 Set the field as null', async () => {
+      await page.locator('#child____reason').fill('')
       await goToSection(page, 'review')
 
       /*
@@ -296,19 +321,16 @@ test.describe.serial("2. Validate the child's details page", () => {
   })
 
   test.describe('2.6 Validate place of delivery field', async () => {
-    test('2.6.1 Keep field as null', async ({ page }) => {
-      await goToSection(page, 'review')
-
-      /*
-       * Expected result: should throw error in application review page:
-       * - Required
-       */
-      await expect(
-        page.locator('[data-test-id="row-value-child.placeOfBirth"]')
-      ).toHaveText(REQUIRED_VALIDATION_ERROR)
+    test.beforeAll(async ({ browser }) => {
+      page = await browser.newPage()
+      loginAndBeginBirthDeclaration({ page })
     })
 
-    test('2.6.2.a Validate Health Institution', async ({ page }) => {
+    test.afterAll(async () => {
+      await page.close()
+    })
+
+    test('2.6.2.a Validate Health Institution', async () => {
       await test.step('Select Health Institution', async () => {
         await page.locator('#child____placeOfBirth').click()
         await page.getByText('Health Institution', { exact: true }).click()
@@ -330,7 +352,7 @@ test.describe.serial("2. Validate the child's details page", () => {
       })
     })
 
-    test('2.6.2.b Select Residential address', async ({ page }) => {
+    test('2.6.2.b Select Residential address', async () => {
       await page.locator('#child____placeOfBirth').click()
       await page.getByText('Residential address', { exact: true }).click()
 
@@ -348,7 +370,7 @@ test.describe.serial("2. Validate the child's details page", () => {
       ).toBeVisible()
     })
 
-    test('2.6.2.c Select Other', async ({ page }) => {
+    test('2.6.2.c Select Other', async () => {
       await page.locator('#child____placeOfBirth').click()
       await page.getByText('Other', { exact: true }).click()
 
@@ -364,6 +386,19 @@ test.describe.serial("2. Validate the child's details page", () => {
       await expect(
         page.locator('#child____address____other-form-input')
       ).toBeVisible()
+    })
+
+    test('2.6.1 Keep field as null', async ({ page }) => {
+      await loginAndBeginBirthDeclaration({ page }) // Use a fresh page for null test
+      await goToSection(page, 'review')
+
+      /*
+       * Expected result: should throw error in application review page:
+       * - Required
+       */
+      await expect(
+        page.locator('[data-test-id="row-value-child.placeOfBirth"]')
+      ).toHaveText(REQUIRED_VALIDATION_ERROR)
     })
   })
 })


### PR DESCRIPTION
Skips logging in in some of the validation tests that can be run in the same `Page` instance.