### PR TITLE
chore: filename -> path with FullDocumentPath

### DIFF
--- a/e2e/testcases/v2-test-data/birth-declaration-with-father-brother.ts
+++ b/e2e/testcases/v2-test-data/birth-declaration-with-father-brother.ts
@@ -1,8 +1,6 @@
 import { v4 as uuidv4 } from 'uuid'
 import { GATEWAY_HOST } from '../../constants'
 import { faker } from '@faker-js/faker'
-import fs from 'fs'
-import path from 'path'
 import { getAllLocations, getLocationIdByName } from '../birth/helpers'
 import { createClient } from '@opencrvs/toolkit/api'
 import {
@@ -11,6 +9,7 @@ import {
   ActionUpdate,
   AddressType
 } from '@opencrvs/toolkit/events'
+import { getSignatureFile, uploadFile } from './utils'
 
 async function getPlaceOfBirth(type: 'PRIVATE_HOME' | 'HEALTH_FACILITY') {
   if (type === 'HEALTH_FACILITY') {
@@ -143,39 +142,6 @@ export interface CreateDeclarationResponse {
   eventId: string
   trackingId: string
   declaration: Declaration
-}
-
-async function uploadFile(file: File, token: string) {
-  const formData = new FormData()
-  const transactionId = uuidv4()
-  formData.append('file', file)
-  formData.append('transactionId', transactionId)
-
-  const url = new URL('/upload', GATEWAY_HOST)
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`
-    },
-    body: formData
-  })
-
-  if (!res.ok) {
-    throw new Error(`Failed to upload file: ${res.statusText}`)
-  }
-
-  return {
-    filename: `${transactionId}.png`,
-    originalFilename: file.name,
-    type: file.type
-  }
-}
-
-function getSignatureFile() {
-  const buffer = fs.readFileSync(path.join(__dirname, 'signature.png'))
-  return new File([buffer], `signature-${Date.now()}.png`, {
-    type: 'image/png'
-  })
 }
 
 export async function createDeclaration(

--- a/e2e/testcases/v2-test-data/birth-declaration.ts
+++ b/e2e/testcases/v2-test-data/birth-declaration.ts
@@ -1,8 +1,6 @@
 import { v4 as uuidv4 } from 'uuid'
 import { GATEWAY_HOST } from '../../constants'
 import { faker } from '@faker-js/faker'
-import fs from 'fs'
-import path from 'path'
 import { getAllLocations, getLocationIdByName } from '../birth/helpers'
 import { createClient } from '@opencrvs/toolkit/api'
 import {
@@ -11,6 +9,7 @@ import {
   ActionUpdate,
   AddressType
 } from '@opencrvs/toolkit/events'
+import { getSignatureFile, uploadFile } from './utils'
 
 type InformantRelation = 'MOTHER' | 'BROTHER'
 
@@ -146,39 +145,6 @@ export type Declaration = Awaited<ReturnType<typeof getDeclaration>>
 export interface CreateDeclarationResponse {
   eventId: string
   declaration: Declaration
-}
-
-function getSignatureFile() {
-  const buffer = fs.readFileSync(path.join(__dirname, 'signature.png'))
-  return new File([buffer], `signature-${Date.now()}.png`, {
-    type: 'image/png'
-  })
-}
-
-async function uploadFile(file: File, token: string) {
-  const formData = new FormData()
-  const transactionId = uuidv4()
-  formData.append('file', file)
-  formData.append('transactionId', transactionId)
-
-  const url = new URL('/upload', GATEWAY_HOST)
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`
-    },
-    body: formData
-  })
-
-  if (!res.ok) {
-    throw new Error(`Failed to upload file: ${res.statusText}`)
-  }
-
-  return {
-    filename: `${transactionId}.png`,
-    originalFilename: file.name,
-    type: file.type
-  }
 }
 
 export async function createDeclaration(

--- a/e2e/testcases/v2-test-data/death-declaration.ts
+++ b/e2e/testcases/v2-test-data/death-declaration.ts
@@ -1,8 +1,6 @@
 import { v4 as uuidv4 } from 'uuid'
 import { GATEWAY_HOST } from '../../constants'
 import { faker } from '@faker-js/faker'
-import fs from 'fs'
-import path from 'path'
 import { getAllLocations, getLocationIdByName } from '../birth/helpers'
 import { createClient } from '@opencrvs/toolkit/api'
 import {
@@ -11,6 +9,7 @@ import {
   ActionUpdate,
   AddressType
 } from '@opencrvs/toolkit/events'
+import { getSignatureFile, uploadFile } from './utils'
 
 async function getPlaceOfDeath(
   type: 'DECEASED_USUAL_RESIDENCE' | 'HEALTH_FACILITY'
@@ -110,39 +109,6 @@ export type Declaration = Awaited<ReturnType<typeof getDeclaration>>
 export interface CreateDeclarationResponse {
   eventId: string
   declaration: Declaration
-}
-
-function getSignatureFile() {
-  const buffer = fs.readFileSync(path.join(__dirname, 'signature.png'))
-  return new File([buffer], `signature-${Date.now()}.png`, {
-    type: 'image/png'
-  })
-}
-
-async function uploadFile(file: File, token: string) {
-  const formData = new FormData()
-  const transactionId = uuidv4()
-  formData.append('file', file)
-  formData.append('transactionId', transactionId)
-
-  const url = new URL('/upload', GATEWAY_HOST)
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`
-    },
-    body: formData
-  })
-
-  if (!res.ok) {
-    throw new Error(`Failed to upload file: ${res.statusText}`)
-  }
-
-  return {
-    filename: `${transactionId}.png`,
-    originalFilename: file.name,
-    type: file.type
-  }
 }
 
 export async function createDeclaration(

--- a/e2e/testcases/v2-test-data/utils.ts
+++ b/e2e/testcases/v2-test-data/utils.ts
@@ -1,0 +1,37 @@
+import { v4 as uuidv4 } from 'uuid'
+import { GATEWAY_HOST } from '../../constants'
+import fs from 'fs'
+import path from 'path'
+
+export function getSignatureFile() {
+  const buffer = fs.readFileSync(path.join(__dirname, 'signature.png'))
+  return new File([buffer], `signature-${Date.now()}.png`, {
+    type: 'image/png'
+  })
+}
+
+export async function uploadFile(file: File, token: string) {
+  const formData = new FormData()
+  const transactionId = uuidv4()
+  formData.append('file', file)
+  formData.append('transactionId', transactionId)
+
+  const url = new URL('/upload', GATEWAY_HOST)
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`
+    },
+    body: formData
+  })
+
+  if (!res.ok) {
+    throw new Error(`Failed to upload file: ${res.statusText}`)
+  }
+
+  return {
+    path: await res.text(),
+    originalFilename: file.name,
+    type: file.type
+  }
+}


### PR DESCRIPTION
## Description

The shape of File field values had changed. Instead of `filename`, `path` is expected with a FullDocumentPath value

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
