### PR TITLE
test: navigate to drafts tab

### DIFF
--- a/e2e/testcases/v2-advanced-search/7-search-birth-event-declaration-stauts.spec.ts
+++ b/e2e/testcases/v2-advanced-search/7-search-birth-event-declaration-stauts.spec.ts
@@ -38,6 +38,9 @@ test.describe
 
     await ensureOutboxIsEmpty(page)
 
+    //@todo: The user should be navigated to "my-drafts" tab by default
+    await page.getByText('My drafts').click()
+
     await expect(
       page.getByText(joinValuesWith([firstname, surname]))
     ).toBeVisible()

--- a/e2e/testcases/v2-birth/1-birth-event-declaration.spec.ts
+++ b/e2e/testcases/v2-birth/1-birth-event-declaration.spec.ts
@@ -460,9 +460,10 @@ test.describe.serial('1. Birth event declaration', () => {
          * - be navigated to "my-drafts" tab
          * - find the declared birth event record on this page list with saved data
          */
-        await expect(page.locator('#content-name')).toHaveText(
-          'Assigned to you'
-        )
+        //@todo: The user should be navigated to "my-drafts" tab by default
+        await page.getByText('My drafts').click()
+
+        await expect(page.locator('#content-name')).toHaveText('My drafts')
 
         await ensureOutboxIsEmpty(page)
 

--- a/e2e/testcases/v2-death/1-death-event-declaration.spec.ts
+++ b/e2e/testcases/v2-death/1-death-event-declaration.spec.ts
@@ -414,9 +414,10 @@ test.describe('1. Death event declaration', () => {
          * - be navigated to "my-drafts" tab
          * - find the declared death event record on this page list with saved data
          */
-        await expect(page.locator('#content-name')).toHaveText(
-          'Assigned to you'
-        )
+        //@todo: The user should be navigated to "my-drafts" tab by default
+        await page.getByText('My drafts').click()
+
+        await expect(page.locator('#content-name')).toHaveText('My drafts')
 
         await ensureOutboxIsEmpty(page)
 

--- a/e2e/testcases/v2-form-state/form-state.spec.ts
+++ b/e2e/testcases/v2-form-state/form-state.spec.ts
@@ -51,6 +51,9 @@ test.describe('Form state', () => {
     })
 
     test('Form states and annotations are not persisted', async () => {
+      //@todo: The user should be navigated to "my-drafts" tab by default
+      await page.getByText('My drafts').click()
+
       await expect(
         page.getByRole('button', { name: childName, exact: true })
       ).toBeVisible()


### PR DESCRIPTION
Drafts do not appear in "Assigned to you" workqueue anymore, so we need to navigate to the "My drafts" workqueue. Although "My drafts" should be the default workqueue in the first place, which is a leftover from the workqueue epic.