### PR TITLE
chore: update test cases to accommodate workqueue action mapping

### DIFF
--- a/e2e/testcases/v2-application/workqueue-flow-2.spec.ts
+++ b/e2e/testcases/v2-application/workqueue-flow-2.spec.ts
@@ -261,7 +261,7 @@ test.describe.serial('2. Workqueue flow - 2', () => {
       await goToSection(page, 'review')
 
       await page.getByRole('button', { name: 'Register' }).click()
-      await page.locator('#confirm_Validate').click()
+      await page.locator('#confirm_Declare').click()
 
       await ensureOutboxIsEmpty(page)
 

--- a/e2e/testcases/v2-application/workqueue-flow-3.spec.ts
+++ b/e2e/testcases/v2-application/workqueue-flow-3.spec.ts
@@ -315,14 +315,6 @@ test.describe.serial('3. Workqueue flow - 3', () => {
     test('3.3.6 Send for review', async () => {
       await continueForm(page, 'Back to review')
 
-      await page.locator('#review____comment').fill(faker.lorem.sentence())
-      await page.getByRole('button', { name: 'Sign' }).click()
-      await drawSignature(page, 'review____signature_canvas_element', false)
-      await page
-        .locator('#review____signature_modal')
-        .getByRole('button', { name: 'Apply' })
-        .click()
-
       await expect(page.getByRole('dialog')).not.toBeVisible()
 
       await page.getByRole('button', { name: 'Send for review' }).click()


### PR DESCRIPTION
## Description
- Update action based id to match the current one
- Remove signing and comment (declare action reads up notify annotation similar manner as other declaration actions)

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
