### PR TITLE
fix: Allow second(s) message to singular

### DIFF
--- a/e2e/testcases/birth/1-birth-event-declaration.spec.ts
+++ b/e2e/testcases/birth/1-birth-event-declaration.spec.ts
@@ -430,7 +430,7 @@ test.describe('1. Birth event declaration', () => {
          * - find the declared birth event record on this page list with saved data
          */
         await expect(page.locator('#content-name')).toHaveText('My drafts')
-        await expect(page.getByText(/seconds ago/)).toBeVisible()
+        await expect(page.getByText(/seconds? ago/)).toBeVisible()
       })
     })
   })
@@ -491,7 +491,7 @@ test.describe('1. Birth event declaration', () => {
       await expect(
         page.locator('#content-name', { hasText: 'My drafts' })
       ).toBeVisible()
-      await expect(page.getByText(/seconds ago/)).toBeHidden()
+      await expect(page.getByText(/seconds? ago/)).toBeHidden()
     })
   })
 
@@ -560,7 +560,7 @@ test.describe('1. Birth event declaration', () => {
       await expect(
         page.locator('#content-name', { hasText: 'My drafts' })
       ).toBeVisible()
-      await expect(page.getByText(/seconds ago/)).toBeHidden()
+      await expect(page.getByText(/seconds? ago/)).toBeHidden()
     })
   })
 

--- a/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
@@ -1437,7 +1437,7 @@ test.describe.serial('8. Validate declaration review page', () => {
             })
           })
           .filter({
-            hasText: /seconds ago/ // should match the registration time
+            hasText: /seconds? ago/ // should match the registration time
           })
       ).not.toHaveCount(0)
     })

--- a/e2e/testcases/death/1-death-event-declaration.spec.ts
+++ b/e2e/testcases/death/1-death-event-declaration.spec.ts
@@ -410,7 +410,7 @@ test.describe('1. Death event declaration', () => {
          * - find the declared death event record on this page list with saved data
          */
         await expect(page.locator('#content-name')).toHaveText('My drafts')
-        await expect(page.getByText(/seconds ago/)).toBeVisible()
+        await expect(page.getByText(/seconds? ago/)).toBeVisible()
       })
     })
   })
@@ -471,7 +471,7 @@ test.describe('1. Death event declaration', () => {
       await expect(
         page.locator('#content-name', { hasText: 'My drafts' })
       ).toBeVisible()
-      await expect(page.getByText(/seconds ago/)).toBeHidden()
+      await expect(page.getByText(/seconds? ago/)).toBeHidden()
     })
   })
 
@@ -540,7 +540,7 @@ test.describe('1. Death event declaration', () => {
       await expect(
         page.locator('#content-name', { hasText: 'My drafts' })
       ).toBeVisible()
-      await expect(page.getByText(/seconds ago/)).toBeHidden()
+      await expect(page.getByText(/seconds? ago/)).toBeHidden()
     })
   })
 

--- a/e2e/testcases/v2-birth/1-birth-event-declaration.spec.ts
+++ b/e2e/testcases/v2-birth/1-birth-event-declaration.spec.ts
@@ -540,7 +540,7 @@ test.describe.serial('1. Birth event declaration', () => {
       // await expect(
       //   page.locator('#content-name', { hasText: 'My drafts' })
       // ).toBeVisible()
-      // await expect(page.getByText(/seconds ago/)).toBeHidden()
+      // await expect(page.getByText(/seconds? ago/)).toBeHidden()
 
       await expect(
         page.getByTestId('search-result').getByText('Assigned to you')
@@ -605,7 +605,7 @@ test.describe.serial('1. Birth event declaration', () => {
       // await expect(
       //   page.locator('#content-name', { hasText: 'My drafts' })
       // ).toBeVisible()
-      // await expect(page.getByText(/seconds ago/)).toBeHidden()
+      // await expect(page.getByText(/seconds? ago/)).toBeHidden()
 
       await expect(
         page.getByTestId('search-result').getByText('Assigned to you')


### PR DESCRIPTION
## Description

Sometimes tests are failing due to inconsistency in expected and actual results:
<img width="1538" height="961" alt="image" src="https://github.com/user-attachments/assets/73ae20d6-4c39-4ace-ad33-6001b02641fd" />


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
