### PR TITLE
take shorter substr of branch name for e2e deployment

### DIFF
--- a/.github/workflows/trigger-e2e-environment.yml
+++ b/.github/workflows/trigger-e2e-environment.yml
@@ -78,7 +78,7 @@ jobs:
                 .trim()
                 .replace(/\s+/g, '-')
                 .replace(/-+/g, '-')
-                .substr(0, 35);
+                .substr(0, 30);
             }
             const result = await github.rest.repos.createDispatchEvent({
               owner: 'opencrvs',
@@ -134,7 +134,7 @@ jobs:
                 .trim()
                 .replace(/\s+/g, '-')
                 .replace(/-+/g, '-')
-                .substr(0, 35);
+                .substr(0, 30);
             }
             const branchName = slugify('${{ env.BRANCH_NAME }}');
             const deployMessage = `Your environment is deployed to https://${branchName}.opencrvs.dev.`;


### PR DESCRIPTION
This was previously done to core here: https://github.com/opencrvs/opencrvs-core/pull/9931

We have been having issues with too long branch names failing on e2e deployment

E.g.:
`failed to create config chorerun-tests-without-increased-gl_***-on-deploy.1756272627: Error response from daemon: rpc error: code = InvalidArgument desc = invalid name, only 64 [a-zA-Z0-9-_.] characters allowed, and the start and end character must be [a-zA-Z0-9]`