### PR TITLE
fix: amend declaration payload to have checkbox default value

### DIFF
--- a/e2e/testcases/v2-test-data/birth-declaration-with-mother-father.ts
+++ b/e2e/testcases/v2-test-data/birth-declaration-with-mother-father.ts
@@ -104,6 +104,7 @@ export async function getDeclaration({
       surname: faker.person.lastName()
     },
     'mother.dob': '1995-09-12',
+    'mother.dobUnknown': false,
     'mother.nationality': 'FAR',
     'mother.idType': 'NATIONAL_ID',
     'mother.educationalAttainment': 'NO_SCHOOLING',


### PR DESCRIPTION
## Description

Amend e2e for https://github.com/opencrvs/opencrvs-core/pull/10323

Update declaration payload with default value for `mother.dobUnknown` field

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
