### PR TITLE
Ocrvs 10562

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -567,3 +567,15 @@ export const fetchUserLocationHierarchy = async (
   })
   return res.data.getUser.primaryOffice.hierarchy.map(({ id }) => id)
 }
+
+export async function expectRowValueWithChangeButton(
+  page: Page,
+  fieldName: string,
+  assertionText: string
+) {
+  await expect(page.getByTestId(`row-value-${fieldName}`)).toContainText(
+    assertionText
+  )
+
+  await expect(page.getByTestId(`change-button-${fieldName}`)).toBeVisible()
+}

--- a/e2e/testcases/v2-birth/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/v2-birth/8-validate-declaration-review-page.spec.ts
@@ -6,7 +6,8 @@ import {
   goToSection,
   formatName,
   loginToV2,
-  formatDateObjectTo_dMMMMyyyy
+  formatDateObjectTo_dMMMMyyyy,
+  expectRowValueWithChangeButton
 } from '../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../constants'
@@ -15,17 +16,6 @@ import { ensureOutboxIsEmpty, selectAction } from '../../v2-utils'
 
 test.describe.serial('8. Validate declaration review page', () => {
   let page: Page
-
-  async function expectRowValueWithChangeButton(
-    fieldName: string,
-    assertionText: string
-  ) {
-    await expect(page.getByTestId(`row-value-${fieldName}`)).toContainText(
-      assertionText
-    )
-
-    await expect(page.getByTestId(`change-button-${fieldName}`)).toBeVisible()
-  }
 
   const declaration = {
     child: {
@@ -218,6 +208,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          */
 
         await expectRowValueWithChangeButton(
+          page,
           'child.name',
           declaration.child.name.firstNames +
             ' ' +
@@ -230,6 +221,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'child.gender',
           declaration.child.gender
         )
@@ -240,6 +232,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'child.dob',
           formatDateObjectTo_dMMMMyyyy(declaration.child.birthDate)
         )
@@ -251,10 +244,12 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'child.placeOfBirth',
           declaration.placeOfBirth
         )
         await expectRowValueWithChangeButton(
+          page,
           'child.birthLocation',
           declaration.birthLocation
         )
@@ -265,6 +260,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'child.attendantAtBirth',
           declaration.attendantAtBirth
         )
@@ -275,6 +271,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'child.birthType',
           declaration.birthType
         )
@@ -285,6 +282,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'child.weightAtBirth',
           declaration.weightAtBirth.toString()
         )
@@ -295,6 +293,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'informant.relation',
           declaration.informantType
         )
@@ -304,6 +303,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'informant.email',
           declaration.informantEmail
         )
@@ -315,6 +315,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'mother.name',
           declaration.mother.name.firstNames +
             ' ' +
@@ -327,6 +328,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'mother.dob',
           formatDateObjectTo_dMMMMyyyy(declaration.mother.birthDate)
         )
@@ -337,6 +339,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'mother.nationality',
           declaration.mother.nationality
         )
@@ -347,10 +350,12 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'mother.idType',
           declaration.mother.identifier.type
         )
         await expectRowValueWithChangeButton(
+          page,
           'mother.nid',
           declaration.mother.identifier.id
         )
@@ -361,14 +366,17 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'mother.address',
           declaration.mother.address.country
         )
         await expectRowValueWithChangeButton(
+          page,
           'mother.address',
           declaration.mother.address.district
         )
         await expectRowValueWithChangeButton(
+          page,
           'mother.address',
           declaration.mother.address.province
         )
@@ -380,6 +388,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'father.name',
           declaration.father.name.firstNames +
             ' ' +
@@ -392,6 +401,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'father.dob',
           formatDateObjectTo_dMMMMyyyy(declaration.father.birthDate)
         )
@@ -402,6 +412,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'father.nationality',
           declaration.father.nationality
         )
@@ -412,10 +423,12 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'father.idType',
           declaration.father.identifier.type
         )
         await expectRowValueWithChangeButton(
+          page,
           'father.nid',
           declaration.father.identifier.id
         )
@@ -425,7 +438,11 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Father's address
          * - Change button
          */
-        await expectRowValueWithChangeButton('father.addressSameAs', 'Yes')
+        await expectRowValueWithChangeButton(
+          page,
+          'father.addressSameAs',
+          'Yes'
+        )
       })
     })
 
@@ -881,6 +898,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'child.name',
         declaration.child.name.firstNames +
           ' ' +
@@ -893,6 +911,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'child.gender',
         declaration.child.gender
       )
@@ -903,6 +922,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'child.dob',
         formatDateObjectTo_dMMMMyyyy(declaration.child.birthDate)
       )
@@ -914,10 +934,12 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'child.placeOfBirth',
         declaration.placeOfBirth
       )
       await expectRowValueWithChangeButton(
+        page,
         'child.birthLocation',
         declaration.birthLocation
       )
@@ -928,6 +950,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'child.attendantAtBirth',
         declaration.attendantAtBirth
       )
@@ -938,6 +961,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'child.birthType',
         declaration.birthType
       )
@@ -948,6 +972,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'child.weightAtBirth',
         declaration.weightAtBirth.toString()
       )
@@ -958,6 +983,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informantType
       )
@@ -967,6 +993,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informantEmail
       )
@@ -978,6 +1005,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'mother.name',
         declaration.mother.name.firstNames
       )
@@ -988,6 +1016,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'mother.dob',
         formatDateObjectTo_dMMMMyyyy(declaration.mother.birthDate)
       )
@@ -998,6 +1027,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'mother.nationality',
         declaration.mother.nationality
       )
@@ -1009,10 +1039,12 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'mother.idType',
         declaration.mother.identifier.type
       )
       await expectRowValueWithChangeButton(
+        page,
         'mother.passport',
         declaration.mother.identifier.id
       )
@@ -1023,14 +1055,17 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'mother.address',
         declaration.mother.address.country
       )
       await expectRowValueWithChangeButton(
+        page,
         'mother.address',
         declaration.mother.address.district
       )
       await expectRowValueWithChangeButton(
+        page,
         'mother.address',
         declaration.mother.address.province
       )
@@ -1042,6 +1077,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'father.name',
         declaration.father.name.firstNames +
           ' ' +
@@ -1054,6 +1090,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'father.dob',
         formatDateObjectTo_dMMMMyyyy(declaration.father.birthDate)
       )
@@ -1064,6 +1101,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'father.nationality',
         declaration.father.nationality
       )
@@ -1075,10 +1113,12 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'father.idType',
         declaration.father.identifier.type
       )
       await expectRowValueWithChangeButton(
+        page,
         'father.passport',
         declaration.father.identifier.id
       )
@@ -1088,7 +1128,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Father's address
        * - Change button
        */
-      await expectRowValueWithChangeButton('father.addressSameAs', 'Yes')
+      await expectRowValueWithChangeButton(page, 'father.addressSameAs', 'Yes')
     })
 
     test.describe('8.2.2 Click any "Change" link', async () => {
@@ -1170,6 +1210,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'child.name',
         declaration.child.name.firstNames +
           ' ' +
@@ -1182,6 +1223,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'child.gender',
         declaration.child.gender
       )
@@ -1192,6 +1234,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'child.dob',
         formatDateObjectTo_dMMMMyyyy(declaration.child.birthDate)
       )
@@ -1203,10 +1246,12 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'child.placeOfBirth',
         declaration.placeOfBirth
       )
       await expectRowValueWithChangeButton(
+        page,
         'child.birthLocation',
         declaration.birthLocation
       )
@@ -1217,6 +1262,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'child.attendantAtBirth',
         declaration.attendantAtBirth
       )
@@ -1227,6 +1273,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'child.birthType',
         declaration.birthType
       )
@@ -1237,6 +1284,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'child.weightAtBirth',
         declaration.weightAtBirth.toString()
       )
@@ -1247,6 +1295,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informantType
       )
@@ -1256,6 +1305,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informantEmail
       )
@@ -1267,6 +1317,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'mother.name',
         declaration.mother.name.firstNames
       )
@@ -1277,6 +1328,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'mother.dob',
         formatDateObjectTo_dMMMMyyyy(declaration.mother.birthDate)
       )
@@ -1287,6 +1339,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'mother.nationality',
         declaration.mother.nationality
       )
@@ -1298,10 +1351,12 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'mother.idType',
         declaration.mother.identifier.type
       )
       await expectRowValueWithChangeButton(
+        page,
         'mother.passport',
         declaration.mother.identifier.id
       )
@@ -1312,14 +1367,17 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'mother.address',
         declaration.mother.address.country
       )
       await expectRowValueWithChangeButton(
+        page,
         'mother.address',
         declaration.mother.address.district
       )
       await expectRowValueWithChangeButton(
+        page,
         'mother.address',
         declaration.mother.address.province
       )
@@ -1331,6 +1389,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'father.name',
         declaration.father.name.firstNames +
           ' ' +
@@ -1343,6 +1402,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'father.dob',
         formatDateObjectTo_dMMMMyyyy(declaration.father.birthDate)
       )
@@ -1353,6 +1413,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'father.nationality',
         declaration.father.nationality
       )
@@ -1364,10 +1425,12 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'father.idType',
         declaration.father.identifier.type
       )
       await expectRowValueWithChangeButton(
+        page,
         'father.passport',
         declaration.father.identifier.id
       )
@@ -1377,7 +1440,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Father's address
        * - Change button
        */
-      await expectRowValueWithChangeButton('father.addressSameAs', 'Yes')
+      await expectRowValueWithChangeButton(page, 'father.addressSameAs', 'Yes')
     })
 
     const newFamilyNameForChild = faker.person.lastName('male')

--- a/e2e/testcases/v2-birth/declarations/birth-declaration-1.spec.ts
+++ b/e2e/testcases/v2-birth/declarations/birth-declaration-1.spec.ts
@@ -6,15 +6,12 @@ import {
   formatName,
   getRandomDate,
   goToSection,
-  loginToV2
+  loginToV2,
+  expectRowValueWithChangeButton
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import {
-  expectRowValueWithChangeButton,
-  fillDate,
-  validateAddress
-} from '../helpers'
+import { fillDate, validateAddress } from '../helpers'
 import { ensureOutboxIsEmpty, selectAction } from '../../../v2-utils'
 
 test.describe.serial('1. Birth declaration case - 1', () => {

--- a/e2e/testcases/v2-birth/declarations/birth-declaration-2.spec.ts
+++ b/e2e/testcases/v2-birth/declarations/birth-declaration-2.spec.ts
@@ -6,11 +6,12 @@ import {
   formatName,
   getRandomDate,
   goToSection,
-  loginToV2
+  loginToV2,
+  expectRowValueWithChangeButton
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import { expectRowValueWithChangeButton, validateAddress } from '../helpers'
+import { validateAddress } from '../helpers'
 import { ensureOutboxIsEmpty, selectAction } from '../../../v2-utils'
 
 test.describe.serial('2. Birth declaration case - 2', () => {

--- a/e2e/testcases/v2-birth/helpers.ts
+++ b/e2e/testcases/v2-birth/helpers.ts
@@ -54,18 +54,6 @@ export async function openBirthDeclaration(page: Page) {
   return page
 }
 
-export async function expectRowValueWithChangeButton(
-  page: Page,
-  fieldName: string,
-  assertionText: string
-) {
-  await expect(page.getByTestId(`row-value-${fieldName}`)).toContainText(
-    assertionText
-  )
-
-  await expect(page.getByTestId(`change-button-${fieldName}`)).toBeVisible()
-}
-
 export const formatV2ChildName = (obj: {
   'child.name': { firstname: string; surname: string }
   [key: string]: any

--- a/e2e/testcases/v2-death/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/v2-death/8-validate-declaration-review-page.spec.ts
@@ -6,7 +6,8 @@ import {
   uploadImageToSection,
   continueForm,
   loginToV2,
-  formatDateObjectTo_dMMMMyyyy
+  formatDateObjectTo_dMMMMyyyy,
+  expectRowValueWithChangeButton
 } from '../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../constants'
@@ -15,16 +16,6 @@ import { ensureOutboxIsEmpty, selectAction } from '../../v2-utils'
 test.describe.serial('8. Validate declaration review page', () => {
   let page: Page
 
-  async function expectRowValueWithChangeButton(
-    fieldName: string,
-    assertionText: string
-  ) {
-    await expect(page.getByTestId(`row-value-${fieldName}`)).toContainText(
-      assertionText
-    )
-
-    await expect(page.getByTestId(`change-button-${fieldName}`)).toBeVisible()
-  }
   const declaration = {
     deceased: {
       name: {
@@ -190,6 +181,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'deceased.name',
           declaration.deceased.name.firstname +
             ' ' +
@@ -202,6 +194,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'deceased.gender',
           declaration.deceased.gender
         )
@@ -212,6 +205,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'deceased.dob',
           formatDateObjectTo_dMMMMyyyy(declaration.deceased.dob)
         )
@@ -222,6 +216,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'deceased.nationality',
           declaration.deceased.nationality
         )
@@ -232,10 +227,12 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'deceased.idType',
           declaration.deceased.idType
         )
         await expectRowValueWithChangeButton(
+          page,
           'deceased.nid',
           declaration.deceased.nid
         )
@@ -246,6 +243,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'deceased.address',
           declaration.deceased.address.country +
             declaration.deceased.address.province +
@@ -258,6 +256,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'eventDetails.date',
           formatDateObjectTo_dMMMMyyyy(declaration.eventDetails.date)
         )
@@ -268,6 +267,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'eventDetails.placeOfDeath',
           declaration.eventDetails.placeOfDeath
         )
@@ -278,6 +278,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'informant.relation',
           declaration.informant.relation
         )
@@ -287,6 +288,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'informant.email',
           declaration.informant.email
         )
@@ -298,6 +300,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'spouse.name',
           declaration.spouse.name.firstname +
             ' ' +
@@ -310,6 +313,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'spouse.dob',
           formatDateObjectTo_dMMMMyyyy(declaration.spouse.dob)
         )
@@ -320,6 +324,7 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'spouse.nationality',
           declaration.spouse.nationality
         )
@@ -330,10 +335,12 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Change button
          */
         await expectRowValueWithChangeButton(
+          page,
           'spouse.idType',
           declaration.spouse.idType
         )
         await expectRowValueWithChangeButton(
+          page,
           'spouse.nid',
           declaration.spouse.nid
         )
@@ -343,7 +350,11 @@ test.describe.serial('8. Validate declaration review page', () => {
          * - Spouse's address
          * - Change button
          */
-        await expectRowValueWithChangeButton('spouse.addressSameAs', 'Yes')
+        await expectRowValueWithChangeButton(
+          page,
+          'spouse.addressSameAs',
+          'Yes'
+        )
       })
     })
 
@@ -745,6 +756,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -757,6 +769,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         declaration.deceased.gender
       )
@@ -767,6 +780,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         formatDateObjectTo_dMMMMyyyy(declaration.eventDetails.date)
       )
@@ -777,6 +791,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nationality',
         declaration.deceased.nationality
       )
@@ -787,10 +802,12 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         declaration.deceased.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'deceased.passport',
         declaration.deceased.passport
       )
@@ -801,6 +818,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.province +
@@ -813,6 +831,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -823,6 +842,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informant.email
       )
@@ -834,6 +854,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         declaration.spouse.name.firstname +
           ' ' +
@@ -846,6 +867,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.dob',
         formatDateObjectTo_dMMMMyyyy(declaration.spouse.dob)
       )
@@ -856,6 +878,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.nationality',
         declaration.spouse.nationality
       )
@@ -867,10 +890,12 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         declaration.spouse.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'spouse.passport',
         declaration.spouse.passport
       )
@@ -880,7 +905,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Spouse's address
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.addressSameAs', 'Yes')
+      await expectRowValueWithChangeButton(page, 'spouse.addressSameAs', 'Yes')
 
       /*
        * Expected result: should show additional comment
@@ -1196,6 +1221,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -1208,6 +1234,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         declaration.deceased.gender
       )
@@ -1218,6 +1245,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         formatDateObjectTo_dMMMMyyyy(declaration.eventDetails.date)
       )
@@ -1228,6 +1256,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nationality',
         declaration.deceased.nationality
       )
@@ -1238,10 +1267,12 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         declaration.deceased.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'deceased.brn',
         declaration.deceased.brn
       )
@@ -1252,14 +1283,17 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country
       )
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.district
       )
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.province
       )
@@ -1270,6 +1304,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -1280,6 +1315,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informant.email
       )
@@ -1291,6 +1327,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         declaration.spouse.name.firstname +
           ' ' +
@@ -1303,6 +1340,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.dob',
         formatDateObjectTo_dMMMMyyyy(declaration.spouse.dob)
       )
@@ -1313,6 +1351,7 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.nationality',
         declaration.spouse.nationality
       )
@@ -1324,17 +1363,22 @@ test.describe.serial('8. Validate declaration review page', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         declaration.spouse.idType
       )
-      await expectRowValueWithChangeButton('spouse.brn', declaration.spouse.brn)
+      await expectRowValueWithChangeButton(
+        page,
+        'spouse.brn',
+        declaration.spouse.brn
+      )
 
       /*
        * Expected result: should include
        * - Spouse's address
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.addressSameAs', 'Yes')
+      await expectRowValueWithChangeButton(page, 'spouse.addressSameAs', 'Yes')
 
       /*
        * Expected result: should show additional comment

--- a/e2e/testcases/v2-death/death-event-summary.spec.tsx
+++ b/e2e/testcases/v2-death/death-event-summary.spec.tsx
@@ -1,0 +1,162 @@
+import { test, expect, type Page } from '@playwright/test'
+import { faker } from '@faker-js/faker'
+import {
+  continueForm,
+  expectRowValueWithChangeButton,
+  getRandomDate,
+  goToSection,
+  joinValuesWith,
+  loginToV2
+} from '../../helpers'
+
+test.describe.serial('Death event summary', () => {
+  let page: Page
+
+  const declaration = {
+    deceased: {
+      name: {
+        firstname: faker.person.firstName('male'),
+        surname: faker.person.lastName('male')
+      },
+      address: {
+        country: 'Farajaland',
+        province: 'Pualula',
+        district: 'Pili',
+        town: 'Deceased Town',
+        residentalArea: 'Deceased Area',
+        street: 'Deceased Street',
+        house: '123',
+        postalCode: '12345'
+      }
+    },
+    eventDetails: {
+      date: getRandomDate(0, 20),
+      causeOfDeathEstablished: false,
+      placeOfDeath: 'Other',
+      address: {
+        country: 'Farajaland',
+        province: 'Pualula',
+        district: 'Pili',
+        town: 'Place of death Town',
+        residentalArea: 'Place of death Area',
+        street: 'Place of death Street',
+        house: '987',
+        postalCode: '65432'
+      }
+    }
+  }
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+  })
+
+  test.afterAll(async () => {
+    await page.close()
+  })
+
+  test('Log in', async () => {
+    await loginToV2(page)
+  })
+
+  test('Start death event declaration', async () => {
+    await page.click('#header-new-event')
+    await page.getByLabel('Death').click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+  })
+
+  test('Input deceased address', async () => {
+    await page.locator('#firstname').fill(declaration.deceased.name.firstname)
+    await page.locator('#surname').fill(declaration.deceased.name.surname)
+
+    await page.locator('#province').click()
+    await page
+      .getByText(declaration.deceased.address.province, { exact: true })
+      .click()
+    await page.locator('#district').click()
+    await page
+      .getByText(declaration.deceased.address.district, { exact: true })
+      .click()
+
+    await page.locator('#town').fill(declaration.deceased.address.town)
+
+    await page
+      .locator('#residentialArea')
+      .fill(declaration.deceased.address.residentalArea)
+
+    await page.locator('#street').fill(declaration.deceased.address.street)
+
+    await page.locator('#number').fill(declaration.deceased.address.house)
+
+    await page.locator('#zipCode').fill(declaration.deceased.address.postalCode)
+
+    await continueForm(page)
+  })
+
+  test('Input place of death address', async () => {
+    await page.locator('#eventDetails____placeOfDeath').click()
+    await page
+      .getByText(declaration.eventDetails.placeOfDeath, { exact: true })
+      .click()
+
+    await page.locator('#province').click()
+    await page
+      .getByText(declaration.eventDetails.address.province, { exact: true })
+      .click()
+    await page.locator('#district').click()
+    await page
+      .getByText(declaration.eventDetails.address.district, { exact: true })
+      .click()
+
+    await page.locator('#town').fill(declaration.eventDetails.address.town)
+
+    await page
+      .locator('#residentialArea')
+      .fill(declaration.eventDetails.address.residentalArea)
+
+    await page.locator('#street').fill(declaration.eventDetails.address.street)
+
+    await page.locator('#number').fill(declaration.eventDetails.address.house)
+
+    await page
+      .locator('#zipCode')
+      .fill(declaration.eventDetails.address.postalCode)
+
+    await goToSection(page, 'review')
+  })
+
+  test('Verify input in review section', async () => {
+    await expectRowValueWithChangeButton(
+      page,
+      'deceased.address',
+      joinValuesWith([...Object.values(declaration.deceased.address)], '')
+    )
+
+    await expectRowValueWithChangeButton(
+      page,
+      'eventDetails.deathLocationOther',
+      joinValuesWith([...Object.values(declaration.eventDetails.address)], '')
+    )
+  })
+
+  test('Save draft and find it in workqueue', async () => {
+    await page.getByText('Save & Exit', { exact: true }).click()
+    await page.getByText('Confirm', { exact: true }).click()
+
+    await page.getByRole('button', { name: 'My drafts' }).click()
+
+    await page
+      .getByRole('button', {
+        name: joinValuesWith(Object.values(declaration.deceased.name), ' ')
+      })
+      .click()
+  })
+
+  test('Uses "other" location in summary', async () => {
+    await expect(
+      page.getByTestId('eventDetails.deathLocationOther')
+    ).toContainText(
+      joinValuesWith([...Object.values(declaration.eventDetails.address)], '')
+    )
+  })
+})

--- a/e2e/testcases/v2-death/declaration/death-declaration-1.spec.ts
+++ b/e2e/testcases/v2-death/declaration/death-declaration-1.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test'
 import {
   continueForm,
   drawSignature,
+  expectRowValueWithChangeButton,
   formatDateObjectTo_dMMMMyyyy,
   getRandomDate,
   goToSection,
@@ -13,16 +14,6 @@ import { ensureOutboxIsEmpty, selectAction } from '../../../v2-utils'
 
 test.describe.serial('1. Death declaration case - 1', () => {
   let page: Page
-  async function expectRowValueWithChangeButton(
-    fieldName: string,
-    assertionText: string
-  ) {
-    await expect(page.getByTestId(`row-value-${fieldName}`)).toContainText(
-      assertionText
-    )
-
-    await expect(page.getByTestId(`change-button-${fieldName}`)).toBeVisible()
-  }
   const declaration = {
     deceased: {
       name: {
@@ -209,6 +200,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -221,6 +213,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         declaration.deceased.gender
       )
@@ -231,6 +224,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.dob',
         formatDateObjectTo_dMMMMyyyy(declaration.deceased.dob)
       )
@@ -241,6 +235,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nationality',
         declaration.deceased.nationality
       )
@@ -251,10 +246,12 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         declaration.deceased.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nid',
         declaration.deceased.nid
       )
@@ -265,6 +262,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.maritalStatus',
         declaration.deceased.maritalStatus
       )
@@ -274,6 +272,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Number of Deceased's Dependants
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.numberOfDependants',
         declaration.deceased.numberOfDependants.toString()
       )
@@ -284,6 +283,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.province +
@@ -301,6 +301,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         formatDateObjectTo_dMMMMyyyy(declaration.eventDetails.date)
       )
@@ -311,6 +312,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.mannerOfDeath',
         declaration.eventDetails.mannerOfDeath
       )
@@ -321,6 +323,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.causeOfDeathEstablished',
         'Yes'
       )
@@ -331,6 +334,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.sourceCauseDeath',
         declaration.eventDetails.sourceCauseDeath
       )
@@ -341,6 +345,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         declaration.eventDetails.placeOfDeath
       )
@@ -351,6 +356,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -360,6 +366,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informant.email
       )
@@ -371,6 +378,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         declaration.spouse.name.firstname +
           ' ' +
@@ -383,6 +391,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.dob',
         formatDateObjectTo_dMMMMyyyy(declaration.spouse.dob)
       )
@@ -393,6 +402,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.nationality',
         declaration.spouse.nationality
       )
@@ -403,17 +413,22 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         declaration.spouse.idType
       )
-      await expectRowValueWithChangeButton('spouse.nid', declaration.spouse.nid)
+      await expectRowValueWithChangeButton(
+        page,
+        'spouse.nid',
+        declaration.spouse.nid
+      )
 
       /*
        * Expected result: should include
        * - Spouse's address
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.addressSameAs', 'Yes')
+      await expectRowValueWithChangeButton(page, 'spouse.addressSameAs', 'Yes')
     })
 
     test('1.1.7 Fill up informant signature', async () => {
@@ -479,6 +494,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -491,6 +507,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         declaration.deceased.gender
       )
@@ -501,6 +518,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.dob',
         formatDateObjectTo_dMMMMyyyy(declaration.deceased.dob)
       )
@@ -511,6 +529,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nationality',
         declaration.deceased.nationality
       )
@@ -521,10 +540,12 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         declaration.deceased.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nid',
         declaration.deceased.nid
       )
@@ -535,6 +556,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.maritalStatus',
         declaration.deceased.maritalStatus
       )
@@ -544,6 +566,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Number of Deceased's Dependants
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.numberOfDependants',
         declaration.deceased.numberOfDependants.toString()
       )
@@ -554,6 +577,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.province +
@@ -571,6 +595,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         formatDateObjectTo_dMMMMyyyy(declaration.eventDetails.date)
       )
@@ -581,6 +606,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.mannerOfDeath',
         declaration.eventDetails.mannerOfDeath
       )
@@ -591,6 +617,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.causeOfDeathEstablished',
         'Yes'
       )
@@ -601,6 +628,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.sourceCauseDeath',
         declaration.eventDetails.sourceCauseDeath
       )
@@ -611,6 +639,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         declaration.eventDetails.placeOfDeath
       )
@@ -621,6 +650,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -630,6 +660,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informant.email
       )
@@ -641,6 +672,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         declaration.spouse.name.firstname +
           ' ' +
@@ -653,6 +685,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.dob',
         formatDateObjectTo_dMMMMyyyy(declaration.spouse.dob)
       )
@@ -663,6 +696,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.nationality',
         declaration.spouse.nationality
       )
@@ -673,17 +707,22 @@ test.describe.serial('1. Death declaration case - 1', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         declaration.spouse.idType
       )
-      await expectRowValueWithChangeButton('spouse.nid', declaration.spouse.nid)
+      await expectRowValueWithChangeButton(
+        page,
+        'spouse.nid',
+        declaration.spouse.nid
+      )
 
       /*
        * Expected result: should include
        * - Spouse's address
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.addressSameAs', 'Yes')
+      await expectRowValueWithChangeButton(page, 'spouse.addressSameAs', 'Yes')
     })
   })
 })

--- a/e2e/testcases/v2-death/declaration/death-declaration-10.spec.ts
+++ b/e2e/testcases/v2-death/declaration/death-declaration-10.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test'
 import {
   continueForm,
   drawSignature,
+  expectRowValueWithChangeButton,
   goToSection,
   loginToV2
 } from '../../../helpers'
@@ -11,16 +12,6 @@ import { REQUIRED_VALIDATION_ERROR } from '../../v2-birth/helpers'
 
 test.describe.serial('10. Death declaration case - 10', () => {
   let page: Page
-  async function expectRowValueWithChangeButton(
-    fieldName: string,
-    assertionText: string
-  ) {
-    await expect(page.getByTestId(`row-value-${fieldName}`)).toContainText(
-      assertionText
-    )
-
-    await expect(page.getByTestId(`change-button-${fieldName}`)).toBeVisible()
-  }
 
   const declaration = {
     deceased: {
@@ -85,6 +76,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         REQUIRED_VALIDATION_ERROR
       )
@@ -95,6 +87,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         REQUIRED_VALIDATION_ERROR
       )
@@ -105,6 +98,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.dob',
         REQUIRED_VALIDATION_ERROR
       )
@@ -114,13 +108,18 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Deceased's Nationality
        * - Change button
        */
-      await expectRowValueWithChangeButton('deceased.nationality', 'Farajaland')
+      await expectRowValueWithChangeButton(
+        page,
+        'deceased.nationality',
+        'Farajaland'
+      )
       /*
        * Expected result: should require
        * - Deceased's Type of Id
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         REQUIRED_VALIDATION_ERROR
       )
@@ -131,6 +130,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.province +
@@ -143,6 +143,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         REQUIRED_VALIDATION_ERROR
       )
@@ -153,6 +154,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         REQUIRED_VALIDATION_ERROR
       )
@@ -163,6 +165,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -173,6 +176,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         REQUIRED_VALIDATION_ERROR
       )
@@ -185,6 +189,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        */
 
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         REQUIRED_VALIDATION_ERROR
       )
@@ -195,6 +200,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.dob',
         REQUIRED_VALIDATION_ERROR
       )
@@ -204,7 +210,11 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Spouse's Nationality
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.nationality', 'Farajaland')
+      await expectRowValueWithChangeButton(
+        page,
+        'spouse.nationality',
+        'Farajaland'
+      )
 
       /*
        * Expected result: should require
@@ -212,6 +222,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         REQUIRED_VALIDATION_ERROR
       )
@@ -221,7 +232,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Spouse's address
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.addressSameAs', 'Yes')
+      await expectRowValueWithChangeButton(page, 'spouse.addressSameAs', 'Yes')
     })
 
     test('10.1.6 Fill up informant signature', async () => {
@@ -284,6 +295,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         REQUIRED_VALIDATION_ERROR
       )
@@ -294,6 +306,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         REQUIRED_VALIDATION_ERROR
       )
@@ -304,6 +317,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.dob',
         REQUIRED_VALIDATION_ERROR
       )
@@ -313,13 +327,18 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Deceased's Nationality
        * - Change button
        */
-      await expectRowValueWithChangeButton('deceased.nationality', 'Farajaland')
+      await expectRowValueWithChangeButton(
+        page,
+        'deceased.nationality',
+        'Farajaland'
+      )
       /*
        * Expected result: should require
        * - Deceased's Type of Id
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         REQUIRED_VALIDATION_ERROR
       )
@@ -330,6 +349,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.province +
@@ -342,6 +362,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         REQUIRED_VALIDATION_ERROR
       )
@@ -352,6 +373,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         REQUIRED_VALIDATION_ERROR
       )
@@ -362,6 +384,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -372,6 +395,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         REQUIRED_VALIDATION_ERROR
       )
@@ -384,6 +408,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        */
 
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         REQUIRED_VALIDATION_ERROR
       )
@@ -394,6 +419,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.dob',
         REQUIRED_VALIDATION_ERROR
       )
@@ -403,7 +429,11 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Spouse's Nationality
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.nationality', 'Farajaland')
+      await expectRowValueWithChangeButton(
+        page,
+        'spouse.nationality',
+        'Farajaland'
+      )
 
       /*
        * Expected result: should require
@@ -411,6 +441,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         REQUIRED_VALIDATION_ERROR
       )
@@ -420,7 +451,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
        * - Spouse's address
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.addressSameAs', 'Yes')
+      await expectRowValueWithChangeButton(page, 'spouse.addressSameAs', 'Yes')
     })
   })
 })

--- a/e2e/testcases/v2-death/declaration/death-declaration-11.spec.ts
+++ b/e2e/testcases/v2-death/declaration/death-declaration-11.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test'
 import {
   continueForm,
   drawSignature,
+  expectRowValueWithChangeButton,
   formatDateObjectTo_dMMMMyyyy,
   getRandomDate,
   goToSection,
@@ -13,16 +14,7 @@ import { ensureOutboxIsEmpty, selectAction } from '../../../v2-utils'
 
 test.describe.serial('11. Death declaration case - 11', () => {
   let page: Page
-  async function expectRowValueWithChangeButton(
-    fieldName: string,
-    assertionText: string
-  ) {
-    await expect(page.getByTestId(`row-value-${fieldName}`)).toContainText(
-      assertionText
-    )
 
-    await expect(page.getByTestId(`change-button-${fieldName}`)).toBeVisible()
-  }
   const declaration = {
     deceased: {
       name: {
@@ -311,6 +303,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -323,6 +316,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         declaration.deceased.gender
       )
@@ -333,6 +327,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.age',
         declaration.deceased.age.toString()
       )
@@ -343,6 +338,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nationality',
         declaration.deceased.nationality
       )
@@ -354,10 +350,12 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         declaration.deceased.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'deceased.brn',
         declaration.deceased.brn
       )
@@ -368,6 +366,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.maritalStatus',
         declaration.deceased.maritalStatus
       )
@@ -378,6 +377,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.state +
@@ -395,6 +395,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         formatDateObjectTo_dMMMMyyyy(declaration.eventDetails.date)
       )
@@ -405,6 +406,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.mannerOfDeath',
         declaration.eventDetails.mannerOfDeath
       )
@@ -415,6 +417,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.causeOfDeathEstablished',
         'Yes'
       )
@@ -425,6 +428,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.sourceCauseDeath',
         declaration.eventDetails.sourceCauseDeath
       )
@@ -435,6 +439,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.description',
         declaration.eventDetails.description
       )
@@ -445,6 +450,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         declaration.eventDetails.placeOfDeath
       )
@@ -455,6 +461,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -466,6 +473,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.name',
         declaration.informant.name.firstname +
           ' ' +
@@ -478,6 +486,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.age',
         declaration.informant.age.toString()
       )
@@ -488,6 +497,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.nationality',
         declaration.informant.nationality
       )
@@ -499,10 +509,12 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.idType',
         declaration.informant.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'informant.passport',
         declaration.informant.passport
       )
@@ -513,6 +525,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.address',
         declaration.informant.address.country +
           declaration.informant.address.province +
@@ -530,6 +543,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informant.email
       )
@@ -541,6 +555,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         declaration.spouse.name.firstname +
           ' ' +
@@ -553,6 +568,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.age',
         declaration.spouse.age.toString()
       )
@@ -563,6 +579,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.nationality',
         declaration.spouse.nationality
       )
@@ -573,10 +590,15 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         declaration.spouse.idType
       )
-      await expectRowValueWithChangeButton('spouse.brn', declaration.spouse.brn)
+      await expectRowValueWithChangeButton(
+        page,
+        'spouse.brn',
+        declaration.spouse.brn
+      )
 
       /*
        * Expected result: should include
@@ -584,6 +606,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.address',
         declaration.spouse.address.country +
           declaration.spouse.address.province +
@@ -659,6 +682,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -671,6 +695,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         declaration.deceased.gender
       )
@@ -681,6 +706,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.age',
         declaration.deceased.age.toString()
       )
@@ -691,6 +717,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nationality',
         declaration.deceased.nationality
       )
@@ -702,10 +729,12 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         declaration.deceased.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'deceased.brn',
         declaration.deceased.brn
       )
@@ -716,6 +745,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.maritalStatus',
         declaration.deceased.maritalStatus
       )
@@ -726,6 +756,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.state +
@@ -743,6 +774,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         formatDateObjectTo_dMMMMyyyy(declaration.eventDetails.date)
       )
@@ -753,6 +785,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.mannerOfDeath',
         declaration.eventDetails.mannerOfDeath
       )
@@ -763,6 +796,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.causeOfDeathEstablished',
         'Yes'
       )
@@ -773,6 +807,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.sourceCauseDeath',
         declaration.eventDetails.sourceCauseDeath
       )
@@ -783,6 +818,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.description',
         declaration.eventDetails.description
       )
@@ -793,6 +829,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         declaration.eventDetails.placeOfDeath
       )
@@ -803,6 +840,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -814,6 +852,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.name',
         declaration.informant.name.firstname +
           ' ' +
@@ -826,6 +865,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.age',
         declaration.informant.age.toString()
       )
@@ -836,6 +876,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.nationality',
         declaration.informant.nationality
       )
@@ -847,10 +888,12 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.idType',
         declaration.informant.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'informant.passport',
         declaration.informant.passport
       )
@@ -861,6 +904,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.address',
         declaration.informant.address.country +
           declaration.informant.address.province +
@@ -878,6 +922,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informant.email
       )
@@ -889,6 +934,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         declaration.spouse.name.firstname +
           ' ' +
@@ -901,6 +947,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.age',
         declaration.spouse.age.toString()
       )
@@ -911,6 +958,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.nationality',
         declaration.spouse.nationality
       )
@@ -921,10 +969,15 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         declaration.spouse.idType
       )
-      await expectRowValueWithChangeButton('spouse.brn', declaration.spouse.brn)
+      await expectRowValueWithChangeButton(
+        page,
+        'spouse.brn',
+        declaration.spouse.brn
+      )
 
       /*
        * Expected result: should include
@@ -932,6 +985,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.address',
         declaration.spouse.address.country +
           declaration.spouse.address.province +

--- a/e2e/testcases/v2-death/declaration/death-declaration-2.spec.ts
+++ b/e2e/testcases/v2-death/declaration/death-declaration-2.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test'
 import {
   continueForm,
   drawSignature,
+  expectRowValueWithChangeButton,
   formatDateObjectTo_dMMMMyyyy,
   getRandomDate,
   loginToV2,
@@ -13,16 +14,6 @@ import { ensureOutboxIsEmpty, selectAction } from '../../../v2-utils'
 
 test.describe.serial('2. Death declaration case - 2', () => {
   let page: Page
-  async function expectRowValueWithChangeButton(
-    fieldName: string,
-    assertionText: string
-  ) {
-    await expect(page.getByTestId(`row-value-${fieldName}`)).toContainText(
-      assertionText
-    )
-
-    await expect(page.getByTestId(`change-button-${fieldName}`)).toBeVisible()
-  }
   const declaration = {
     deceased: {
       name: {
@@ -361,6 +352,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -373,6 +365,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         declaration.deceased.gender
       )
@@ -383,6 +376,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.age',
         declaration.deceased.age.toString()
       )
@@ -393,6 +387,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nationality',
         declaration.deceased.nationality
       )
@@ -404,10 +399,12 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         declaration.deceased.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'deceased.passport',
         declaration.deceased.passport
       )
@@ -418,6 +415,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.maritalStatus',
         declaration.deceased.maritalStatus
       )
@@ -428,6 +426,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.province +
@@ -445,6 +444,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         formatDateObjectTo_dMMMMyyyy(declaration.eventDetails.date)
       )
@@ -455,6 +455,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.mannerOfDeath',
         declaration.eventDetails.mannerOfDeath
       )
@@ -465,6 +466,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.causeOfDeathEstablished',
         'Yes'
       )
@@ -475,6 +477,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.sourceCauseDeath',
         declaration.eventDetails.sourceCauseDeath
       )
@@ -485,6 +488,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.description',
         declaration.eventDetails.description
       )
@@ -495,6 +499,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         declaration.eventDetails.placeOfDeath
       )
@@ -505,6 +510,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -516,6 +522,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.name',
         declaration.informant.name.firstname +
           ' ' +
@@ -528,6 +535,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.dob',
         formatDateObjectTo_dMMMMyyyy(declaration.informant.dob)
       )
@@ -538,6 +546,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.nationality',
         declaration.informant.nationality
       )
@@ -549,10 +558,12 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.idType',
         declaration.informant.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'informant.nid',
         declaration.informant.nid
       )
@@ -562,7 +573,11 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - informant's address
        * - Change button
        */
-      await expectRowValueWithChangeButton('informant.addressSameAs', 'Yes')
+      await expectRowValueWithChangeButton(
+        page,
+        'informant.addressSameAs',
+        'Yes'
+      )
 
       /*
        * Expected result: should include
@@ -570,6 +585,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informant.email
       )
@@ -581,6 +597,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         declaration.spouse.name.firstname +
           ' ' +
@@ -593,6 +610,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.age',
         declaration.spouse.age.toString()
       )
@@ -603,6 +621,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.nationality',
         declaration.spouse.nationality
       )
@@ -613,10 +632,12 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         declaration.spouse.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'spouse.passport',
         declaration.spouse.passport
       )
@@ -627,6 +648,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.address',
         declaration.spouse.address.country +
           declaration.spouse.address.province +
@@ -702,6 +724,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -714,6 +737,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         declaration.deceased.gender
       )
@@ -724,6 +748,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.age',
         declaration.deceased.age.toString()
       )
@@ -734,6 +759,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nationality',
         declaration.deceased.nationality
       )
@@ -745,10 +771,12 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         declaration.deceased.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'deceased.passport',
         declaration.deceased.passport
       )
@@ -759,6 +787,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.maritalStatus',
         declaration.deceased.maritalStatus
       )
@@ -769,6 +798,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.province +
@@ -786,6 +816,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         formatDateObjectTo_dMMMMyyyy(declaration.eventDetails.date)
       )
@@ -796,6 +827,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.mannerOfDeath',
         declaration.eventDetails.mannerOfDeath
       )
@@ -806,6 +838,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.causeOfDeathEstablished',
         'Yes'
       )
@@ -816,6 +849,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.sourceCauseDeath',
         declaration.eventDetails.sourceCauseDeath
       )
@@ -826,6 +860,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.description',
         declaration.eventDetails.description
       )
@@ -836,6 +871,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         declaration.eventDetails.placeOfDeath
       )
@@ -846,6 +882,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -857,6 +894,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.name',
         declaration.informant.name.firstname +
           ' ' +
@@ -869,6 +907,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.dob',
         formatDateObjectTo_dMMMMyyyy(declaration.informant.dob)
       )
@@ -879,6 +918,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.nationality',
         declaration.informant.nationality
       )
@@ -890,10 +930,12 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.idType',
         declaration.informant.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'informant.nid',
         declaration.informant.nid
       )
@@ -903,7 +945,11 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - informant's address
        * - Change button
        */
-      await expectRowValueWithChangeButton('informant.addressSameAs', 'Yes')
+      await expectRowValueWithChangeButton(
+        page,
+        'informant.addressSameAs',
+        'Yes'
+      )
 
       /*
        * Expected result: should include
@@ -911,6 +957,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informant.email
       )
@@ -922,6 +969,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         declaration.spouse.name.firstname +
           ' ' +
@@ -934,6 +982,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.age',
         declaration.spouse.age.toString()
       )
@@ -944,6 +993,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.nationality',
         declaration.spouse.nationality
       )
@@ -954,10 +1004,12 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         declaration.spouse.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'spouse.passport',
         declaration.spouse.passport
       )
@@ -968,6 +1020,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.address',
         declaration.spouse.address.country +
           declaration.spouse.address.province +

--- a/e2e/testcases/v2-death/declaration/death-declaration-3.spec.ts
+++ b/e2e/testcases/v2-death/declaration/death-declaration-3.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test'
 import {
   continueForm,
   drawSignature,
+  expectRowValueWithChangeButton,
   formatDateObjectTo_dMMMMyyyy,
   getRandomDate,
   goToSection,
@@ -13,16 +14,7 @@ import { ensureOutboxIsEmpty, selectAction } from '../../../v2-utils'
 
 test.describe.serial('3. Death declaration case - 3', () => {
   let page: Page
-  async function expectRowValueWithChangeButton(
-    fieldName: string,
-    assertionText: string
-  ) {
-    await expect(page.getByTestId(`row-value-${fieldName}`)).toContainText(
-      assertionText
-    )
 
-    await expect(page.getByTestId(`change-button-${fieldName}`)).toBeVisible()
-  }
   const declaration = {
     deceased: {
       name: {
@@ -311,6 +303,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -323,6 +316,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         declaration.deceased.gender
       )
@@ -333,6 +327,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.age',
         declaration.deceased.age.toString()
       )
@@ -343,6 +338,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nationality',
         declaration.deceased.nationality
       )
@@ -354,10 +350,12 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         declaration.deceased.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'deceased.brn',
         declaration.deceased.brn
       )
@@ -368,6 +366,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.maritalStatus',
         declaration.deceased.maritalStatus
       )
@@ -378,6 +377,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.state +
@@ -395,6 +395,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         formatDateObjectTo_dMMMMyyyy(declaration.eventDetails.date)
       )
@@ -405,6 +406,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.mannerOfDeath',
         declaration.eventDetails.mannerOfDeath
       )
@@ -415,6 +417,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.causeOfDeathEstablished',
         'Yes'
       )
@@ -425,6 +428,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.sourceCauseDeath',
         declaration.eventDetails.sourceCauseDeath
       )
@@ -435,6 +439,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.description',
         declaration.eventDetails.description
       )
@@ -445,6 +450,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         declaration.eventDetails.placeOfDeath
       )
@@ -455,6 +461,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -466,6 +473,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.name',
         declaration.informant.name.firstname +
           ' ' +
@@ -478,6 +486,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.age',
         declaration.informant.age.toString()
       )
@@ -488,6 +497,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.nationality',
         declaration.informant.nationality
       )
@@ -499,10 +509,12 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.idType',
         declaration.informant.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'informant.passport',
         declaration.informant.passport
       )
@@ -513,6 +525,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.address',
         declaration.informant.address.country +
           declaration.informant.address.province +
@@ -530,6 +543,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informant.email
       )
@@ -541,6 +555,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         declaration.spouse.name.firstname +
           ' ' +
@@ -553,6 +568,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.age',
         declaration.spouse.age.toString()
       )
@@ -563,6 +579,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.nationality',
         declaration.spouse.nationality
       )
@@ -573,10 +590,15 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         declaration.spouse.idType
       )
-      await expectRowValueWithChangeButton('spouse.brn', declaration.spouse.brn)
+      await expectRowValueWithChangeButton(
+        page,
+        'spouse.brn',
+        declaration.spouse.brn
+      )
 
       /*
        * Expected result: should include
@@ -584,6 +606,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.address',
         declaration.spouse.address.country +
           declaration.spouse.address.province +
@@ -659,6 +682,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -671,6 +695,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         declaration.deceased.gender
       )
@@ -681,6 +706,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.age',
         declaration.deceased.age.toString()
       )
@@ -691,6 +717,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nationality',
         declaration.deceased.nationality
       )
@@ -702,10 +729,12 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         declaration.deceased.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'deceased.brn',
         declaration.deceased.brn
       )
@@ -716,6 +745,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.maritalStatus',
         declaration.deceased.maritalStatus
       )
@@ -726,6 +756,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.state +
@@ -743,6 +774,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         formatDateObjectTo_dMMMMyyyy(declaration.eventDetails.date)
       )
@@ -753,6 +785,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.mannerOfDeath',
         declaration.eventDetails.mannerOfDeath
       )
@@ -763,6 +796,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.causeOfDeathEstablished',
         'Yes'
       )
@@ -773,6 +807,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.sourceCauseDeath',
         declaration.eventDetails.sourceCauseDeath
       )
@@ -783,6 +818,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.description',
         declaration.eventDetails.description
       )
@@ -793,6 +829,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         declaration.eventDetails.placeOfDeath
       )
@@ -803,6 +840,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -814,6 +852,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.name',
         declaration.informant.name.firstname +
           ' ' +
@@ -826,6 +865,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.age',
         declaration.informant.age.toString()
       )
@@ -836,6 +876,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.nationality',
         declaration.informant.nationality
       )
@@ -847,10 +888,12 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.idType',
         declaration.informant.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'informant.passport',
         declaration.informant.passport
       )
@@ -861,6 +904,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.address',
         declaration.informant.address.country +
           declaration.informant.address.province +
@@ -878,6 +922,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informant.email
       )
@@ -889,6 +934,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         declaration.spouse.name.firstname +
           ' ' +
@@ -901,6 +947,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.age',
         declaration.spouse.age.toString()
       )
@@ -911,6 +958,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.nationality',
         declaration.spouse.nationality
       )
@@ -921,10 +969,15 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         declaration.spouse.idType
       )
-      await expectRowValueWithChangeButton('spouse.brn', declaration.spouse.brn)
+      await expectRowValueWithChangeButton(
+        page,
+        'spouse.brn',
+        declaration.spouse.brn
+      )
 
       /*
        * Expected result: should include
@@ -932,6 +985,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.address',
         declaration.spouse.address.country +
           declaration.spouse.address.province +

--- a/e2e/testcases/v2-death/declaration/death-declaration-4.spec.ts
+++ b/e2e/testcases/v2-death/declaration/death-declaration-4.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test'
 import {
   continueForm,
   drawSignature,
+  expectRowValueWithChangeButton,
   formatDateObjectTo_dMMMMyyyy,
   getRandomDate,
   loginToV2,
@@ -13,16 +14,7 @@ import { ensureOutboxIsEmpty, selectAction } from '../../../v2-utils'
 
 test.describe.serial('4. Death declaration case - 4', () => {
   let page: Page
-  async function expectRowValueWithChangeButton(
-    fieldName: string,
-    assertionText: string
-  ) {
-    await expect(page.getByTestId(`row-value-${fieldName}`)).toContainText(
-      assertionText
-    )
 
-    await expect(page.getByTestId(`change-button-${fieldName}`)).toBeVisible()
-  }
   const declaration = {
     deceased: {
       name: {
@@ -387,6 +379,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -399,6 +392,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         declaration.deceased.gender
       )
@@ -409,6 +403,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.age',
         declaration.deceased.age.toString()
       )
@@ -419,6 +414,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nationality',
         declaration.deceased.nationality
       )
@@ -429,6 +425,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         declaration.deceased.idType
       )
@@ -439,6 +436,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.maritalStatus',
         declaration.deceased.maritalStatus
       )
@@ -449,6 +447,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.state +
@@ -466,6 +465,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         formatDateObjectTo_dMMMMyyyy(declaration.eventDetails.date)
       )
@@ -476,6 +476,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.mannerOfDeath',
         declaration.eventDetails.mannerOfDeath
       )
@@ -486,6 +487,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.causeOfDeathEstablished',
         'Yes'
       )
@@ -496,6 +498,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.sourceCauseDeath',
         declaration.eventDetails.sourceCauseDeath
       )
@@ -506,6 +509,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         declaration.eventDetails.placeOfDeath
       )
@@ -516,6 +520,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -527,6 +532,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.name',
         declaration.informant.name.firstname +
           ' ' +
@@ -539,6 +545,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.age',
         declaration.informant.age.toString()
       )
@@ -549,6 +556,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.nationality',
         declaration.informant.nationality
       )
@@ -560,10 +568,12 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.idType',
         declaration.informant.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'informant.brn',
         declaration.informant.brn
       )
@@ -574,6 +584,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.address',
         declaration.informant.address.country +
           declaration.informant.address.province +
@@ -591,6 +602,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informant.email
       )
@@ -602,6 +614,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         declaration.spouse.name.firstname +
           ' ' +
@@ -614,6 +627,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.age',
         declaration.spouse.age.toString()
       )
@@ -624,6 +638,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.nationality',
         declaration.spouse.nationality
       )
@@ -634,6 +649,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         declaration.spouse.idType
       )
@@ -644,6 +660,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.address',
         declaration.spouse.address.country +
           declaration.spouse.address.state +
@@ -719,6 +736,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -731,6 +749,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         declaration.deceased.gender
       )
@@ -741,6 +760,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.age',
         declaration.deceased.age.toString()
       )
@@ -751,6 +771,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nationality',
         declaration.deceased.nationality
       )
@@ -761,6 +782,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         declaration.deceased.idType
       )
@@ -771,6 +793,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.maritalStatus',
         declaration.deceased.maritalStatus
       )
@@ -781,6 +804,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.state +
@@ -798,6 +822,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         formatDateObjectTo_dMMMMyyyy(declaration.eventDetails.date)
       )
@@ -808,6 +833,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.mannerOfDeath',
         declaration.eventDetails.mannerOfDeath
       )
@@ -818,6 +844,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.causeOfDeathEstablished',
         'Yes'
       )
@@ -828,6 +855,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.sourceCauseDeath',
         declaration.eventDetails.sourceCauseDeath
       )
@@ -838,6 +866,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         declaration.eventDetails.placeOfDeath
       )
@@ -848,6 +877,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -859,6 +889,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.name',
         declaration.informant.name.firstname +
           ' ' +
@@ -871,6 +902,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.age',
         declaration.informant.age.toString()
       )
@@ -881,6 +913,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.nationality',
         declaration.informant.nationality
       )
@@ -892,10 +925,12 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.idType',
         declaration.informant.idType
       )
       await expectRowValueWithChangeButton(
+        page,
         'informant.brn',
         declaration.informant.brn
       )
@@ -906,6 +941,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.address',
         declaration.informant.address.country +
           declaration.informant.address.province +
@@ -923,6 +959,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informant.email
       )
@@ -934,6 +971,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         declaration.spouse.name.firstname +
           ' ' +
@@ -946,6 +984,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.age',
         declaration.spouse.age.toString()
       )
@@ -956,6 +995,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.nationality',
         declaration.spouse.nationality
       )
@@ -966,6 +1006,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         declaration.spouse.idType
       )
@@ -976,6 +1017,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.address',
         declaration.spouse.address.country +
           declaration.spouse.address.state +

--- a/e2e/testcases/v2-death/declaration/death-declaration-5.spec.ts
+++ b/e2e/testcases/v2-death/declaration/death-declaration-5.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test'
 import {
   continueForm,
   drawSignature,
+  expectRowValueWithChangeButton,
   formatDateObjectTo_dMMMMyyyy,
   getRandomDate,
   goToSection,
@@ -13,16 +14,7 @@ import { ensureOutboxIsEmpty, selectAction } from '../../../v2-utils'
 
 test.describe.serial('5. Death declaration case - 5', () => {
   let page: Page
-  async function expectRowValueWithChangeButton(
-    fieldName: string,
-    assertionText: string
-  ) {
-    await expect(page.getByTestId(`row-value-${fieldName}`)).toContainText(
-      assertionText
-    )
 
-    await expect(page.getByTestId(`change-button-${fieldName}`)).toBeVisible()
-  }
   const declaration = {
     deceased: {
       name: {
@@ -286,6 +278,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -298,6 +291,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         declaration.deceased.gender
       )
@@ -308,6 +302,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.age',
         declaration.deceased.age.toString()
       )
@@ -318,6 +313,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nationality',
         declaration.deceased.nationality
       )
@@ -328,6 +324,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         declaration.deceased.idType
       )
@@ -338,6 +335,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.maritalStatus',
         declaration.deceased.maritalStatus
       )
@@ -348,6 +346,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.state +
@@ -365,6 +364,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         formatDateObjectTo_dMMMMyyyy(declaration.eventDetails.date)
       )
@@ -375,6 +375,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.mannerOfDeath',
         declaration.eventDetails.mannerOfDeath
       )
@@ -385,6 +386,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         declaration.eventDetails.placeOfDeath
       )
@@ -395,6 +397,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.deathLocationOther',
         declaration.eventDetails.deathLocationOther.country +
           declaration.eventDetails.deathLocationOther.province +
@@ -412,6 +415,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -423,6 +427,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.name',
         declaration.informant.name.firstname +
           ' ' +
@@ -435,6 +440,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.age',
         declaration.informant.age.toString()
       )
@@ -445,6 +451,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.nationality',
         declaration.informant.nationality
       )
@@ -455,6 +462,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.idType',
         declaration.informant.idType
       )
@@ -465,6 +473,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.address',
         declaration.informant.address.country +
           declaration.informant.address.state +
@@ -482,6 +491,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informant.email
       )
@@ -491,9 +501,14 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Reason
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.detailsNotAvailable', 'Yes')
+      await expectRowValueWithChangeButton(
+        page,
+        'spouse.detailsNotAvailable',
+        'Yes'
+      )
 
       await expectRowValueWithChangeButton(
+        page,
         'spouse.reason',
         declaration.spouse.reason
       )
@@ -562,6 +577,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -574,6 +590,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         declaration.deceased.gender
       )
@@ -584,6 +601,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.age',
         declaration.deceased.age.toString()
       )
@@ -594,6 +612,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nationality',
         declaration.deceased.nationality
       )
@@ -604,6 +623,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         declaration.deceased.idType
       )
@@ -614,6 +634,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.maritalStatus',
         declaration.deceased.maritalStatus
       )
@@ -624,6 +645,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.state +
@@ -641,6 +663,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         formatDateObjectTo_dMMMMyyyy(declaration.eventDetails.date)
       )
@@ -651,6 +674,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.mannerOfDeath',
         declaration.eventDetails.mannerOfDeath
       )
@@ -661,6 +685,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         declaration.eventDetails.placeOfDeath
       )
@@ -671,6 +696,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.deathLocationOther',
         declaration.eventDetails.deathLocationOther.country +
           declaration.eventDetails.deathLocationOther.province +
@@ -688,6 +714,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -699,6 +726,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.name',
         declaration.informant.name.firstname +
           ' ' +
@@ -711,6 +739,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.age',
         declaration.informant.age.toString()
       )
@@ -721,6 +750,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.nationality',
         declaration.informant.nationality
       )
@@ -731,6 +761,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.idType',
         declaration.informant.idType
       )
@@ -741,6 +772,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.address',
         declaration.informant.address.country +
           declaration.informant.address.state +
@@ -758,6 +790,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informant.email
       )
@@ -767,9 +800,14 @@ test.describe.serial('5. Death declaration case - 5', () => {
        * - Reason
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.detailsNotAvailable', 'Yes')
+      await expectRowValueWithChangeButton(
+        page,
+        'spouse.detailsNotAvailable',
+        'Yes'
+      )
 
       await expectRowValueWithChangeButton(
+        page,
         'spouse.reason',
         declaration.spouse.reason
       )

--- a/e2e/testcases/v2-death/declaration/death-declaration-6.spec.ts
+++ b/e2e/testcases/v2-death/declaration/death-declaration-6.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test'
 import {
   continueForm,
   drawSignature,
+  expectRowValueWithChangeButton,
   formatDateObjectTo_dMMMMyyyy,
   getRandomDate,
   goToSection,
@@ -18,16 +19,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
       assertionText
     )
   }
-  async function expectRowValueWithChangeButton(
-    fieldName: string,
-    assertionText: string
-  ) {
-    await expect(page.getByTestId(`row-value-${fieldName}`)).toContainText(
-      assertionText
-    )
 
-    await expect(page.getByTestId(`change-button-${fieldName}`)).toBeVisible()
-  }
   const declaration = {
     deceased: {
       name: {
@@ -291,6 +283,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -303,6 +296,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         declaration.deceased.gender
       )
@@ -313,6 +307,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.age',
         declaration.deceased.age.toString()
       )
@@ -323,6 +318,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nationality',
         declaration.deceased.nationality
       )
@@ -333,6 +329,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         declaration.deceased.idType
       )
@@ -343,6 +340,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.maritalStatus',
         declaration.deceased.maritalStatus
       )
@@ -353,6 +351,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.state +
@@ -370,6 +369,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         formatDateObjectTo_dMMMMyyyy(declaration.eventDetails.date)
       )
@@ -380,6 +380,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.mannerOfDeath',
         declaration.eventDetails.mannerOfDeath
       )
@@ -390,6 +391,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         declaration.eventDetails.placeOfDeath
       )
@@ -400,6 +402,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.deathLocationOther',
         declaration.eventDetails.deathLocationOther.country +
           declaration.eventDetails.deathLocationOther.province +
@@ -417,6 +420,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -428,6 +432,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.name',
         declaration.informant.name.firstname +
           ' ' +
@@ -440,6 +445,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.age',
         declaration.informant.age.toString()
       )
@@ -450,6 +456,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.nationality',
         declaration.informant.nationality
       )
@@ -460,6 +467,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.idType',
         declaration.informant.idType
       )
@@ -470,6 +478,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.address',
         declaration.informant.address.country +
           declaration.informant.address.state +
@@ -487,6 +496,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informant.email
       )
@@ -496,9 +506,14 @@ test.describe.serial('6. Death declaration case - 6', () => {
        * - Reason
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.detailsNotAvailable', 'Yes')
+      await expectRowValueWithChangeButton(
+        page,
+        'spouse.detailsNotAvailable',
+        'Yes'
+      )
 
       await expectRowValueWithChangeButton(
+        page,
         'spouse.reason',
         declaration.spouse.reason
       )

--- a/e2e/testcases/v2-death/declaration/death-declaration-7.spec.ts
+++ b/e2e/testcases/v2-death/declaration/death-declaration-7.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test'
 import {
   continueForm,
   drawSignature,
+  expectRowValueWithChangeButton,
   formatDateObjectTo_dMMMMyyyy,
   getRandomDate,
   goToSection,
@@ -18,16 +19,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
       assertionText
     )
   }
-  async function expectRowValueWithChangeButton(
-    fieldName: string,
-    assertionText: string
-  ) {
-    await expect(page.getByTestId(`row-value-${fieldName}`)).toContainText(
-      assertionText
-    )
 
-    await expect(page.getByTestId(`change-button-${fieldName}`)).toBeVisible()
-  }
   const declaration = {
     deceased: {
       name: {
@@ -294,6 +286,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -306,6 +299,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         declaration.deceased.gender
       )
@@ -316,6 +310,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.age',
         declaration.deceased.age.toString()
       )
@@ -326,6 +321,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.nationality',
         declaration.deceased.nationality
       )
@@ -335,6 +331,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         declaration.deceased.idType
       )
@@ -345,6 +342,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.maritalStatus',
         declaration.deceased.maritalStatus
       )
@@ -355,6 +353,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.state +
@@ -372,6 +371,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         formatDateObjectTo_dMMMMyyyy(declaration.eventDetails.date)
       )
@@ -382,6 +382,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.mannerOfDeath',
         declaration.eventDetails.mannerOfDeath
       )
@@ -392,6 +393,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         declaration.eventDetails.placeOfDeath
       )
@@ -402,6 +404,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.deathLocationOther',
         declaration.eventDetails.deathLocationOther.country +
           declaration.eventDetails.deathLocationOther.state +
@@ -419,6 +422,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -430,6 +434,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.name',
         declaration.informant.name.firstname +
           ' ' +
@@ -442,6 +447,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.age',
         declaration.informant.age.toString()
       )
@@ -452,6 +458,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.nationality',
         declaration.informant.nationality
       )
@@ -461,6 +468,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.idType',
         declaration.informant.idType
       )
@@ -471,6 +479,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.address',
         declaration.informant.address.country +
           declaration.informant.address.state +
@@ -488,6 +497,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         declaration.informant.email
       )
@@ -499,10 +509,12 @@ test.describe.serial('7. Death declaration case - 7', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.detailsNotAvailable',
         declaration.spouse.detailsNotAvailable ? 'Yes' : 'No'
       )
       await expectRowValueWithChangeButton(
+        page,
         'spouse.reason',
         declaration.spouse.reason
       )

--- a/e2e/testcases/v2-death/declaration/death-declaration-8.spec.ts
+++ b/e2e/testcases/v2-death/declaration/death-declaration-8.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test'
 import {
   continueForm,
   drawSignature,
+  expectRowValueWithChangeButton,
   goToSection,
   loginToV2
 } from '../../../helpers'
@@ -12,16 +13,6 @@ import { REQUIRED_VALIDATION_ERROR } from '../../v2-birth/helpers'
 
 test.describe.serial('8. Death declaration case - 8', () => {
   let page: Page
-  async function expectRowValueWithChangeButton(
-    fieldName: string,
-    assertionText: string
-  ) {
-    await expect(page.getByTestId(`row-value-${fieldName}`)).toContainText(
-      assertionText
-    )
-
-    await expect(page.getByTestId(`change-button-${fieldName}`)).toBeVisible()
-  }
 
   const declaration = {
     deceased: {
@@ -97,6 +88,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -109,6 +101,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         REQUIRED_VALIDATION_ERROR
       )
@@ -119,6 +112,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.dob',
         REQUIRED_VALIDATION_ERROR
       )
@@ -128,13 +122,18 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Deceased's Nationality
        * - Change button
        */
-      await expectRowValueWithChangeButton('deceased.nationality', 'Farajaland')
+      await expectRowValueWithChangeButton(
+        page,
+        'deceased.nationality',
+        'Farajaland'
+      )
       /*
        * Expected result: should require
        * - Deceased's Type of Id
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         REQUIRED_VALIDATION_ERROR
       )
@@ -145,6 +144,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.province +
@@ -157,6 +157,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         REQUIRED_VALIDATION_ERROR
       )
@@ -167,6 +168,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         REQUIRED_VALIDATION_ERROR
       )
@@ -177,6 +179,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -187,6 +190,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         REQUIRED_VALIDATION_ERROR
       )
@@ -199,6 +203,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        */
 
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         REQUIRED_VALIDATION_ERROR
       )
@@ -209,6 +214,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.dob',
         REQUIRED_VALIDATION_ERROR
       )
@@ -218,7 +224,11 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Spouse's Nationality
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.nationality', 'Farajaland')
+      await expectRowValueWithChangeButton(
+        page,
+        'spouse.nationality',
+        'Farajaland'
+      )
 
       /*
        * Expected result: should require
@@ -226,6 +236,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         REQUIRED_VALIDATION_ERROR
       )
@@ -235,7 +246,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Spouse's address
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.addressSameAs', 'Yes')
+      await expectRowValueWithChangeButton(page, 'spouse.addressSameAs', 'Yes')
     })
 
     test('8.1.6 Fill up informant signature', async () => {
@@ -302,6 +313,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -314,6 +326,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         REQUIRED_VALIDATION_ERROR
       )
@@ -324,6 +337,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.dob',
         REQUIRED_VALIDATION_ERROR
       )
@@ -333,13 +347,18 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Deceased's Nationality
        * - Change button
        */
-      await expectRowValueWithChangeButton('deceased.nationality', 'Farajaland')
+      await expectRowValueWithChangeButton(
+        page,
+        'deceased.nationality',
+        'Farajaland'
+      )
       /*
        * Expected result: should require
        * - Deceased's Type of Id
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         REQUIRED_VALIDATION_ERROR
       )
@@ -350,6 +369,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.province +
@@ -362,6 +382,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         REQUIRED_VALIDATION_ERROR
       )
@@ -372,6 +393,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         REQUIRED_VALIDATION_ERROR
       )
@@ -382,6 +404,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -392,6 +415,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         REQUIRED_VALIDATION_ERROR
       )
@@ -404,6 +428,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        */
 
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         REQUIRED_VALIDATION_ERROR
       )
@@ -414,6 +439,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.dob',
         REQUIRED_VALIDATION_ERROR
       )
@@ -423,7 +449,11 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Spouse's Nationality
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.nationality', 'Farajaland')
+      await expectRowValueWithChangeButton(
+        page,
+        'spouse.nationality',
+        'Farajaland'
+      )
 
       /*
        * Expected result: should require
@@ -431,6 +461,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         REQUIRED_VALIDATION_ERROR
       )
@@ -440,7 +471,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
        * - Spouse's address
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.addressSameAs', 'Yes')
+      await expectRowValueWithChangeButton(page, 'spouse.addressSameAs', 'Yes')
     })
   })
 })

--- a/e2e/testcases/v2-death/declaration/death-declaration-9.spec.ts
+++ b/e2e/testcases/v2-death/declaration/death-declaration-9.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from '@playwright/test'
 import {
   continueForm,
   drawSignature,
+  expectRowValueWithChangeButton,
   goToSection,
   loginToV2
 } from '../../../helpers'
@@ -12,16 +13,6 @@ import { REQUIRED_VALIDATION_ERROR } from '../../v2-birth/helpers'
 
 test.describe.serial('9. Death declaration case - 9', () => {
   let page: Page
-  async function expectRowValueWithChangeButton(
-    fieldName: string,
-    assertionText: string
-  ) {
-    await expect(page.getByTestId(`row-value-${fieldName}`)).toContainText(
-      assertionText
-    )
-
-    await expect(page.getByTestId(`change-button-${fieldName}`)).toBeVisible()
-  }
 
   const declaration = {
     deceased: {
@@ -97,6 +88,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname +
           ' ' +
@@ -109,6 +101,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         REQUIRED_VALIDATION_ERROR
       )
@@ -119,6 +112,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.dob',
         REQUIRED_VALIDATION_ERROR
       )
@@ -128,13 +122,18 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Deceased's Nationality
        * - Change button
        */
-      await expectRowValueWithChangeButton('deceased.nationality', 'Farajaland')
+      await expectRowValueWithChangeButton(
+        page,
+        'deceased.nationality',
+        'Farajaland'
+      )
       /*
        * Expected result: should require
        * - Deceased's Type of Id
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         REQUIRED_VALIDATION_ERROR
       )
@@ -145,6 +144,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.province +
@@ -157,6 +157,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         REQUIRED_VALIDATION_ERROR
       )
@@ -167,6 +168,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         REQUIRED_VALIDATION_ERROR
       )
@@ -177,6 +179,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -187,6 +190,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         REQUIRED_VALIDATION_ERROR
       )
@@ -199,6 +203,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        */
 
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         REQUIRED_VALIDATION_ERROR
       )
@@ -209,6 +214,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.dob',
         REQUIRED_VALIDATION_ERROR
       )
@@ -218,7 +224,11 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Spouse's Nationality
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.nationality', 'Farajaland')
+      await expectRowValueWithChangeButton(
+        page,
+        'spouse.nationality',
+        'Farajaland'
+      )
 
       /*
        * Expected result: should require
@@ -226,6 +236,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         REQUIRED_VALIDATION_ERROR
       )
@@ -235,7 +246,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Spouse's address
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.addressSameAs', 'Yes')
+      await expectRowValueWithChangeButton(page, 'spouse.addressSameAs', 'Yes')
     })
 
     test('9.1.6 Fill up informant signature', async () => {
@@ -302,6 +313,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.name',
         declaration.deceased.name.firstname
       )
@@ -312,6 +324,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.gender',
         REQUIRED_VALIDATION_ERROR
       )
@@ -322,6 +335,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.dob',
         REQUIRED_VALIDATION_ERROR
       )
@@ -331,13 +345,18 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Deceased's Nationality
        * - Change button
        */
-      await expectRowValueWithChangeButton('deceased.nationality', 'Farajaland')
+      await expectRowValueWithChangeButton(
+        page,
+        'deceased.nationality',
+        'Farajaland'
+      )
       /*
        * Expected result: should require
        * - Deceased's Type of Id
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.idType',
         REQUIRED_VALIDATION_ERROR
       )
@@ -348,6 +367,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'deceased.address',
         declaration.deceased.address.country +
           declaration.deceased.address.province +
@@ -360,6 +380,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.date',
         REQUIRED_VALIDATION_ERROR
       )
@@ -370,6 +391,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'eventDetails.placeOfDeath',
         REQUIRED_VALIDATION_ERROR
       )
@@ -380,6 +402,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.relation',
         declaration.informant.relation
       )
@@ -390,6 +413,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'informant.email',
         REQUIRED_VALIDATION_ERROR
       )
@@ -402,6 +426,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        */
 
       await expectRowValueWithChangeButton(
+        page,
         'spouse.name',
         REQUIRED_VALIDATION_ERROR
       )
@@ -412,6 +437,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.dob',
         REQUIRED_VALIDATION_ERROR
       )
@@ -421,7 +447,11 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Spouse's Nationality
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.nationality', 'Farajaland')
+      await expectRowValueWithChangeButton(
+        page,
+        'spouse.nationality',
+        'Farajaland'
+      )
 
       /*
        * Expected result: should require
@@ -429,6 +459,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Change button
        */
       await expectRowValueWithChangeButton(
+        page,
         'spouse.idType',
         REQUIRED_VALIDATION_ERROR
       )
@@ -438,7 +469,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
        * - Spouse's address
        * - Change button
        */
-      await expectRowValueWithChangeButton('spouse.addressSameAs', 'Yes')
+      await expectRowValueWithChangeButton(page, 'spouse.addressSameAs', 'Yes')
     })
   })
 })

--- a/src/form/v2/death/index.ts
+++ b/src/form/v2/death/index.ts
@@ -121,7 +121,7 @@ export const deathEvent = defineConfig({
         ]
       },
       {
-        fieldId: 'deceased.address',
+        fieldId: 'eventDetails.deathLocationOther',
         emptyValueMessage: {
           defaultMessage: 'No place of death',
           description:


### PR DESCRIPTION
## Description
- Ensure when "other" is selected as place of death, we show the correct value in summary
- Write test case
- Reuse method across tests instead of creating a separate one.
https://github.com/opencrvs/opencrvs-core/issues/10562

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
