### PR TITLE
Birth correction on mobile test, add e2e mobile helpers

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -278,7 +278,7 @@ export const expectAddress = async (
 }
 
 /*
-  The deletion section is formatted like bellow:
+  The deletion section is formatted like below:
   	'-'
     'Farajaland'
     'Central'

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -11,6 +11,7 @@ import {
 import { format, parseISO } from 'date-fns'
 import { isArray, random } from 'lodash'
 import fetch from 'node-fetch'
+import { isMobile } from './mobile-helpers'
 
 export async function login(page: Page, username: string, password: string) {
   const token = await getToken(username, password)
@@ -35,6 +36,13 @@ export async function createPIN(page: Page) {
 }
 
 export async function logout(page: Page) {
+  if (isMobile(page)) {
+    await page.goto(CLIENT_V2_URL)
+    await page.getByRole('button', { name: 'Toggle menu', exact: true }).click()
+    await page.getByRole('button', { name: 'Logout', exact: true }).click()
+    return
+  }
+
   await page.locator('#ProfileMenu-dropdownMenu').click()
   await page
     .locator('#ProfileMenu-dropdownMenu')

--- a/e2e/mobile-helpers.ts
+++ b/e2e/mobile-helpers.ts
@@ -1,0 +1,12 @@
+import { Page } from '@playwright/test'
+
+export const MOBILE_VIEWPORT_SIZE = { height: 800, width: 360 }
+
+export function setMobileViewport(page: Page) {
+  page.setViewportSize(MOBILE_VIEWPORT_SIZE)
+}
+
+export function isMobile(page: Page) {
+  const width = page.viewportSize()?.width
+  return width ? width <= MOBILE_VIEWPORT_SIZE.width : false
+}

--- a/e2e/testcases/v2-advanced-search/advanced-search.mobile.spec.ts
+++ b/e2e/testcases/v2-advanced-search/advanced-search.mobile.spec.ts
@@ -5,8 +5,7 @@ import { CREDENTIALS } from '../../constants'
 import { faker } from '@faker-js/faker'
 import { getAllLocations, getLocationIdByName } from '../birth/helpers'
 import { expectInUrl } from '../../v2-utils'
-
-const MOBILE_VIEWPORT_SIZE = { height: 800, width: 360 }
+import { setMobileViewport } from '../../mobile-helpers'
 
 test.describe.serial('Advanced Search - Mobile', () => {
   let page: Page
@@ -14,7 +13,7 @@ test.describe.serial('Advanced Search - Mobile', () => {
   let district = ''
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage()
-    page.setViewportSize(MOBILE_VIEWPORT_SIZE)
+    setMobileViewport(page)
     const token = await getToken(
       CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
       CREDENTIALS.LOCAL_REGISTRAR.PASSWORD

--- a/e2e/testcases/v2-correction-birth/birth-correction-flow.mobile.spec.ts
+++ b/e2e/testcases/v2-correction-birth/birth-correction-flow.mobile.spec.ts
@@ -10,6 +10,8 @@ import {
   ensureAssigned,
   ensureOutboxIsEmpty,
   expectInUrl,
+  navigateToWorkqueue,
+  selectAction,
   type
 } from '../../v2-utils'
 import { formatV2ChildName } from '../v2-birth/helpers'
@@ -43,18 +45,12 @@ test.describe.serial('Birth correction flow - Mobile', () => {
   })
 
   test('Navigate to the correction form', async () => {
-    await page.getByRole('button', { name: 'Toggle menu', exact: true }).click()
-    await page.getByRole('button', { name: 'Ready to print' }).click()
+    await navigateToWorkqueue(page, 'Ready to print')
     await page
       .getByRole('button', { name: formatV2ChildName(declaration) })
       .click()
 
-    await ensureAssigned(page)
-    await page.getByRole('button', { name: 'Action', exact: true }).click()
-    await page
-      .locator('#page-title')
-      .getByText('Correct record', { exact: true })
-      .click()
+    await selectAction(page, 'Correct record')
   })
 
   test('Fill in the correction details form', async () => {
@@ -161,10 +157,7 @@ test.describe.serial('Birth correction flow - Mobile', () => {
     })
 
     test("Find the event in the 'Ready for review' workflow", async () => {
-      await page
-        .getByRole('button', { name: 'Toggle menu', exact: true })
-        .click()
-      await page.getByRole('button', { name: 'Ready for review' }).click()
+      await navigateToWorkqueue(page, 'Ready for review')
 
       await page
         .getByRole('button', { name: formatV2ChildName(declaration) })
@@ -172,12 +165,7 @@ test.describe.serial('Birth correction flow - Mobile', () => {
     })
 
     test('Navigate to correction review', async () => {
-      await ensureAssigned(page)
-      await page.getByRole('button', { name: 'Action', exact: true }).click()
-      await page
-        .locator('#page-title')
-        .getByText('Review', { exact: true })
-        .click()
+      await selectAction(page, 'Review')
 
       await expect(page.getByText('RequesterInformant (Mother)')).toBeVisible()
       await expect(

--- a/e2e/testcases/v2-correction-birth/birth-correction-flow.mobile.spec.ts
+++ b/e2e/testcases/v2-correction-birth/birth-correction-flow.mobile.spec.ts
@@ -1,0 +1,249 @@
+import { expect, test, type Page } from '@playwright/test'
+import { getToken, loginToV2, logout } from '../../helpers'
+import { faker } from '@faker-js/faker'
+import { CREDENTIALS } from '../../constants'
+import {
+  createDeclaration,
+  Declaration
+} from '../v2-test-data/birth-declaration-with-mother-father'
+import {
+  ensureAssigned,
+  ensureOutboxIsEmpty,
+  expectInUrl,
+  selectAction,
+  type
+} from '../../v2-utils'
+import { formatV2ChildName } from '../v2-birth/helpers'
+import { setMobileViewport } from '../../mobile-helpers'
+
+test.describe.serial('Birth correction flow - Mobile', () => {
+  let declaration: Declaration
+  let eventId: string
+  let page: Page
+
+  test.beforeAll(async ({ browser }) => {
+    const token = await getToken(
+      CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
+      CREDENTIALS.LOCAL_REGISTRAR.PASSWORD
+    )
+    const res = await createDeclaration(
+      token,
+      undefined,
+      undefined,
+      'HEALTH_FACILITY'
+    )
+    declaration = res.declaration
+    eventId = res.eventId
+
+    page = await browser.newPage()
+    setMobileViewport(page)
+  })
+
+  test('Login', async () => {
+    await loginToV2(page, CREDENTIALS.REGISTRATION_AGENT)
+  })
+
+  test('Navigate to the correction form', async () => {
+    await page.getByRole('button', { name: 'Toggle menu', exact: true }).click()
+    await page.getByRole('button', { name: 'Ready to print' }).click()
+    await page
+      .getByRole('button', { name: formatV2ChildName(declaration) })
+      .click()
+
+    await ensureAssigned(page)
+    await page.getByRole('button', { name: 'Action', exact: true }).click()
+    await page
+      .locator('#page-title')
+      .getByText('Correct record', { exact: true })
+      .click()
+  })
+
+  test('Fill in the correction details form', async () => {
+    await page.locator('#requester____type').click()
+    await page.getByText('Informant (Mother)', { exact: true }).click()
+
+    await page.locator('#reason____option').click()
+    await page
+      .getByText('Myself or an agent made a mistake (Clerical error)', {
+        exact: true
+      })
+      .click()
+
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await page.getByRole('button', { name: 'Verified' }).click()
+  })
+
+  test('Fill in the supporting documents form', async () => {
+    const path = require('path')
+    const attachmentPath = path.resolve(__dirname, './image.png')
+    const inputFile = await page.locator(
+      'input[name="documents____supportingDocs"][type="file"]'
+    )
+
+    await page.getByTestId('select__documents____supportingDocs').click()
+    await page.getByText('Affidavit', { exact: true }).click()
+
+    await inputFile.setInputFiles(attachmentPath)
+
+    await page.getByTestId('select__documents____supportingDocs').click()
+    await page.getByText('Court Document', { exact: true }).click()
+    await inputFile.setInputFiles(attachmentPath)
+
+    await page.getByRole('button', { name: 'Continue' }).click()
+  })
+
+  const fee = faker.number.int({ min: 1, max: 1000 })
+
+  test('Fill in the fees form', async () => {
+    await page.locator('#fees____amount').fill(fee.toString())
+
+    await page.getByRole('button', { name: 'Continue' }).click()
+  })
+
+  test('Review page should be displayed and continue button should be disabled', async () => {
+    await expectInUrl(page, `/events/request-correction/${eventId}/review`)
+    await expect(page.getByRole('button', { name: 'Continue' })).toBeDisabled()
+  })
+
+  const newFirstName = faker.person.firstName()
+  const reasonForDelayedRegistration = faker.lorem.sentence(4)
+
+  test('After changing child name, continue button should be enabled', async () => {
+    await page.getByTestId('change-button-child.dob').click()
+    await page.getByTestId('child____dob-yyyy').fill('2024')
+    await page.getByTestId('child____dob-mm').fill('6')
+    await page.getByTestId('child____dob-dd').fill('24')
+    await page
+      .getByTestId('text__child____reason')
+      .fill(reasonForDelayedRegistration)
+
+    await type(page, '#firstname', newFirstName)
+    await page.getByRole('button', { name: 'Back to review' }).click()
+    await expect(page.getByRole('button', { name: 'Continue' })).toBeEnabled()
+  })
+
+  test('Continue to the summary page', async () => {
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await expectInUrl(page, `/events/request-correction/${eventId}/summary`)
+    await expect(
+      page.getByRole('button', { name: 'Back to review' })
+    ).toBeEnabled()
+    await expect(
+      page.getByRole('button', { name: 'Submit correction request' })
+    ).toBeEnabled()
+  })
+
+  test('Submit correction request', async () => {
+    await page
+      .getByRole('button', { name: 'Submit correction request' })
+      .click()
+
+    await expect(
+      page.getByText('Send record correction for approval?')
+    ).toBeVisible()
+    await expect(
+      page.getByText(
+        'The Registrar will be notified of this correction request and a record of this request will be recorded'
+      )
+    ).toBeVisible()
+
+    await page.getByRole('button', { name: 'Confirm', exact: true }).click()
+    await expectInUrl(page, `/events/overview/${eventId}`)
+    await ensureOutboxIsEmpty(page)
+  })
+
+  test('Logout', async () => {
+    await logout(page)
+  })
+
+  test.describe('Approve correction request', () => {
+    test('Login as Local Registrar', async () => {
+      await loginToV2(page, CREDENTIALS.LOCAL_REGISTRAR)
+    })
+
+    test("Find the event in the 'Ready for review' workflow", async () => {
+      await page
+        .getByRole('button', { name: 'Toggle menu', exact: true })
+        .click()
+      await page.getByRole('button', { name: 'Ready for review' }).click()
+
+      await page
+        .getByRole('button', { name: formatV2ChildName(declaration) })
+        .click()
+    })
+
+    test('Navigate to correction review', async () => {
+      await ensureAssigned(page)
+      await page.getByRole('button', { name: 'Action', exact: true }).click()
+      await page
+        .locator('#page-title')
+        .getByText('Review', { exact: true })
+        .click()
+
+      await expect(page.getByText('RequesterInformant (Mother)')).toBeVisible()
+      await expect(
+        page.getByText(
+          'Reason for correctionMyself or an agent made a mistake (Clerical error)'
+        )
+      ).toBeVisible()
+
+      await expect(
+        page.getByRole('heading', { name: "Child's details" })
+      ).toBeVisible()
+    })
+
+    test('Validate correction values', async () => {
+      await expect(page.getByText('Submitter' + 'Felix Katongo')).toBeVisible()
+      await expect(
+        page.getByText('Requester' + 'Informant (Mother)')
+      ).toBeVisible()
+      await expect(page.getByText('Fee total' + `$${fee}`)).toBeVisible()
+      await expect(
+        page
+          .locator('#listTable-corrections-table-child')
+          .getByText(
+            "Child's name" +
+              `${declaration['child.name'].firstname} ${declaration['child.name'].surname}` +
+              `${newFirstName} ${declaration['child.name'].surname}`
+          )
+      ).toBeVisible()
+
+      await expect(
+        page
+          .locator('#listTable-corrections-table-child')
+          .getByText(
+            'Reason for delayed registration' +
+              '-' +
+              reasonForDelayedRegistration
+          )
+      ).toBeVisible()
+
+      await expect(
+        page.getByTestId('row-value-child.name').getByRole('deletion')
+      ).toHaveText(
+        `${declaration['child.name'].firstname} ${declaration['child.name'].surname}`,
+        { ignoreCase: true }
+      )
+    })
+
+    test('Approve correction request', async () => {
+      await page.getByRole('button', { name: 'Approve', exact: true }).click()
+      await page.getByRole('button', { name: 'Confirm', exact: true }).click()
+
+      await expectInUrl(page, `/events/overview/${eventId}`)
+
+      await expect(
+        page.getByRole('heading', {
+          name: formatV2ChildName({
+            'child.name': {
+              firstname: newFirstName,
+              surname: declaration['child.name'].surname
+            }
+          })
+        })
+      ).toBeVisible({
+        timeout: 60_000
+      })
+    })
+  })
+})

--- a/e2e/testcases/v2-correction-birth/birth-correction-flow.mobile.spec.ts
+++ b/e2e/testcases/v2-correction-birth/birth-correction-flow.mobile.spec.ts
@@ -10,7 +10,6 @@ import {
   ensureAssigned,
   ensureOutboxIsEmpty,
   expectInUrl,
-  selectAction,
   type
 } from '../../v2-utils'
 import { formatV2ChildName } from '../v2-birth/helpers'

--- a/e2e/v2-utils.ts
+++ b/e2e/v2-utils.ts
@@ -48,29 +48,11 @@ export async function selectAction(
     await ensureAssigned(page)
   }
 
+  await page.getByRole('button', { name: 'Action', exact: true }).click()
+
   if (isMobile(page)) {
-    await page.getByRole('button', { name: 'Action', exact: true }).click()
     await page.locator('#page-title').getByText(action, { exact: true }).click()
     return
-  }
-
-  // Keep retrying the click until the dropdown is visible
-  let isVisible = false
-  let attempts = 0
-  const maxAttempts = 10
-
-  while (!isVisible && attempts < maxAttempts) {
-    await page.getByRole('button', { name: 'Action', exact: true }).click()
-    isVisible = await page
-      .locator('#action-Dropdown-Content')
-      .getByText(action, { exact: true })
-      .isVisible()
-
-    if (!isVisible) {
-      // Small wait before retrying
-      await page.waitForTimeout(500)
-      attempts++
-    }
   }
 
   await page

--- a/e2e/v2-utils.ts
+++ b/e2e/v2-utils.ts
@@ -1,8 +1,30 @@
 import { Page, expect } from '@playwright/test'
 import {
+  CLIENT_V2_URL,
   SAFE_INPUT_CHANGE_TIMEOUT_MS,
   SAFE_OUTBOX_TIMEOUT_MS
 } from './constants'
+import { isMobile } from './mobile-helpers'
+
+type Workqueue =
+  | 'Ready to print'
+  | 'Ready for review'
+  | 'Notifications'
+  | 'Requires updates'
+  | 'In external validation'
+  | 'Assigned to you'
+  | 'Recent'
+  | 'Sent for review'
+  | 'Outbox'
+
+export async function navigateToWorkqueue(page: Page, workqueue: Workqueue) {
+  if (isMobile(page)) {
+    await page.goto(CLIENT_V2_URL)
+    await page.getByRole('button', { name: 'Toggle menu', exact: true }).click()
+  }
+
+  await page.getByRole('button', { name: workqueue }).click()
+}
 
 export async function selectAction(
   page: Page,
@@ -24,6 +46,12 @@ export async function selectAction(
     action !== 'View'
   ) {
     await ensureAssigned(page)
+  }
+
+  if (isMobile(page)) {
+    await page.getByRole('button', { name: 'Action', exact: true }).click()
+    await page.locator('#page-title').getByText(action, { exact: true }).click()
+    return
   }
 
   // Keep retrying the click until the dropdown is visible


### PR DESCRIPTION
## Description

Core: https://github.com/opencrvs/opencrvs-core/pull/10746

* Add test for birth correction flow on mobile
* Add helper functions for mobile testing:
  * `setMobileViewport()`
  * `isMobile()`
* Add support to `selectAction()` for mobile
* Add `navigateToWorkqueue()` helper

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
