### PR TITLE
fix e2e for workqueue redirection after an action is completed

### DIFF
--- a/e2e/testcases/v2-application/5b-validate-ready-for-review-LR.spec.ts
+++ b/e2e/testcases/v2-application/5b-validate-ready-for-review-LR.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '../v2-test-data/birth-declaration'
 import { ActionType } from '@opencrvs/toolkit/events'
 import { formatV2ChildName } from '../v2-birth/helpers'
-import { ensureOutboxIsEmpty, selectAction } from '../../v2-utils'
+import { ensureOutboxIsEmpty, expectInUrl, selectAction } from '../../v2-utils'
 import { getRowByTitle } from '../v2-print-certificate/birth/helpers'
 
 test.describe
@@ -87,11 +87,11 @@ test.describe
     await expect(page.getByText('Register the birth?')).toBeVisible()
     await page.locator('#confirm_Validate').click()
 
-    // Should not redirect back to Ready for review workqueue, rather go to the first one
-    await expect(page.locator('#content-name')).toHaveText('Assigned to you')
+    // Should redirect back to Ready for review workqueue
+    await expect(page.locator('#content-name')).toHaveText('Ready for review')
 
     await ensureOutboxIsEmpty(page)
-    await page.getByText('Ready for review').click()
+    await expectInUrl(page, 'workqueue/in-review-all')
 
     await expect(
       page.getByRole('button', { name: formatV2ChildName(declaration) })

--- a/e2e/testcases/v2-correction-birth/birth-correction-flow.mobile.spec.ts
+++ b/e2e/testcases/v2-correction-birth/birth-correction-flow.mobile.spec.ts
@@ -143,7 +143,7 @@ test.describe.serial('Birth correction flow - Mobile', () => {
     ).toBeVisible()
 
     await page.getByRole('button', { name: 'Confirm', exact: true }).click()
-    await expectInUrl(page, `/events/overview/${eventId}`)
+    await expectInUrl(page, `/workqueue/ready-to-print`)
     await ensureOutboxIsEmpty(page)
   })
 
@@ -217,7 +217,19 @@ test.describe.serial('Birth correction flow - Mobile', () => {
       await page.getByRole('button', { name: 'Approve', exact: true }).click()
       await page.getByRole('button', { name: 'Confirm', exact: true }).click()
 
-      await expectInUrl(page, `/events/overview/${eventId}`)
+      await expectInUrl(page, `/workqueue/in-review-all`)
+      await ensureOutboxIsEmpty(page)
+      await navigateToWorkqueue(page, 'Ready to print')
+      await page
+        .getByRole('button', {
+          name: formatV2ChildName({
+            'child.name': {
+              firstname: newFirstName,
+              surname: declaration['child.name'].surname
+            }
+          })
+        })
+        .click()
 
       await expect(
         page.getByRole('heading', {

--- a/e2e/testcases/v2-correction-birth/birth-correction-flow.spec.ts
+++ b/e2e/testcases/v2-correction-birth/birth-correction-flow.spec.ts
@@ -240,7 +240,7 @@ test.describe.serial('Birth correction flow', () => {
     ).toBeVisible()
 
     await page.getByRole('button', { name: 'Confirm', exact: true }).click()
-    await expectInUrl(page, `/events/overview/${eventId}`)
+    await expectInUrl(page, `/workqueue/ready-to-print`)
     await ensureOutboxIsEmpty(page)
   })
 
@@ -317,7 +317,19 @@ test.describe.serial('Birth correction flow', () => {
       await page.getByRole('button', { name: 'Approve', exact: true }).click()
       await page.getByRole('button', { name: 'Confirm', exact: true }).click()
 
-      await expectInUrl(page, `/events/overview/${eventId}`)
+      await expectInUrl(page, `/workqueue/in-review-all`)
+      await ensureOutboxIsEmpty(page)
+      await page.getByRole('button', { name: 'Ready to print' }).click()
+      await page
+        .getByRole('button', {
+          name: formatV2ChildName({
+            'child.name': {
+              firstname: newFirstName,
+              surname: declaration['child.name'].surname
+            }
+          })
+        })
+        .click()
 
       await expect(
         page.getByText(

--- a/e2e/testcases/v2-correction-birth/birth-make-correction-flow.spec.ts
+++ b/e2e/testcases/v2-correction-birth/birth-make-correction-flow.spec.ts
@@ -228,7 +228,7 @@ test.describe.serial('Birth Record correction flow', () => {
 
     await page.getByRole('button', { name: 'Confirm', exact: true }).click()
 
-    await expectInUrl(page, `/events/overview/${eventId}`)
+    await expectInUrl(page, `/workqueue/ready-to-print`)
 
     await page.waitForResponse((response) =>
       response
@@ -239,6 +239,9 @@ test.describe.serial('Birth Record correction flow', () => {
 
   test('Record correction action appears in audit history', async () => {
     await page.reload()
+    await page
+      .getByRole('button', { name: formatV2ChildName(declaration) })
+      .click()
     await ensureAssigned(page)
 
     // Go to second page of audit history list

--- a/e2e/testcases/v2-correction-birth/correct-birth-record-1.spec.ts
+++ b/e2e/testcases/v2-correction-birth/correct-birth-record-1.spec.ts
@@ -272,7 +272,7 @@ test.describe('1. Correct record - 1', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review#child____name`
+          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=ready-to-print#child____name`
         )
 
         await page
@@ -319,7 +319,7 @@ test.describe('1. Correct record - 1', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review#child____gender`
+          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=ready-to-print#child____gender`
         )
 
         await page.getByTestId('select__child____gender').locator('svg').click()
@@ -357,7 +357,7 @@ test.describe('1. Correct record - 1', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review#child____dob`
+          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=ready-to-print#child____dob`
         )
 
         const birthDay = updatedChildDetails.birthDate.split('-')
@@ -398,7 +398,7 @@ test.describe('1. Correct record - 1', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review#child____placeOfBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=ready-to-print#child____placeOfBirth`
         )
 
         await page
@@ -447,7 +447,7 @@ test.describe('1. Correct record - 1', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review#child____attendantAtBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=ready-to-print#child____attendantAtBirth`
         )
 
         await page.getByTestId('select__child____attendantAtBirth').click()
@@ -488,7 +488,7 @@ test.describe('1. Correct record - 1', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review#child____birthType`
+          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=ready-to-print#child____birthType`
         )
 
         await page.getByTestId('select__child____birthType').click()
@@ -549,7 +549,7 @@ test.describe('1. Correct record - 1', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review#child____weightAtBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=ready-to-print#child____weightAtBirth`
         )
 
         await page
@@ -655,7 +655,7 @@ test.describe('1. Correct record - 1', () => {
         /*
          * Expected result: should be navigated to event overview
          */
-        await expectInUrl(page, `/events/overview/${eventId}`)
+        await expectInUrl(page, `/workqueue/ready-to-print`)
 
         /*
          * Expected result: should

--- a/e2e/testcases/v2-correction-birth/correct-birth-record-10.spec.ts
+++ b/e2e/testcases/v2-correction-birth/correct-birth-record-10.spec.ts
@@ -188,7 +188,7 @@ test.describe('10. Correct record', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review#child____name`
+          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=ready-to-print#child____name`
         )
 
         await page
@@ -235,7 +235,7 @@ test.describe('10. Correct record', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review#child____gender`
+          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=ready-to-print#child____gender`
         )
 
         await page.getByTestId('select__child____gender').locator('svg').click()
@@ -273,7 +273,7 @@ test.describe('10. Correct record', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review#child____dob`
+          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=ready-to-print#child____dob`
         )
 
         const birthDay = updatedChildDetails.birthDate.split('-')
@@ -314,7 +314,7 @@ test.describe('10. Correct record', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review#child____placeOfBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=ready-to-print#child____placeOfBirth`
         )
 
         await page
@@ -363,7 +363,7 @@ test.describe('10. Correct record', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review#child____attendantAtBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=ready-to-print#child____attendantAtBirth`
         )
 
         await page.getByTestId('select__child____attendantAtBirth').click()
@@ -404,7 +404,7 @@ test.describe('10. Correct record', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review#child____birthType`
+          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=ready-to-print#child____birthType`
         )
 
         await page.getByTestId('select__child____birthType').click()
@@ -465,7 +465,7 @@ test.describe('10. Correct record', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review#child____weightAtBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=ready-to-print#child____weightAtBirth`
         )
 
         await page
@@ -572,7 +572,7 @@ test.describe('10. Correct record', () => {
         /*
          * Expected result: should be navigated to event overview
          */
-        await expectInUrl(page, `/events/overview/${eventId}`)
+        await expectInUrl(page, `/workqueue/ready-to-print`)
 
         /*
          * Expected result: should

--- a/e2e/testcases/v2-correction-birth/correct-birth-record-2.spec.ts
+++ b/e2e/testcases/v2-correction-birth/correct-birth-record-2.spec.ts
@@ -148,7 +148,7 @@ test.describe.serial('Correct record - 2', () => {
 
       await expectInUrl(
         page,
-        `/events/request-correction/${eventId}/pages/informant?from=review#informant____relation`
+        `/events/request-correction/${eventId}/pages/informant?from=review&workqueue=ready-to-print#informant____relation`
       )
 
       await page.locator('#informant____relation').click()
@@ -186,7 +186,7 @@ test.describe.serial('Correct record - 2', () => {
 
       await expectInUrl(
         page,
-        `/events/request-correction/${eventId}/pages/child?from=review#child____placeOfBirth`
+        `/events/request-correction/${eventId}/pages/child?from=review&workqueue=ready-to-print#child____placeOfBirth`
       )
 
       await page.locator('#child____placeOfBirth').click()
@@ -242,7 +242,7 @@ test.describe.serial('Correct record - 2', () => {
       .click()
     await page.getByRole('button', { name: 'Confirm' }).click()
 
-    await expectInUrl(page, `/events/overview/${eventId}`)
+    await expectInUrl(page, `/workqueue/ready-to-print`)
   })
 
   test.describe('2.8 Correction Review', async () => {

--- a/e2e/testcases/v2-events-rest-api/create-and-notify-event.spec.ts
+++ b/e2e/testcases/v2-events-rest-api/create-and-notify-event.spec.ts
@@ -879,7 +879,7 @@ test.describe('Events REST API', () => {
 
       await printAndExpectPopup(page)
 
-      await expectInUrl(page, `/events/overview/${eventId}`)
+      await expectInUrl(page, `/workqueue/ready-to-print`)
     })
   })
 })

--- a/e2e/testcases/v2-navigation/navigating-in-and-out-of-action.spec.ts
+++ b/e2e/testcases/v2-navigation/navigating-in-and-out-of-action.spec.ts
@@ -78,8 +78,8 @@ test.describe.serial('Navigating in and out of action', () => {
     await page.getByRole('button', { name: 'Print', exact: true }).click()
 
     // Wait for PDF the load and the page to be redirected to the overview page
-    await page.waitForURL(`**/events/overview/${eventId}`)
-    await expectInUrl(page, `/events/overview/${eventId}`)
+    await page.waitForURL(`**/workqueue/ready-to-print`)
+    await expectInUrl(page, `/workqueue/ready-to-print`)
   })
 
   test('Browser back button should take user to the front page instead of action flow', async () => {

--- a/e2e/testcases/v2-print-certificate/birth/36.03-validate-certify-record-page.spec.ts
+++ b/e2e/testcases/v2-print-certificate/birth/36.03-validate-certify-record-page.spec.ts
@@ -11,13 +11,14 @@ import {
   selectCertificationType,
   selectRequesterType
 } from './helpers'
-import { ensureAssigned, expectInUrl } from '../../../v2-utils'
+import { ensureAssigned, expectInUrl, type } from '../../../v2-utils'
+import { formatV2ChildName } from '../../v2-birth/helpers'
 
 test.describe.serial('3.0 Validate "Certify record" page', () => {
   let eventId: string
   let declaration: Declaration
   let page: Page
-
+  let trackingId: string | undefined
   test.beforeAll(async ({ browser }) => {
     const token = await getToken(
       CREDENTIALS.LOCAL_REGISTRAR.USERNAME,
@@ -26,6 +27,7 @@ test.describe.serial('3.0 Validate "Certify record" page', () => {
     const res = await createDeclaration(token)
     eventId = res.eventId
     declaration = res.declaration
+    trackingId = res.trackingId
     page = await browser.newPage()
   })
 
@@ -136,6 +138,14 @@ test.describe.serial('3.0 Validate "Certify record" page', () => {
   })
 
   test('3.8 Validate Certified -modal', async () => {
+    if (!trackingId) {
+      throw new Error('Tracking ID is undefined')
+    }
+    await type(page, '#searchText', trackingId)
+    await page.locator('#searchIconButton').click()
+    await page
+      .getByRole('button', { name: formatV2ChildName(declaration) })
+      .click()
     await ensureAssigned(page)
     await page.getByRole('button', { name: 'Certified', exact: true }).click()
 

--- a/e2e/testcases/v2-print-certificate/birth/36.05.06-validate-certify-record-page.spec.ts
+++ b/e2e/testcases/v2-print-certificate/birth/36.05.06-validate-certify-record-page.spec.ts
@@ -12,8 +12,9 @@ import {
   navigateToCertificatePrintAction,
   printAndExpectPopup
 } from './helpers'
-import { ensureAssigned, expectInUrl } from '../../../v2-utils'
+import { ensureAssigned, type, expectInUrl } from '../../../v2-utils'
 import { REQUIRED_VALIDATION_ERROR } from '../../v2-birth/helpers'
+import { formatV2ChildName } from '../../v2-birth/helpers'
 
 async function selectIdType(page: Page, idType: string) {
   await page.locator('#collector____OTHER____idType').click()
@@ -24,6 +25,7 @@ test.describe.serial('Validate collect payment page', () => {
   let eventId: string
   let declaration: Declaration
   let page: Page
+  let trackingId: string | undefined
 
   test.beforeAll(async ({ browser }) => {
     const token = await getToken(
@@ -33,6 +35,7 @@ test.describe.serial('Validate collect payment page', () => {
     const res = await createDeclaration(token)
     eventId = res.eventId
     declaration = res.declaration
+    trackingId = res.trackingId
     page = await browser.newPage()
   })
 
@@ -143,6 +146,14 @@ test.describe.serial('Validate collect payment page', () => {
   })
 
   test('5.10 Validate Certified -modal', async () => {
+    if (!trackingId) {
+      throw new Error('Tracking ID is undefined')
+    }
+    await type(page, '#searchText', trackingId)
+    await page.locator('#searchIconButton').click()
+    await page
+      .getByRole('button', { name: formatV2ChildName(declaration) })
+      .click()
     await ensureAssigned(page)
     await page.getByRole('button', { name: 'Certified', exact: true }).click()
 

--- a/e2e/testcases/v2-print-certificate/birth/36.10-validate-certify-record-page.spec.ts
+++ b/e2e/testcases/v2-print-certificate/birth/36.10-validate-certify-record-page.spec.ts
@@ -66,6 +66,6 @@ test.describe.serial('10.0 Validate "Review" page', () => {
   test('10.3 Click print button, user will navigate to a new tab from where user can download PDF', async () => {
     await printAndExpectPopup(page)
 
-    await expectInUrl(page, `/events/overview/${eventId}`)
+    await expectInUrl(page, `/workqueue/ready-to-print`)
   })
 })

--- a/e2e/testcases/v2-print-certificate/birth/print-to-someone-else-using-alien-number.spec.ts
+++ b/e2e/testcases/v2-print-certificate/birth/print-to-someone-else-using-alien-number.spec.ts
@@ -12,7 +12,8 @@ import {
   navigateToCertificatePrintAction,
   printAndExpectPopup
 } from './helpers'
-import { ensureAssigned } from '../../../v2-utils'
+import { ensureAssigned, type } from '../../../v2-utils'
+import { formatV2ChildName } from '../../v2-birth/helpers'
 
 async function selectIdType(page: Page, idType: string) {
   await page.locator('#collector____OTHER____idType').click()
@@ -23,6 +24,7 @@ test.describe
   .serial('Print to someone else using Alien Number as ID type', () => {
   let declaration: Declaration
   let page: Page
+  let trackingId: string | undefined
 
   test.beforeAll(async ({ browser }) => {
     const token = await getToken(
@@ -31,6 +33,7 @@ test.describe
     )
     const res = await createDeclaration(token)
     declaration = res.declaration
+    trackingId = res.trackingId
     page = await browser.newPage()
   })
 
@@ -67,6 +70,14 @@ test.describe
   })
 
   test('Validate Certified -modal', async () => {
+    if (!trackingId) {
+      throw new Error('Tracking ID is undefined')
+    }
+    await type(page, '#searchText', trackingId)
+    await page.locator('#searchIconButton').click()
+    await page
+      .getByRole('button', { name: formatV2ChildName(declaration) })
+      .click()
     await ensureAssigned(page)
     await page.getByRole('button', { name: 'Certified', exact: true }).click()
 

--- a/e2e/testcases/v2-print-certificate/birth/print-with-slow-connection.spec.ts
+++ b/e2e/testcases/v2-print-certificate/birth/print-with-slow-connection.spec.ts
@@ -73,6 +73,6 @@ test.describe
     // Check that the popup URL contains PDF content
     await expect(popup.url()).toBe('about:blank')
     await expect(download.suggestedFilename()).toMatch(/^.*\.pdf$/)
-    await expectInUrl(page, `/events/overview/${eventId}`)
+    await expectInUrl(page, `/workqueue/ready-to-print`)
   })
 })

--- a/e2e/testcases/v2-print-certificate/death/36.10-validate-certify-record-page.spec.ts
+++ b/e2e/testcases/v2-print-certificate/death/36.10-validate-certify-record-page.spec.ts
@@ -66,6 +66,6 @@ test.describe.serial('10.0 Validate "Review" page', () => {
 
   test('10.3 On click print button, user will navigate to a new tab from where user can download PDF', async () => {
     await printAndExpectPopup(page)
-    await expectInUrl(page, `/events/overview/${eventId}`)
+    await expectInUrl(page, `/workqueue/ready-to-print`)
   })
 })


### PR DESCRIPTION
## Description

issue: https://github.com/opencrvs/opencrvs-core/issues/10688
related: https://github.com/opencrvs/opencrvs-core/issues/10691
core pr: https://github.com/opencrvs/opencrvs-core/pull/10752

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
