### PR TITLE
mother e-signat verified status added in dedup config 

### DIFF
--- a/src/form/v2/birth/dedupConfig.ts
+++ b/src/form/v2/birth/dedupConfig.ts
@@ -24,7 +24,10 @@ const motherIdMatchesIfGiven = or(
   motherIdNotProvided,
   field('mother.nid').strictMatches(),
   field('mother.passport').strictMatches(),
-  field('mother.brn').strictMatches()
+  field('mother.brn').strictMatches(),
+  field('mother.verified').strictMatches({
+    value: 'authenticated'
+  })
 )
 
 const childDobWithin9Months = field('child.dob').dateRangeMatches({


### PR DESCRIPTION
## Description

issue: https://github.com/opencrvs/opencrvs-core/issues/10907
dedup config for mother was missing the e-signate flow, added mother.verified status.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
