### PR TITLE
fix: reset informant inputs when relation is changed

### DIFF
--- a/e2e/testcases/form-state/informant-reset.spec.ts
+++ b/e2e/testcases/form-state/informant-reset.spec.ts
@@ -1,0 +1,165 @@
+import { Page, expect, test } from '@playwright/test'
+import { goToSection, login } from '../../helpers'
+import { openBirthDeclaration } from '../birth/helpers'
+
+test.describe('Informant details resets when relation is changed', () => {
+  test.describe.serial('Birth', async () => {
+    let page: Page
+
+    test.beforeAll(async ({ browser }) => {
+      page = await browser.newPage()
+    })
+
+    test.afterAll(async () => {
+      await page.close()
+    })
+
+    test('Login', async () => {
+      await login(page)
+    })
+
+    test('Fill in informant details', async () => {
+      await openBirthDeclaration(page)
+
+      await goToSection(page, 'informant')
+
+      await page.locator('#informant____relation').click()
+      await page
+        .getByText('Brother', {
+          exact: true
+        })
+        .click()
+
+      await page.locator('#firstname').fill('Bart')
+      await page.locator('#surname').fill('simpson')
+
+      await page.getByPlaceholder('dd').fill('11')
+      await page.getByPlaceholder('mm').fill('11')
+      await page.getByPlaceholder('yyyy').fill('1999')
+
+      await page.locator('#informant____idType').click()
+      await page.getByText('National ID', { exact: true }).click()
+
+      await page.locator('#informant____nid').fill('1234567890')
+
+      await page.locator('#country').click()
+      await page.getByText('Estonia', { exact: true }).click()
+      await page.locator('#state').fill('Springfield')
+      await page.locator('#district2').fill('Spring County')
+      await page.locator('#cityOrTown').fill('Spring City')
+      await page.locator('#addressLine1').fill('Evergreen')
+      await page.locator('#addressLine2').fill('Terrace')
+      await page.locator('#addressLine3').fill('742')
+      await page.locator('#postcodeOrZip').fill('1320')
+
+      await page.locator('#informant____phoneNo').fill('0712345612')
+      await page.locator('#informant____email').fill('bart@gmail.com')
+    })
+
+    test('Change informant', async () => {
+      await page.locator('#informant____relation').click()
+      await page
+        .getByText('Sister', {
+          exact: true
+        })
+        .click()
+
+      await expect(page.locator('#firstname')).toHaveValue('')
+      await expect(page.locator('#surname')).toHaveValue('')
+
+      await expect(page.locator('#informant____dob-dd')).toHaveValue('')
+      await expect(page.locator('#informant____dob-mm')).toHaveValue('')
+      await expect(page.locator('#informant____dob-yyyy')).toHaveValue('')
+
+      await expect(page.getByText('National ID')).toBeHidden()
+
+      await expect(page.getByText('Estonia')).toBeHidden()
+      await expect(page.locator('#country')).toHaveText('Farajaland')
+      await expect(page.locator('#province')).toHaveText('Central')
+      await expect(page.locator('#district')).toHaveText('Ibombo')
+
+      await expect(page.locator('#informant____phoneNo')).toHaveValue('')
+      await expect(page.locator('#informant____email')).toHaveValue('')
+    })
+  })
+  test.describe.serial('Death', async () => {
+    let page: Page
+
+    test.beforeAll(async ({ browser }) => {
+      page = await browser.newPage()
+    })
+
+    test.afterAll(async () => {
+      await page.close()
+    })
+
+    test('Login', async () => {
+      await login(page)
+    })
+
+    test('Fill in informant details', async () => {
+      await page.click('#header-new-event')
+      await page.getByLabel('Death').click()
+      await page.getByRole('button', { name: 'Continue' }).click()
+      await goToSection(page, 'informant')
+
+      await page.locator('#informant____relation').click()
+      await page
+        .getByText('Son', {
+          exact: true
+        })
+        .click()
+
+      await page.locator('#firstname').fill('Bart')
+      await page.locator('#surname').fill('simpson')
+
+      await page.getByPlaceholder('dd').fill('11')
+      await page.getByPlaceholder('mm').fill('11')
+      await page.getByPlaceholder('yyyy').fill('1999')
+
+      await page.locator('#informant____idType').click()
+      await page.getByText('National ID', { exact: true }).click()
+
+      await page.locator('#informant____nid').fill('1234567890')
+
+      await page.locator('#informant____addressSameAs_NO').check()
+
+      await page.locator('#country').click()
+      await page.getByText('Estonia', { exact: true }).click()
+      await page.locator('#state').fill('Springfield')
+      await page.locator('#district2').fill('Spring County')
+      await page.locator('#cityOrTown').fill('Spring City')
+      await page.locator('#addressLine1').fill('Evergreen')
+      await page.locator('#addressLine2').fill('Terrace')
+      await page.locator('#addressLine3').fill('742')
+      await page.locator('#postcodeOrZip').fill('1320')
+
+      await page.locator('#informant____phoneNo').fill('0712345612')
+      await page.locator('#informant____email').fill('bart@gmail.com')
+    })
+
+    test('Change informant', async () => {
+      await page.locator('#informant____relation').click()
+      await page
+        .getByText('Daughter', {
+          exact: true
+        })
+        .click()
+
+      await expect(page.locator('#firstname')).toHaveValue('')
+      await expect(page.locator('#surname')).toHaveValue('')
+
+      await expect(page.locator('#informant____dob-dd')).toHaveValue('')
+      await expect(page.locator('#informant____dob-mm')).toHaveValue('')
+      await expect(page.locator('#informant____dob-yyyy')).toHaveValue('')
+
+      await expect(page.getByText('National ID')).toBeHidden()
+
+      await expect(page.getByText('Estonia')).toBeHidden()
+      await expect(page.locator('#country')).toBeHidden()
+
+      await expect(page.locator('#informant____phoneNo')).toHaveValue('')
+      await expect(page.locator('#informant____email')).toHaveValue('')
+    })
+  })
+})

--- a/src/form/v2/birth/forms/pages/informant.ts
+++ b/src/form/v2/birth/forms/pages/informant.ts
@@ -178,7 +178,8 @@ export const informant = defineFormPage({
             conditional: informantOtherThanParent
           }
         ],
-        validation: [invalidNameValidator('informant.name')]
+        validation: [invalidNameValidator('informant.name')],
+        parent: field('informant.relation')
       },
       {
         valuePath: 'data.name',
@@ -224,7 +225,8 @@ export const informant = defineFormPage({
               informantOtherThanParent
             )
           }
-        ]
+        ],
+        parent: field('informant.relation')
       },
       {
         valuePath: 'data.birthDate',
@@ -333,7 +335,8 @@ export const informant = defineFormPage({
             type: ConditionalType.SHOW,
             conditional: informantOtherThanParent
           }
-        ]
+        ],
+        parent: field('informant.relation')
       },
       {
         valuePath: 'data.idType',
@@ -373,7 +376,8 @@ export const informant = defineFormPage({
               not(field('informant.nid').isEqualTo(field('father.nid')))
             )
           }
-        ]
+        ],
+        parent: field('informant.relation')
       },
       {
         valuePath: 'data.nid',

--- a/src/form/v2/death/forms/pages/informant.ts
+++ b/src/form/v2/death/forms/pages/informant.ts
@@ -189,7 +189,8 @@ export const informant = defineFormPage({
             conditional: informantOtherThanSpouse
           }
         ],
-        validation: [invalidNameValidator('informant.name')]
+        validation: [invalidNameValidator('informant.name')],
+        parent: field('informant.relation')
       },
       {
         valuePath: 'data.name',
@@ -224,7 +225,8 @@ export const informant = defineFormPage({
               informantOtherThanSpouse
             )
           }
-        ]
+        ],
+        parent: field('informant.relation')
       },
       {
         valuePath: 'data.birthDate',
@@ -332,7 +334,8 @@ export const informant = defineFormPage({
             type: ConditionalType.SHOW,
             conditional: informantOtherThanSpouse
           }
-        ]
+        ],
+        parent: field('informant.relation')
       },
       {
         valuePath: 'data.idType',
@@ -372,7 +375,8 @@ export const informant = defineFormPage({
               not(field('informant.nid').isEqualTo(field('deceased.nid')))
             )
           }
-        ]
+        ],
+        parent: field('informant.relation')
       },
       {
         valuePath: 'data.nid',
@@ -458,7 +462,8 @@ export const informant = defineFormPage({
             YesNoTypes.YES
           )
         }
-      ]
+      ],
+      parent: field('informant.relation')
     },
     {
       id: 'informant.addressDivider1',


### PR DESCRIPTION
## Description

[Screencast from 2025-11-11 12-38-21.webm](https://github.com/user-attachments/assets/b939e29f-9ffb-4568-b399-af3ce42e8bd1)


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
