### PR TITLE
Switch tests to use new declaration action UI, add new testcase

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -587,3 +587,22 @@ export async function expectRowValueWithChangeButton(
 export async function switchEventTab(page: Page, tab: 'Audit' | 'Record') {
   await page.getByRole('button', { name: tab, exact: true }).click()
 }
+
+/** Assert whether a button on the action menu exists and is enabled/disabled */
+export async function validateActionMenuButton(
+  page: Page,
+  action: string,
+  isEnabled = true
+) {
+  await page.getByRole('button', { name: 'Action', exact: true }).click()
+  const actionButton = page.getByText(action, { exact: true })
+  await expect(actionButton).toBeVisible()
+
+  if (isEnabled) {
+    await expect(actionButton).not.toHaveAttribute('disabled')
+  } else {
+    await expect(actionButton).toHaveAttribute('disabled')
+  }
+
+  await page.getByRole('button', { name: 'Action', exact: true }).click()
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -606,3 +606,16 @@ export async function validateActionMenuButton(
 
   await page.getByRole('button', { name: 'Action', exact: true }).click()
 }
+
+export async function selectDeclarationAction(
+  page: Page,
+  action: string,
+  confirm = true
+) {
+  await page.getByRole('button', { name: 'Action', exact: true }).click()
+  await page.getByText(action, { exact: true }).click()
+
+  if (confirm) {
+    await page.getByRole('button', { name: action, exact: true }).click()
+  }
+}

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -609,7 +609,14 @@ export async function validateActionMenuButton(
 
 export async function selectDeclarationAction(
   page: Page,
-  action: string,
+  action:
+    | 'Notify'
+    | 'Declare'
+    | 'Validate'
+    | 'Register'
+    | 'Reject'
+    | 'Delete declaration'
+    | 'Save & Exit',
   confirm = true
 ) {
   await page.getByRole('button', { name: 'Action', exact: true }).click()

--- a/e2e/testcases/advanced-search/1-search-birth-event-declaration-registration-details.spec.ts
+++ b/e2e/testcases/advanced-search/1-search-birth-event-declaration-registration-details.spec.ts
@@ -22,12 +22,9 @@ test.describe
 
     await createDeclaration(token, {
       'child.dob': faker.date
-        // Randomly chosen DOB between 2010-01-01 and 2020-12-31
-        // Ensures the created record appears on the first page of search results
-        .between({ from: '2010-01-01', to: '2020-12-31' })
+        .between({ from: '2025-09-10', to: '2025-11-28' })
         .toISOString()
         .split('T')[0],
-      'child.reason': 'Other', // needed for late dob value
       'child.gender': 'female'
     })
   })

--- a/e2e/testcases/advanced-search/2-search-birth-event-declaration-child-details.spec.ts
+++ b/e2e/testcases/advanced-search/2-search-birth-event-declaration-child-details.spec.ts
@@ -22,12 +22,9 @@ test.describe
 
     record = await createDeclaration(token, {
       'child.dob': faker.date
-        // Randomly chosen DOB between 2010-01-01 and 2020-12-31
-        // Ensures the created record appears on the first page of search results
-        .between({ from: '2010-01-01', to: '2020-12-31' })
+        .between({ from: '2025-09-10', to: '2025-11-28' })
         .toISOString()
         .split('T')[0],
-      'child.reason': 'Other', // needed for late dob value
       'child.gender': 'female'
     })
     ;[yyyy, mm, dd] = record.declaration['child.dob'].split('-')

--- a/e2e/testcases/advanced-search/3-search-birth-event-declaration-child-event-details.spec.ts
+++ b/e2e/testcases/advanced-search/3-search-birth-event-declaration-child-event-details.spec.ts
@@ -24,12 +24,9 @@ test.describe
       token,
       {
         'child.dob': faker.date
-          // Randomly chosen DOB between 2010-01-01 and 2020-12-31
-          // Ensures the created record appears on the first page of search results
-          .between({ from: '2010-01-01', to: '2020-12-31' })
+          .between({ from: '2025-09-10', to: '2025-11-28' })
           .toISOString()
           .split('T')[0],
-        'child.reason': 'Other', // needed for late dob value
         'child.gender': 'female'
       },
       'REGISTER',
@@ -162,9 +159,7 @@ test.describe
       token,
       {
         'child.dob': faker.date
-          // Randomly chosen DOB between 2010-01-01 and 2020-12-31
-          // Ensures the created record appears on the first page of search results
-          .between({ from: '2010-01-01', to: '2020-12-31' })
+          .between({ from: '2025-09-10', to: '2025-11-28' })
           .toISOString()
           .split('T')[0],
         'child.placeOfBirth': 'PRIVATE_HOME',
@@ -174,7 +169,6 @@ test.describe
           administrativeArea: district,
           streetLevelDetails: { town: 'Dhaka' }
         },
-        'child.reason': 'Other', // needed for late dob value
         'child.gender': 'female'
       },
       'REGISTER',

--- a/e2e/testcases/advanced-search/advanced-search.mobile.spec.ts
+++ b/e2e/testcases/advanced-search/advanced-search.mobile.spec.ts
@@ -31,9 +31,7 @@ test.describe.serial('Advanced Search - Mobile', () => {
       token,
       {
         'child.dob': faker.date
-          // Randomly chosen DOB between 2010-01-01 and 2020-12-31
-          // Ensures the created record appears on the first page of search results
-          .between({ from: '2010-01-01', to: '2020-12-31' })
+          .between({ from: '2025-09-10', to: '2025-11-28' })
           .toISOString()
           .split('T')[0],
         'child.placeOfBirth': 'PRIVATE_HOME',
@@ -43,7 +41,6 @@ test.describe.serial('Advanced Search - Mobile', () => {
           administrativeArea: district,
           streetLevelDetails: { town: 'Dhaka' }
         },
-        'child.reason': 'Other', // needed for late dob value
         'child.gender': 'female'
       },
       'REGISTER',

--- a/e2e/testcases/application/1-my-draft.spec.ts
+++ b/e2e/testcases/application/1-my-draft.spec.ts
@@ -1,6 +1,11 @@
 import { expect, test, type Page } from '@playwright/test'
 
-import { formatName, goToSection, login } from '../../helpers'
+import {
+  formatName,
+  goToSection,
+  login,
+  selectDeclarationAction
+} from '../../helpers'
 import { CREDENTIALS } from '../../constants'
 import { faker } from '@faker-js/faker'
 import { getRowByTitle } from '../print-certificate/birth/helpers'
@@ -83,8 +88,7 @@ test.describe.serial('1: Validate my draft tab', () => {
 
     await goToSection(page, 'review')
 
-    await page.getByRole('button', { name: 'Send for review' }).click()
-    await page.getByRole('button', { name: 'Confirm' }).click()
+    await selectDeclarationAction(page, 'Notify')
 
     await ensureOutboxIsEmpty(page)
 

--- a/e2e/testcases/application/30-offline-outbox.spec.ts
+++ b/e2e/testcases/application/30-offline-outbox.spec.ts
@@ -6,7 +6,8 @@ import {
   formatName,
   getRandomDate,
   goToSection,
-  login
+  login,
+  selectDeclarationAction
 } from '../../helpers'
 import { CREDENTIALS } from '../../constants'
 import { faker } from '@faker-js/faker'
@@ -113,7 +114,7 @@ test.describe
     await page.click('#header-new-event')
     await page.getByLabel('Birth').click()
     await goToSection(page, 'review')
-    await page.getByRole('button', { name: 'Exit', exact: true }).click()
+    await page.getByTestId('exit-button').click()
     await page.getByRole('button', { name: 'Confirm', exact: true }).click()
 
     await page.context().setOffline(true)
@@ -293,10 +294,8 @@ test.describe
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('30.1.8 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('30.1.8 Declare', async () => {
+      await selectDeclarationAction(page, 'Declare')
     })
   })
 
@@ -317,10 +316,8 @@ test.describe
         .fill(partialDeclaration1.child.name.familyName)
       await goToSection(page, 'review')
     })
-    test('30.2.2 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('30.2.2 Notify', async () => {
+      await selectDeclarationAction(page, 'Notify')
     })
   })
 
@@ -341,10 +338,8 @@ test.describe
         .fill(partialDeclaration2.child.name.familyName)
       await goToSection(page, 'review')
     })
-    test('30.3.2 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('30.3.2 Notify', async () => {
+      await selectDeclarationAction(page, 'Notify')
     })
   })
 

--- a/e2e/testcases/application/4a-validate-require-update-FA.spec.ts
+++ b/e2e/testcases/application/4a-validate-require-update-FA.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from '@playwright/test'
 
-import { login, getToken } from '../../helpers'
+import { login, getToken, selectDeclarationAction } from '../../helpers'
 import { CREDENTIALS, SAFE_WORKQUEUE_TIMEOUT_MS } from '../../constants'
 import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { ActionType } from '@opencrvs/toolkit/events'
@@ -100,9 +100,7 @@ test.describe
 
     await row.getByRole('button', { name: 'Review' }).click()
 
-    await page.getByRole('button', { name: 'Send for review' }).click()
-    await expect(page.getByText('Send for review?')).toBeVisible()
-    await page.getByRole('button', { name: 'Confirm' }).click()
+    await selectDeclarationAction(page, 'Declare')
 
     // Should redirect back to requires update workqueue
     await expect(page.locator('#content-name')).toHaveText('Requires updates')

--- a/e2e/testcases/application/user-conditional-form-flow.spec.ts
+++ b/e2e/testcases/application/user-conditional-form-flow.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect, type Page } from '@playwright/test'
-import { continueForm, formatName, getRandomDate, login } from '../../helpers'
+import {
+  continueForm,
+  formatName,
+  getRandomDate,
+  login,
+  selectDeclarationAction
+} from '../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../constants'
 
@@ -86,10 +92,8 @@ test.describe.serial('1. User conditional form flow', () => {
       ).toHaveText('Yes')
     })
 
-    test('1.1.5 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('1.1.5 Declare', async () => {
+      await selectDeclarationAction(page, 'Declare')
 
       await ensureOutboxIsEmpty(page)
 

--- a/e2e/testcases/application/workqueue-flow-1.spec.ts
+++ b/e2e/testcases/application/workqueue-flow-1.spec.ts
@@ -6,7 +6,8 @@ import {
   formatName,
   getRandomDate,
   goToSection,
-  login
+  login,
+  selectDeclarationAction
 } from '../../helpers'
 import { CREDENTIALS } from '../../constants'
 import {
@@ -128,11 +129,8 @@ test.describe.serial('1. Workqueue flow - 1', () => {
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('1.1.4 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
-
+    test('1.1.4 Notify', async () => {
+      await selectDeclarationAction(page, 'Notify')
       await ensureOutboxIsEmpty(page)
     })
 
@@ -261,13 +259,11 @@ test.describe.serial('1. Workqueue flow - 1', () => {
         .click()
 
       await page.locator('#father____addressSameAs_YES').click()
+      await page.getByRole('button', { name: 'Back to review' }).click()
     })
 
-    test('1.2.6 Send for approval', async () => {
-      await goToSection(page, 'review')
-
-      await page.getByRole('button', { name: 'Send for approval' }).click()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('1.2.6 Validate', async () => {
+      await selectDeclarationAction(page, 'Validate')
 
       await ensureOutboxIsEmpty(page)
 

--- a/e2e/testcases/application/workqueue-flow-2.spec.ts
+++ b/e2e/testcases/application/workqueue-flow-2.spec.ts
@@ -14,6 +14,7 @@ import {
   ensureOutboxIsEmpty,
   selectAction
 } from '../../utils'
+import { selectDeclarationAction } from '../../helpers'
 import { assertRecordInWorkqueue, fillDate } from '../birth/helpers'
 
 // FA Notifies => LR Registers
@@ -126,11 +127,8 @@ test.describe.serial('2. Workqueue flow - 2', () => {
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('2.1.4 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
-
+    test('2.1.4 Notify', async () => {
+      await selectDeclarationAction(page, 'Notify')
       await ensureOutboxIsEmpty(page)
     })
 
@@ -262,9 +260,7 @@ test.describe.serial('2. Workqueue flow - 2', () => {
 
     test('2.2.6 Register', async () => {
       await goToSection(page, 'review')
-
-      await page.getByRole('button', { name: 'Register' }).click()
-      await page.locator('#confirm_Declare').click()
+      await selectDeclarationAction(page, 'Register')
 
       await ensureOutboxIsEmpty(page)
       await ensureInExternalValidationIsEmpty(page)

--- a/e2e/testcases/application/workqueue-flow-3.spec.ts
+++ b/e2e/testcases/application/workqueue-flow-3.spec.ts
@@ -209,7 +209,7 @@ test.describe.serial('3. Workqueue flow - 3', () => {
     })
   })
 
-  test.describe('3.3 Re-notify by FA', async () => {
+  test.describe('3.3 Declare by FA', async () => {
     test('3.3.1 Login', async () => {
       await login(page, CREDENTIALS.FIELD_AGENT, true)
       await assertRecordInWorkqueue({
@@ -314,11 +314,11 @@ test.describe.serial('3. Workqueue flow - 3', () => {
       await page.locator('#father____addressSameAs_YES').click()
     })
 
-    test('3.3.6 Notify', async () => {
+    test('3.3.6 Declare', async () => {
       await continueForm(page, 'Back to review')
       await expect(page.getByRole('dialog')).not.toBeVisible()
 
-      await selectDeclarationAction(page, 'Notify')
+      await selectDeclarationAction(page, 'Declare')
 
       await ensureOutboxIsEmpty(page)
     })

--- a/e2e/testcases/application/workqueue-flow-3.spec.ts
+++ b/e2e/testcases/application/workqueue-flow-3.spec.ts
@@ -6,7 +6,8 @@ import {
   formatName,
   getRandomDate,
   goToSection,
-  login
+  login,
+  selectDeclarationAction
 } from '../../helpers'
 import { CREDENTIALS } from '../../constants'
 import {
@@ -135,10 +136,8 @@ test.describe.serial('3. Workqueue flow - 3', () => {
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('3.1.4 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('3.1.4 Notify', async () => {
+      await selectDeclarationAction(page, 'Notify')
 
       await ensureOutboxIsEmpty(page)
     })
@@ -187,7 +186,7 @@ test.describe.serial('3. Workqueue flow - 3', () => {
 
       await selectAction(page, 'Review')
 
-      await page.getByRole('button', { name: 'Reject' }).click()
+      await selectDeclarationAction(page, 'Reject', false)
 
       await page.getByTestId('reject-reason').fill(faker.lorem.sentence())
 
@@ -315,14 +314,11 @@ test.describe.serial('3. Workqueue flow - 3', () => {
       await page.locator('#father____addressSameAs_YES').click()
     })
 
-    test('3.3.6 Send for review', async () => {
+    test('3.3.6 Notify', async () => {
       await continueForm(page, 'Back to review')
-
       await expect(page.getByRole('dialog')).not.toBeVisible()
 
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+      await selectDeclarationAction(page, 'Notify')
 
       await ensureOutboxIsEmpty(page)
     })
@@ -414,7 +410,7 @@ test.describe.serial('3. Workqueue flow - 3', () => {
         .getByRole('button', { name: 'Review' })
         .click()
 
-      await selectAction(page, 'Reject')
+      await selectDeclarationAction(page, 'Reject', false)
 
       await page.getByTestId('reject-reason').fill(faker.lorem.sentence())
 

--- a/e2e/testcases/application/workqueue-flow-4.spec.ts
+++ b/e2e/testcases/application/workqueue-flow-4.spec.ts
@@ -6,7 +6,8 @@ import {
   formatName,
   getRandomDate,
   goToSection,
-  login
+  login,
+  selectDeclarationAction
 } from '../../helpers'
 import { CREDENTIALS } from '../../constants'
 import {
@@ -204,10 +205,8 @@ test.describe.serial('4. Workqueue flow - 4', () => {
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('4.1.7 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('4.1.7 Declare', async () => {
+      await selectDeclarationAction(page, 'Declare')
 
       await ensureOutboxIsEmpty(page)
     })

--- a/e2e/testcases/archival/basic-archival.spec.ts
+++ b/e2e/testcases/archival/basic-archival.spec.ts
@@ -6,7 +6,8 @@ import {
   getRandomDate,
   goToSection,
   login,
-  logout
+  logout,
+  selectDeclarationAction
 } from '../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../constants'
@@ -255,10 +256,8 @@ test.describe.serial('Basic Archival flow', () => {
       .click()
   })
 
-  test('Send for review', async () => {
-    await page.getByRole('button', { name: 'Send for review' }).click()
-    await page.getByRole('button', { name: 'Confirm' }).click()
-
+  test('Declare', async () => {
+    await selectDeclarationAction(page, 'Declare')
     await ensureOutboxIsEmpty(page)
   })
 

--- a/e2e/testcases/birth/1-birth-event-declaration.spec.ts
+++ b/e2e/testcases/birth/1-birth-event-declaration.spec.ts
@@ -2,7 +2,7 @@ import { expect, test, type Page } from '@playwright/test'
 import { login } from '../../helpers'
 import path from 'path'
 import { faker } from '@faker-js/faker'
-import { ensureOutboxIsEmpty, selectAction } from '../../utils'
+import { ensureOutboxIsEmpty, expectInUrl, selectAction } from '../../utils'
 import { REQUIRED_VALIDATION_ERROR } from './helpers'
 import { trackAndDeleteCreatedEvents } from '../test-data/eventDeletion'
 
@@ -387,21 +387,14 @@ test.describe.serial('1. Birth event declaration', () => {
 
       test('1.8.3 click continue', async () => {
         await page.getByRole('button', { name: 'Continue' }).click()
-
-        /*
-         * Expected result: should navigate to "Review" page
-         */
-        await expect(
-          page
-            .getByRole('button', { name: 'Send for review' })
-            .or(page.getByRole('button', { name: 'Register' }))
-        ).toBeVisible()
+        await expectInUrl(page, `/review`)
       })
     })
 
     test.describe('1.9 Validate "Save & Exit" Button  ', async () => {
-      test('1.9.1 Click the "Save & Exit" button from any page', async () => {
-        await page.getByRole('button', { name: 'Save & Exit' }).click()
+      test('1.9.1 Click the "Save & Exit" button from review page', async () => {
+        await page.getByRole('button', { name: 'Action' }).click()
+        await page.getByText('Save & Exit', { exact: true }).click()
 
         /*
          * Expected result: should open modal with:
@@ -439,7 +432,9 @@ test.describe.serial('1. Birth event declaration', () => {
       })
 
       test('1.9.3 Click Confirm', async () => {
-        await page.getByRole('button', { name: 'Save & Exit' }).click()
+        await page.getByRole('button', { name: 'Action' }).click()
+        await page.getByText('Save & Exit', { exact: true }).click()
+
         await page.getByRole('button', { name: 'Confirm' }).click()
 
         /*
@@ -475,6 +470,7 @@ test.describe.serial('1. Birth event declaration', () => {
       })
     })
   })
+
   test.describe('1.10 Validate "Exit" Button', async () => {
     test.beforeEach(async ({ page }) => {
       await login(page)

--- a/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
@@ -12,7 +12,8 @@ import {
 } from '../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../constants'
-import { fillDate, selectDeclarationAction } from './helpers'
+import { fillDate } from './helpers'
+import { selectDeclarationAction } from '../../helpers'
 import { ensureOutboxIsEmpty, selectAction } from '../../utils'
 
 test.describe.serial('8. Validate declaration review page', () => {

--- a/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
@@ -14,7 +14,7 @@ import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../constants'
 import { fillDate } from './helpers'
 import { selectDeclarationAction } from '../../helpers'
-import { ensureOutboxIsEmpty, selectAction } from '../../utils'
+import { ensureAssigned, ensureOutboxIsEmpty, selectAction } from '../../utils'
 
 test.describe.serial('8. Validate declaration review page', () => {
   let page: Page
@@ -892,18 +892,6 @@ test.describe.serial('8. Validate declaration review page', () => {
     test('8.2.2 Validate', async () => {
       await selectAction(page, 'Validate')
     })
-
-    test('8.2.3 Confirm the declaration to send for approval', async () => {
-      await page.getByRole('button', { name: 'Confirm' }).click()
-      await ensureOutboxIsEmpty(page)
-      await page.getByText('Sent for approval').click()
-
-      await expect(
-        page.getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-      ).toBeVisible()
-    })
   })
 
   test.describe('8.3 Local registrar actions', async () => {
@@ -1146,6 +1134,7 @@ test.describe.serial('8. Validate declaration review page', () => {
     })
 
     test('8.3.1.2 Register', async () => {
+      await ensureAssigned(page)
       await selectAction(page, 'Register')
       await page.getByRole('button', { name: 'Confirm' }).click()
     })

--- a/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
@@ -12,7 +12,7 @@ import {
 } from '../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../constants'
-import { fillDate } from './helpers'
+import { fillDate, selectDeclarationAction } from './helpers'
 import { ensureOutboxIsEmpty, selectAction } from '../../utils'
 
 test.describe.serial('8. Validate declaration review page', () => {
@@ -860,14 +860,12 @@ test.describe.serial('8. Validate declaration review page', () => {
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('8.1.7 Click send button', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
+    test('8.1.7 Declare', async () => {
+      await selectDeclarationAction(page, 'Declare', true)
+      await ensureOutboxIsEmpty(page)
     })
 
     test('8.1.8 Confirm the declaration to send for review', async () => {
-      await page.getByRole('button', { name: 'Confirm' }).click()
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Sent for review').click()
 
       await expect(

--- a/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
@@ -891,6 +891,18 @@ test.describe.serial('8. Validate declaration review page', () => {
     })
     test('8.2.2 Validate', async () => {
       await selectAction(page, 'Validate')
+      await page.getByRole('button', { name: 'Confirm' }).click()
+    })
+
+    test('8.2.3 Confirm the declaration is in Sent for approval workqueue', async () => {
+      await ensureOutboxIsEmpty(page)
+      await page.getByText('Sent for approval').click()
+
+      await expect(
+        page.getByRole('button', {
+          name: formatName(declaration.child.name)
+        })
+      ).toBeVisible()
     })
   })
 

--- a/e2e/testcases/birth/declarations/add-mother-details-on-review.spec.ts
+++ b/e2e/testcases/birth/declarations/add-mother-details-on-review.spec.ts
@@ -11,7 +11,8 @@ import {
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
 import { ensureOutboxIsEmpty, selectAction } from '../../../utils'
-import { REQUIRED_VALIDATION_ERROR, selectDeclarationAction } from '../helpers'
+import { REQUIRED_VALIDATION_ERROR } from '../helpers'
+import { selectDeclarationAction } from '../../../helpers'
 
 test.describe.serial('Add mother details on review', () => {
   let page: Page
@@ -218,7 +219,7 @@ test.describe.serial('Add mother details on review', () => {
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('Send for review', async () => {
+    test('Declare', async () => {
       await selectDeclarationAction(page, 'Declare')
 
       await ensureOutboxIsEmpty(page)

--- a/e2e/testcases/birth/declarations/add-mother-details-on-review.spec.ts
+++ b/e2e/testcases/birth/declarations/add-mother-details-on-review.spec.ts
@@ -11,7 +11,7 @@ import {
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
 import { ensureOutboxIsEmpty, selectAction } from '../../../utils'
-import { REQUIRED_VALIDATION_ERROR } from '../helpers'
+import { REQUIRED_VALIDATION_ERROR, selectDeclarationAction } from '../helpers'
 
 test.describe.serial('Add mother details on review', () => {
   let page: Page
@@ -219,8 +219,7 @@ test.describe.serial('Add mother details on review', () => {
     })
 
     test('Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+      await selectDeclarationAction(page, 'Declare')
 
       await ensureOutboxIsEmpty(page)
 

--- a/e2e/testcases/birth/declarations/birth-declaration-1.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-1.spec.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import { fillDate, validateAddress } from '../helpers'
+import { fillDate, selectDeclarationAction, validateAddress } from '../helpers'
 import { ensureAssigned, ensureOutboxIsEmpty } from '../../../utils'
 
 test.describe.serial('1. Birth declaration case - 1', () => {
@@ -474,10 +474,8 @@ test.describe.serial('1. Birth declaration case - 1', () => {
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('1.1.8 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('1.1.8 Declare', async () => {
+      await selectDeclarationAction(page, 'Declare')
 
       await ensureOutboxIsEmpty(page)
 

--- a/e2e/testcases/birth/declarations/birth-declaration-1.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-1.spec.ts
@@ -12,7 +12,8 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import { fillDate, selectDeclarationAction, validateAddress } from '../helpers'
+import { fillDate, validateAddress } from '../helpers'
+import { selectDeclarationAction } from '../../../helpers'
 import { ensureAssigned, ensureOutboxIsEmpty } from '../../../utils'
 
 test.describe.serial('1. Birth declaration case - 1', () => {

--- a/e2e/testcases/birth/declarations/birth-declaration-10.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-10.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import { REQUIRED_VALIDATION_ERROR } from '../helpers'
+import { REQUIRED_VALIDATION_ERROR, selectDeclarationAction } from '../helpers'
 import { ensureOutboxIsEmpty } from '../../../utils'
 test.describe.serial('10. Birth declaration case - 10', () => {
   let page: Page
@@ -175,10 +175,8 @@ test.describe.serial('10. Birth declaration case - 10', () => {
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('10.1.8 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('10.1.8 Notify', async () => {
+      await selectDeclarationAction(page, 'Notify')
 
       await ensureOutboxIsEmpty(page)
       await page.getByText('Sent for review').click()

--- a/e2e/testcases/birth/declarations/birth-declaration-10.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-10.spec.ts
@@ -9,7 +9,8 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import { REQUIRED_VALIDATION_ERROR, selectDeclarationAction } from '../helpers'
+import { REQUIRED_VALIDATION_ERROR } from '../helpers'
+import { selectDeclarationAction } from '../../../helpers'
 import { ensureOutboxIsEmpty } from '../../../utils'
 test.describe.serial('10. Birth declaration case - 10', () => {
   let page: Page

--- a/e2e/testcases/birth/declarations/birth-declaration-2.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-2.spec.ts
@@ -12,7 +12,7 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import { validateAddress } from '../helpers'
+import { selectDeclarationAction, validateAddress } from '../helpers'
 import { ensureOutboxIsEmpty } from '../../../utils'
 
 test.describe.serial('2. Birth declaration case - 2', () => {
@@ -535,6 +535,17 @@ test.describe.serial('2. Birth declaration case - 2', () => {
       )
     })
 
+    test('2.1.6.1 Validate declare action not available before filling in signature and comment', async () => {
+      await page.getByRole('button', { name: 'Action' }).click()
+      const declareButton = page.getByText('Declare', { exact: true })
+      await expect(declareButton).toBeVisible()
+      await expect(declareButton).toHaveAttribute('disabled')
+
+      const notifyButton = page.getByText('Notify', { exact: true })
+      await expect(notifyButton).toBeVisible()
+      await expect(notifyButton).not.toHaveAttribute('disabled')
+    })
+
     test('2.1.7 Fill up informant comment & signature', async () => {
       await page.locator('#review____comment').fill(faker.lorem.sentence())
       await page.getByRole('button', { name: 'Sign', exact: true }).click()
@@ -547,10 +558,8 @@ test.describe.serial('2. Birth declaration case - 2', () => {
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('2.1.8 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('2.1.8 Declare', async () => {
+      await selectDeclarationAction(page, 'Declare')
 
       await ensureOutboxIsEmpty(page)
 

--- a/e2e/testcases/birth/declarations/birth-declaration-2.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-2.spec.ts
@@ -8,7 +8,8 @@ import {
   goToSection,
   login,
   switchEventTab,
-  expectRowValue
+  expectRowValue,
+  validateActionMenuButton
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
@@ -537,14 +538,8 @@ test.describe.serial('2. Birth declaration case - 2', () => {
     })
 
     test('2.1.6.1 Validate declare action not available before filling in signature and comment', async () => {
-      await page.getByRole('button', { name: 'Action' }).click()
-      const declareButton = page.getByText('Declare', { exact: true })
-      await expect(declareButton).toBeVisible()
-      await expect(declareButton).toHaveAttribute('disabled')
-
-      const notifyButton = page.getByText('Notify', { exact: true })
-      await expect(notifyButton).toBeVisible()
-      await expect(notifyButton).not.toHaveAttribute('disabled')
+      await validateActionMenuButton(page, 'Declare', false)
+      await validateActionMenuButton(page, 'Notify', true)
     })
 
     test('2.1.7 Fill up informant comment & signature', async () => {

--- a/e2e/testcases/birth/declarations/birth-declaration-2.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-2.spec.ts
@@ -12,7 +12,8 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import { selectDeclarationAction, validateAddress } from '../helpers'
+import { validateAddress } from '../helpers'
+import { selectDeclarationAction } from '../../../helpers'
 import { ensureOutboxIsEmpty } from '../../../utils'
 
 test.describe.serial('2. Birth declaration case - 2', () => {

--- a/e2e/testcases/birth/declarations/birth-declaration-3.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-3.spec.ts
@@ -14,7 +14,8 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import { fillDate, selectDeclarationAction, validateAddress } from '../helpers'
+import { fillDate, validateAddress } from '../helpers'
+import { selectDeclarationAction } from '../../../helpers'
 import { ensureOutboxIsEmpty } from '../../../utils'
 
 test.describe.serial('3. Birth declaration case - 3', () => {

--- a/e2e/testcases/birth/declarations/birth-declaration-3.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-3.spec.ts
@@ -14,7 +14,7 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import { fillDate, validateAddress } from '../helpers'
+import { fillDate, selectDeclarationAction, validateAddress } from '../helpers'
 import { ensureOutboxIsEmpty } from '../../../utils'
 
 test.describe.serial('3. Birth declaration case - 3', () => {
@@ -710,11 +710,8 @@ test.describe.serial('3. Birth declaration case - 3', () => {
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('3.1.9 Send for approval', async () => {
-      await page.getByRole('button', { name: 'Send for approval' }).click()
-      await expect(page.getByText('Send for approval?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
-
+    test('3.1.9 Validate', async () => {
+      await selectDeclarationAction(page, 'Validate')
       await ensureOutboxIsEmpty(page)
 
       await page.getByText('Sent for approval').click()

--- a/e2e/testcases/birth/declarations/birth-declaration-4.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-4.spec.ts
@@ -8,6 +8,7 @@ import {
   goToSection,
   login,
   logout,
+  selectDeclarationAction,
   switchEventTab
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
@@ -623,10 +624,8 @@ test.describe.serial('4. Birth declaration case - 4', () => {
 
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
-    test('4.1.8 Send for approval', async () => {
-      await page.getByRole('button', { name: 'Send for approval' }).click()
-      await expect(page.getByText('Send for approval?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('4.1.8 Validate', async () => {
+      await selectDeclarationAction(page, 'Validate')
 
       await ensureOutboxIsEmpty(page)
 

--- a/e2e/testcases/birth/declarations/birth-declaration-5.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-5.spec.ts
@@ -6,7 +6,8 @@ import {
   formatName,
   getRandomDate,
   goToSection,
-  login
+  login,
+  selectDeclarationAction
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
@@ -512,9 +513,7 @@ test.describe.serial('5. Birth declaration case - 5', () => {
     })
 
     test('5.1.8 Register', async () => {
-      await page.getByRole('button', { name: 'Register' }).click()
-      await page.locator('#confirm_Declare').click()
-
+      await selectDeclarationAction(page, 'Register')
       await ensureOutboxIsEmpty(page)
 
       await page.getByText('Ready to print').click()

--- a/e2e/testcases/birth/declarations/birth-declaration-7.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-7.spec.ts
@@ -6,6 +6,7 @@ import {
   goToSection,
   login,
   logout,
+  selectDeclarationAction,
   switchEventTab,
   uploadImage,
   uploadImageToSection
@@ -227,10 +228,8 @@ test.describe.serial('7. Birth declaration case - 7', () => {
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('7.1.9 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('7.1.9 Declare', async () => {
+      await selectDeclarationAction(page, 'Declare')
 
       await ensureOutboxIsEmpty(page)
 

--- a/e2e/testcases/birth/declarations/birth-declaration-7.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-7.spec.ts
@@ -228,8 +228,8 @@ test.describe.serial('7. Birth declaration case - 7', () => {
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('7.1.9 Declare', async () => {
-      await selectDeclarationAction(page, 'Declare')
+    test('7.1.9 Notify', async () => {
+      await selectDeclarationAction(page, 'Notify')
 
       await ensureOutboxIsEmpty(page)
 

--- a/e2e/testcases/birth/declarations/birth-declaration-8.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-8.spec.ts
@@ -6,6 +6,7 @@ import {
   goToSection,
   login,
   logout,
+  selectDeclarationAction,
   switchEventTab
 } from '../../../helpers'
 import { CREDENTIALS } from '../../../constants'
@@ -257,10 +258,8 @@ test.describe.serial('8. Birth declaration case - 8', () => {
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('8.1.8 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('8.1.8 Declare', async () => {
+      await selectDeclarationAction(page, 'Declare')
 
       await ensureOutboxIsEmpty(page)
 

--- a/e2e/testcases/birth/declarations/birth-declaration-8.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-8.spec.ts
@@ -258,8 +258,8 @@ test.describe.serial('8. Birth declaration case - 8', () => {
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('8.1.8 Declare', async () => {
-      await selectDeclarationAction(page, 'Declare')
+    test('8.1.8 Notify', async () => {
+      await selectDeclarationAction(page, 'Notify')
 
       await ensureOutboxIsEmpty(page)
 

--- a/e2e/testcases/birth/declarations/birth-declaration-9.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-9.spec.ts
@@ -178,8 +178,8 @@ test.describe.serial('9. Birth declaration case - 9', () => {
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('9.1.8 Declare', async () => {
-      await selectDeclarationAction(page, 'Declare')
+    test('9.1.8 Notify', async () => {
+      await selectDeclarationAction(page, 'Notify')
 
       await ensureOutboxIsEmpty(page)
       await page.getByText('Sent for review').click()

--- a/e2e/testcases/birth/declarations/birth-declaration-9.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-9.spec.ts
@@ -5,6 +5,7 @@ import {
   formatName,
   goToSection,
   login,
+  selectDeclarationAction,
   switchEventTab
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
@@ -177,10 +178,8 @@ test.describe.serial('9. Birth declaration case - 9', () => {
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('9.1.8 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('9.1.8 Declare', async () => {
+      await selectDeclarationAction(page, 'Declare')
 
       await ensureOutboxIsEmpty(page)
       await page.getByText('Sent for review').click()

--- a/e2e/testcases/birth/declarations/change-informant-on-review.spec.ts
+++ b/e2e/testcases/birth/declarations/change-informant-on-review.spec.ts
@@ -6,7 +6,8 @@ import {
   getRandomDate,
   goToSection,
   login,
-  logout
+  logout,
+  selectDeclarationAction
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
@@ -242,10 +243,8 @@ test.describe.serial('Change informant on review', () => {
       await expect(page.getByRole('dialog')).not.toBeVisible()
     })
 
-    test('Send for approval', async () => {
-      await page.getByRole('button', { name: 'Send for approval' }).click()
-      await page.getByRole('button', { name: 'Confirm' }).click()
-
+    test('Validate', async () => {
+      await selectDeclarationAction(page, 'Validate')
       await ensureOutboxIsEmpty(page)
 
       await page.getByText('Sent for approval').click()

--- a/e2e/testcases/birth/declarations/submit-incomplete.spec.ts
+++ b/e2e/testcases/birth/declarations/submit-incomplete.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect, type Page } from '@playwright/test'
-import { formatName, goToSection, login } from '../../../helpers'
+import {
+  formatName,
+  goToSection,
+  login,
+  selectDeclarationAction
+} from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS, SAFE_WORKQUEUE_TIMEOUT_MS } from '../../../constants'
 import { ensureOutboxIsEmpty } from '../../../utils'
@@ -47,10 +52,7 @@ test.describe.serial('Submit and verify incomplete birth declaration', () => {
 
     test('Go to review and send for review', async () => {
       await goToSection(page, 'review')
-      await page
-        .getByRole('button', { name: 'Send for review', exact: true })
-        .click()
-      await page.getByRole('button', { name: 'Confirm', exact: true }).click()
+      await selectDeclarationAction(page, 'Notify')
     })
 
     test('Verify summary page', async () => {

--- a/e2e/testcases/birth/helpers.ts
+++ b/e2e/testcases/birth/helpers.ts
@@ -129,3 +129,16 @@ export function getLocationIdByName(locations: fhir.Location[], name: string) {
   }
   return location.id
 }
+
+export async function selectDeclarationAction(
+  page: Page,
+  action: string,
+  confirm = true
+) {
+  await page.getByRole('button', { name: 'Action', exact: true }).click()
+  await page.getByText(action, { exact: true }).click()
+
+  if (confirm) {
+    await page.getByRole('button', { name: action, exact: true }).click()
+  }
+}

--- a/e2e/testcases/birth/helpers.ts
+++ b/e2e/testcases/birth/helpers.ts
@@ -129,16 +129,3 @@ export function getLocationIdByName(locations: fhir.Location[], name: string) {
   }
   return location.id
 }
-
-export async function selectDeclarationAction(
-  page: Page,
-  action: string,
-  confirm = true
-) {
-  await page.getByRole('button', { name: 'Action', exact: true }).click()
-  await page.getByText(action, { exact: true }).click()
-
-  if (confirm) {
-    await page.getByRole('button', { name: action, exact: true }).click()
-  }
-}

--- a/e2e/testcases/birth/save-and-delete-drafts.spec.ts
+++ b/e2e/testcases/birth/save-and-delete-drafts.spec.ts
@@ -1,11 +1,8 @@
 import { expect, Page, test } from '@playwright/test'
 import { goToSection, login, logout } from '../../helpers'
 import { CREDENTIALS } from '../../constants'
-import {
-  fillChildDetails,
-  openBirthDeclaration,
-  selectDeclarationAction
-} from './helpers'
+import { fillChildDetails, openBirthDeclaration } from './helpers'
+import { selectDeclarationAction } from '../../helpers'
 import { ensureOutboxIsEmpty } from '../../utils'
 
 /**

--- a/e2e/testcases/birth/save-and-delete-drafts.spec.ts
+++ b/e2e/testcases/birth/save-and-delete-drafts.spec.ts
@@ -1,7 +1,11 @@
 import { expect, Page, test } from '@playwright/test'
 import { goToSection, login, logout } from '../../helpers'
 import { CREDENTIALS } from '../../constants'
-import { fillChildDetails, openBirthDeclaration } from './helpers'
+import {
+  fillChildDetails,
+  openBirthDeclaration,
+  selectDeclarationAction
+} from './helpers'
 import { ensureOutboxIsEmpty } from '../../utils'
 
 /**
@@ -58,8 +62,7 @@ test.describe('Save and delete drafts', () => {
       await page.getByRole('button', { name: 'Action', exact: true }).click()
 
       await page.getByText('Declare').click()
-      await page.locator('#event-menu-dropdownMenu').click()
-      await page.getByText('Delete declaration').click()
+      await selectDeclarationAction(page, 'Delete declaration', false)
       await expect(
         page.getByText('Are you sure you want to delete this declaration?')
       ).toBeVisible()
@@ -84,7 +87,7 @@ test.describe('Save and delete drafts', () => {
     test('Exit without saving', async () => {
       const childName = await fillChildDetails(page)
       await goToSection(page, 'review')
-      await page.getByRole('button', { name: 'Exit', exact: true }).click()
+      await page.getByTestId('exit-button').click()
 
       await expect(
         page.getByText(

--- a/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
@@ -111,7 +111,6 @@ test.describe.serial('Correct record - 4', () => {
         },
         'child.gender': 'male',
         'child.dob': format(subDays(new Date(), 2), 'yyyy-MM-dd'),
-        'child.reason': 'Late',
         'child.placeOfBirth': 'PRIVATE_HOME',
         'child.attendantAtBirth': 'PHYSICIAN',
         'child.birthType': 'SINGLE',

--- a/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
@@ -12,7 +12,7 @@ import {
   createDeclaration as createDeclarationV2,
   Declaration as DeclarationV2
 } from '../test-data/birth-declaration-with-mother-father'
-import { format, subYears } from 'date-fns'
+import { format, subDays, subYears } from 'date-fns'
 import {
   CREDENTIALS,
   SAFE_INPUT_CHANGE_TIMEOUT_MS,
@@ -110,7 +110,7 @@ test.describe.serial('Correct record - 4', () => {
           surname: faker.person.lastName()
         },
         'child.gender': 'male',
-        'child.dob': format(subYears(new Date(), 1), 'yyyy-MM-dd'),
+        'child.dob': format(subDays(new Date(), 2), 'yyyy-MM-dd'),
         'child.reason': 'Late',
         'child.placeOfBirth': 'PRIVATE_HOME',
         'child.attendantAtBirth': 'PHYSICIAN',

--- a/e2e/testcases/correction-birth/correct-birth-record-change-father-id-number.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-change-father-id-number.spec.ts
@@ -11,7 +11,7 @@ import {
   createDeclaration as createDeclarationV2,
   Declaration as DeclarationV2
 } from '../test-data/birth-declaration-with-mother-father'
-import { format, subYears } from 'date-fns'
+import { format, subDays, subYears } from 'date-fns'
 import { CREDENTIALS } from '../../constants'
 import { formatV2ChildName } from '../birth/helpers'
 import { ensureAssigned, selectAction } from '../../utils'
@@ -45,7 +45,7 @@ test.describe.serial("Correct record - Change father's ID number", () => {
           surname: faker.person.lastName()
         },
         'child.gender': 'male',
-        'child.dob': format(subYears(new Date(), 1), 'yyyy-MM-dd'),
+        'child.dob': format(subDays(new Date(), 2), 'yyyy-MM-dd'),
         'child.reason': 'Late',
         'child.placeOfBirth': 'PRIVATE_HOME',
         'child.attendantAtBirth': 'PHYSICIAN',

--- a/e2e/testcases/correction-birth/correct-birth-record-change-father-id-number.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-change-father-id-number.spec.ts
@@ -46,7 +46,6 @@ test.describe.serial("Correct record - Change father's ID number", () => {
         },
         'child.gender': 'male',
         'child.dob': format(subDays(new Date(), 2), 'yyyy-MM-dd'),
-        'child.reason': 'Late',
         'child.placeOfBirth': 'PRIVATE_HOME',
         'child.attendantAtBirth': 'PHYSICIAN',
         'child.birthType': 'SINGLE',

--- a/e2e/testcases/correction-birth/correct-birth-record-change-informant.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-change-informant.spec.ts
@@ -10,7 +10,7 @@ import {
   createDeclaration as createDeclarationV2,
   Declaration as DeclarationV2
 } from '../test-data/birth-declaration-with-mother-father'
-import { format, subYears } from 'date-fns'
+import { format, subDays, subYears } from 'date-fns'
 import {
   CREDENTIALS,
   SAFE_INPUT_CHANGE_TIMEOUT_MS,
@@ -85,7 +85,7 @@ test.describe.serial('Correct record - change informant type', () => {
           surname: faker.person.lastName()
         },
         'child.gender': 'male',
-        'child.dob': format(subYears(new Date(), 1), 'yyyy-MM-dd'),
+        'child.dob': format(subDays(new Date(), 2), 'yyyy-MM-dd'),
         'child.reason': 'Late',
         'child.placeOfBirth': 'PRIVATE_HOME',
         'child.attendantAtBirth': 'PHYSICIAN',

--- a/e2e/testcases/correction-birth/direct-correction-offline.spec.ts
+++ b/e2e/testcases/correction-birth/direct-correction-offline.spec.ts
@@ -40,7 +40,6 @@ test.describe.serial('Direct correction offline', () => {
         },
         'child.gender': 'male',
         'child.dob': format(subDays(new Date(), 2), 'yyyy-MM-dd'),
-        'child.reason': 'Late',
         'child.placeOfBirth': 'PRIVATE_HOME',
         'child.attendantAtBirth': 'PHYSICIAN',
         'child.birthType': 'SINGLE',

--- a/e2e/testcases/correction-birth/direct-correction-offline.spec.ts
+++ b/e2e/testcases/correction-birth/direct-correction-offline.spec.ts
@@ -5,7 +5,7 @@ import {
   createDeclaration as createDeclarationV2,
   Declaration as DeclarationV2
 } from '../test-data/birth-declaration-with-mother-father'
-import { format, subYears } from 'date-fns'
+import { format, subDays, subYears } from 'date-fns'
 import { CREDENTIALS, SAFE_OUTBOX_TIMEOUT_MS } from '../../constants'
 import { formatV2ChildName } from '../birth/helpers'
 import { ensureAssigned } from '../../utils'
@@ -39,7 +39,7 @@ test.describe.serial('Direct correction offline', () => {
           surname: faker.person.lastName()
         },
         'child.gender': 'male',
-        'child.dob': format(subYears(new Date(), 1), 'yyyy-MM-dd'),
+        'child.dob': format(subDays(new Date(), 2), 'yyyy-MM-dd'),
         'child.reason': 'Late',
         'child.placeOfBirth': 'PRIVATE_HOME',
         'child.attendantAtBirth': 'PHYSICIAN',

--- a/e2e/testcases/correction-birth/request-and-accept-correction-offline.spec.ts
+++ b/e2e/testcases/correction-birth/request-and-accept-correction-offline.spec.ts
@@ -5,7 +5,7 @@ import {
   createDeclaration as createDeclarationV2,
   Declaration as DeclarationV2
 } from '../test-data/birth-declaration-with-mother-father'
-import { format, subYears } from 'date-fns'
+import { format, subDays, subYears } from 'date-fns'
 import { CREDENTIALS, SAFE_OUTBOX_TIMEOUT_MS } from '../../constants'
 import { formatV2ChildName } from '../birth/helpers'
 import { ensureAssigned, selectAction, type } from '../../utils'
@@ -39,7 +39,7 @@ test.describe.serial('Request and accept correction (offline)', () => {
           surname: faker.person.lastName()
         },
         'child.gender': 'male',
-        'child.dob': format(subYears(new Date(), 1), 'yyyy-MM-dd'),
+        'child.dob': format(subDays(new Date(), 1), 'yyyy-MM-dd'),
         'child.reason': 'Late',
         'child.placeOfBirth': 'PRIVATE_HOME',
         'child.attendantAtBirth': 'PHYSICIAN',

--- a/e2e/testcases/correction-birth/request-and-accept-correction-offline.spec.ts
+++ b/e2e/testcases/correction-birth/request-and-accept-correction-offline.spec.ts
@@ -40,7 +40,6 @@ test.describe.serial('Request and accept correction (offline)', () => {
         },
         'child.gender': 'male',
         'child.dob': format(subDays(new Date(), 1), 'yyyy-MM-dd'),
-        'child.reason': 'Late',
         'child.placeOfBirth': 'PRIVATE_HOME',
         'child.attendantAtBirth': 'PHYSICIAN',
         'child.birthType': 'SINGLE',

--- a/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration.spec.ts
@@ -5,7 +5,8 @@ import {
   formatName,
   goToSection,
   login,
-  switchEventTab
+  switchEventTab,
+  validateActionMenuButton
 } from '../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../constants'
@@ -171,11 +172,7 @@ test.describe.serial('Approval of late birth registration', () => {
     })
 
     test('Approve action should be disabled before assignment', async () => {
-      await page.getByRole('button', { name: 'Action', exact: true }).click()
-      const approveButton = page.getByText('Approve', { exact: true })
-      await expect(approveButton).toBeVisible()
-      await expect(approveButton).toHaveAttribute('disabled')
-      await page.getByRole('button', { name: 'Action', exact: true }).click()
+      await validateActionMenuButton(page, 'Approve', false)
     })
 
     test('Assign', async () => {
@@ -461,10 +458,8 @@ test.describe
     })
 
     test('Direct registration should be unavailable', async () => {
-      await page.getByRole('button', { name: 'Action', exact: true }).click()
-      const declareButton = page.getByText('Register', { exact: true })
-      await expect(declareButton).toBeVisible()
-      await expect(declareButton).toHaveAttribute('disabled')
+      await validateActionMenuButton(page, 'Declare')
+      await validateActionMenuButton(page, 'Register', false)
     })
 
     test('Change child dob to recent date', async () => {
@@ -479,10 +474,7 @@ test.describe
     })
 
     test('Direct registration should be available', async () => {
-      await page.getByRole('button', { name: 'Action', exact: true }).click()
-      const declareButton = page.getByText('Register', { exact: true })
-      await expect(declareButton).toBeVisible()
-      await expect(declareButton).not.toHaveAttribute('disabled')
+      await validateActionMenuButton(page, 'Register')
     })
   })
 })

--- a/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration.spec.ts
@@ -11,7 +11,7 @@ import {
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../constants'
 import { ensureAssigned, ensureOutboxIsEmpty, selectAction } from '../../utils'
-import { selectDeclarationAction } from '../birth/helpers'
+import { selectDeclarationAction } from '../../helpers'
 import { format, subYears, subMonths, subDays } from 'date-fns'
 
 const recentDate = subDays(new Date(), 2)

--- a/e2e/testcases/death/1-death-event-declaration.spec.ts
+++ b/e2e/testcases/death/1-death-event-declaration.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from '@playwright/test'
-import { login } from '../../helpers'
+import { login, selectDeclarationAction } from '../../helpers'
 import { faker } from '@faker-js/faker'
 import { ensureOutboxIsEmpty, expectInUrl, type } from '../../utils'
 const deceased = {
@@ -370,7 +370,7 @@ test.describe('1. Death event declaration', () => {
 
     test.describe('1.9 Validate "Save & Exit" Button  ', async () => {
       test('1.9.1 Click the "Save & Exit" button from any page', async () => {
-        await page.getByRole('button', { name: 'Save & Exit' }).click()
+        await selectDeclarationAction(page, 'Save & Exit', false)
 
         /*
          * Expected result: should open modal with:
@@ -406,7 +406,7 @@ test.describe('1. Death event declaration', () => {
       })
 
       test('1.9.3 Click Confirm', async () => {
-        await page.getByRole('button', { name: 'Save & Exit' }).click()
+        await selectDeclarationAction(page, 'Save & Exit', false)
         await page.getByRole('button', { name: 'Confirm' }).click()
 
         /*

--- a/e2e/testcases/death/1-death-event-declaration.spec.ts
+++ b/e2e/testcases/death/1-death-event-declaration.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from '@playwright/test'
 import { login } from '../../helpers'
 import { faker } from '@faker-js/faker'
-import { ensureOutboxIsEmpty, type } from '../../utils'
+import { ensureOutboxIsEmpty, expectInUrl, type } from '../../utils'
 const deceased = {
   name: {
     firstname: faker.person.firstName('male')
@@ -364,15 +364,7 @@ test.describe('1. Death event declaration', () => {
 
       test('1.8.3 click continue', async () => {
         await page.getByRole('button', { name: 'Continue' }).click()
-
-        /*
-         * Expected result: should navigate to "Review" page
-         */
-        await expect(
-          page
-            .getByRole('button', { name: 'Send for review' })
-            .or(page.getByRole('button', { name: 'Register' }))
-        ).toBeVisible()
+        await expectInUrl(page, `/review`)
       })
     })
 

--- a/e2e/testcases/death/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/death/8-validate-declaration-review-page.spec.ts
@@ -9,7 +9,8 @@ import {
   formatDateObjectTo_dMMMMyyyy,
   expectRowValue,
   expectRowValueWithChangeButton,
-  switchEventTab
+  switchEventTab,
+  selectDeclarationAction
 } from '../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../constants'
@@ -703,13 +704,11 @@ test.describe.serial('8. Validate declaration review page', () => {
         .click()
     })
 
-    test('8.1.7 Click send button', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
+    test('8.1.7 Notify', async () => {
+      await selectDeclarationAction(page, 'Notify')
     })
 
-    test('8.1.8 Confirm the declaration to send for review', async () => {
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('8.1.8 Validate that declaration is available on "Sent for review"', async () => {
       await ensureOutboxIsEmpty(page)
       await expect(page.getByText('Farajaland CRS')).toBeVisible()
 

--- a/e2e/testcases/death/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/death/8-validate-declaration-review-page.spec.ts
@@ -1173,15 +1173,12 @@ test.describe.serial('8. Validate declaration review page', () => {
       test.skip('Skipped for now', async () => {})
     })
 
-    test('8.2.6 Click send button', async () => {
-      await page.getByRole('button', { name: 'Send for approval' }).click()
-      await expect(page.getByText('Send for approval?')).toBeVisible()
+    test('8.2.6 Validate', async () => {
+      await selectDeclarationAction(page, 'Validate')
+      await ensureOutboxIsEmpty(page)
     })
 
     test('8.2.7 Confirm the declaration to send for approval', async () => {
-      await page.getByRole('button', { name: 'Confirm' }).click()
-      await ensureOutboxIsEmpty(page)
-
       await page.getByText('Sent for approval').click()
       /*
        * @TODO: When workflows are implemented on V2, this should navigate to correct workflow first.

--- a/e2e/testcases/death/death-event-summary.spec.tsx
+++ b/e2e/testcases/death/death-event-summary.spec.tsx
@@ -6,7 +6,8 @@ import {
   getRandomDate,
   goToSection,
   joinValuesWith,
-  login
+  login,
+  selectDeclarationAction
 } from '../../helpers'
 
 test.describe.serial('Death event summary', () => {
@@ -140,7 +141,7 @@ test.describe.serial('Death event summary', () => {
   })
 
   test('Save draft and find it in workqueue', async () => {
-    await page.getByText('Save & Exit', { exact: true }).click()
+    await selectDeclarationAction(page, 'Save & Exit', false)
     await page.getByText('Confirm', { exact: true }).click()
 
     await page.getByRole('button', { name: 'My drafts' }).click()

--- a/e2e/testcases/death/declaration/death-declaration-1.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-1.spec.ts
@@ -8,7 +8,8 @@ import {
   goToSection,
   login,
   switchEventTab,
-  expectRowValue
+  expectRowValue,
+  selectDeclarationAction
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
@@ -443,10 +444,8 @@ test.describe.serial('1. Death declaration case - 1', () => {
         .click()
     })
 
-    test('1.1.8 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('1.1.8 Declare', async () => {
+      await selectDeclarationAction(page, 'Declare')
       await ensureOutboxIsEmpty(page)
       await expect(page.getByText('Farajaland CRS')).toBeVisible()
 

--- a/e2e/testcases/death/declaration/death-declaration-10.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-10.spec.ts
@@ -4,7 +4,8 @@ import {
   drawSignature,
   expectRowValueWithChangeButton,
   goToSection,
-  login
+  login,
+  selectDeclarationAction
 } from '../../../helpers'
 import { CREDENTIALS } from '../../../constants'
 import { ensureOutboxIsEmpty, selectAction } from '../../../utils'
@@ -244,10 +245,8 @@ test.describe.serial('10. Death declaration case - 10', () => {
         .click()
     })
 
-    test('10.1.7 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('10.1.7 Notify', async () => {
+      await selectDeclarationAction(page, 'Notify')
       await ensureOutboxIsEmpty(page)
       await expect(page.getByText('Farajaland CRS')).toBeVisible()
 

--- a/e2e/testcases/death/declaration/death-declaration-11.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-11.spec.ts
@@ -8,7 +8,8 @@ import {
   goToSection,
   login,
   switchEventTab,
-  expectRowValue
+  expectRowValue,
+  selectDeclarationAction
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
@@ -631,10 +632,8 @@ test.describe.serial('11. Death declaration case - 11', () => {
         .click()
     })
 
-    test('11.1.8 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('11.1.8 Declare', async () => {
+      await selectDeclarationAction(page, 'Declare')
       await ensureOutboxIsEmpty(page)
       await expect(page.getByText('Farajaland CRS')).toBeVisible()
 

--- a/e2e/testcases/death/declaration/death-declaration-2.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-2.spec.ts
@@ -8,7 +8,8 @@ import {
   login,
   switchEventTab,
   uploadImageToSection,
-  expectRowValue
+  expectRowValue,
+  selectDeclarationAction
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
@@ -673,10 +674,8 @@ test.describe.serial('2. Death declaration case - 2', () => {
         .click()
     })
 
-    test('2.1.8 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('2.1.8 Declare', async () => {
+      await selectDeclarationAction(page, 'Declare')
       await ensureOutboxIsEmpty(page)
       await expect(page.getByText('Farajaland CRS')).toBeVisible()
 

--- a/e2e/testcases/death/declaration/death-declaration-3.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-3.spec.ts
@@ -8,6 +8,7 @@ import {
   getRandomDate,
   goToSection,
   login,
+  selectDeclarationAction,
   switchEventTab
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
@@ -631,10 +632,8 @@ test.describe.serial('3. Death declaration case - 3', () => {
         .click()
     })
 
-    test('3.1.8 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('3.1.8 Declare', async () => {
+      await selectDeclarationAction(page, 'Declare')
       await ensureOutboxIsEmpty(page)
       await expect(page.getByText('Farajaland CRS')).toBeVisible()
 

--- a/e2e/testcases/death/declaration/death-declaration-4.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-4.spec.ts
@@ -8,7 +8,8 @@ import {
   login,
   switchEventTab,
   uploadImageToSection,
-  expectRowValue
+  expectRowValue,
+  selectDeclarationAction
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
@@ -689,10 +690,8 @@ test.describe.serial('4. Death declaration case - 4', () => {
         .click()
     })
 
-    test('4.1.8 Send for approval', async () => {
-      await page.getByRole('button', { name: 'Send for approval' }).click()
-      await expect(page.getByText('Send for approval?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('4.1.8 Validate', async () => {
+      await selectDeclarationAction(page, 'Validate')
       await ensureOutboxIsEmpty(page)
       await expect(page.getByText('Farajaland CRS')).toBeVisible()
 

--- a/e2e/testcases/death/declaration/death-declaration-5.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-5.spec.ts
@@ -8,7 +8,8 @@ import {
   goToSection,
   login,
   switchEventTab,
-  expectRowValue
+  expectRowValue,
+  selectDeclarationAction
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
@@ -526,10 +527,8 @@ test.describe.serial('5. Death declaration case - 5', () => {
         .click()
     })
 
-    test('5.1.8 Send for approval', async () => {
-      await page.getByRole('button', { name: 'Send for approval' }).click()
-      await expect(page.getByText('Send for approval?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('5.1.8 Validate', async () => {
+      await selectDeclarationAction(page, 'Validate')
       await ensureOutboxIsEmpty(page)
       await expect(page.getByText('Farajaland CRS')).toBeVisible()
 

--- a/e2e/testcases/death/declaration/death-declaration-6.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-6.spec.ts
@@ -7,6 +7,7 @@ import {
   getRandomDate,
   goToSection,
   login,
+  selectDeclarationAction,
   switchEventTab
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
@@ -531,9 +532,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
     })
 
     test('6.1.8 Register', async () => {
-      await page.getByRole('button', { name: 'Register' }).click()
-      await expect(page.getByText('Register the death?')).toBeVisible()
-      await page.locator('#confirm_Declare').click()
+      await selectDeclarationAction(page, 'Register')
       await ensureOutboxIsEmpty(page)
       await expect(page.getByText('Farajaland CRS')).toBeVisible()
 

--- a/e2e/testcases/death/declaration/death-declaration-7.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-7.spec.ts
@@ -7,6 +7,7 @@ import {
   getRandomDate,
   goToSection,
   login,
+  selectDeclarationAction,
   switchEventTab
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
@@ -532,9 +533,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
     })
 
     test('7.1.8 Register', async () => {
-      await page.getByRole('button', { name: 'Register' }).click()
-      await expect(page.getByText('Register the death?')).toBeVisible()
-      await page.locator('#confirm_Declare').click()
+      await selectDeclarationAction(page, 'Register')
       await ensureOutboxIsEmpty(page)
       await expect(page.getByText('Farajaland CRS')).toBeVisible()
 

--- a/e2e/testcases/death/declaration/death-declaration-8.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-8.spec.ts
@@ -4,7 +4,8 @@ import {
   drawSignature,
   expectRowValueWithChangeButton,
   goToSection,
-  login
+  login,
+  selectDeclarationAction
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
@@ -259,10 +260,8 @@ test.describe.serial('8. Death declaration case - 8', () => {
         .click()
     })
 
-    test('8.1.7 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('8.1.7 Notify', async () => {
+      await selectDeclarationAction(page, 'Notify')
       await ensureOutboxIsEmpty(page)
       await expect(page.getByText('Farajaland CRS')).toBeVisible()
 

--- a/e2e/testcases/death/declaration/death-declaration-9.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-9.spec.ts
@@ -4,7 +4,8 @@ import {
   drawSignature,
   expectRowValueWithChangeButton,
   goToSection,
-  login
+  login,
+  selectDeclarationAction
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
@@ -259,10 +260,8 @@ test.describe.serial('9. Death declaration case - 9', () => {
         .click()
     })
 
-    test('9.1.7 Send for review', async () => {
-      await page.getByRole('button', { name: 'Send for review' }).click()
-      await expect(page.getByText('Send for review?')).toBeVisible()
-      await page.getByRole('button', { name: 'Confirm' }).click()
+    test('9.1.7 Notify', async () => {
+      await selectDeclarationAction(page, 'Notify')
       await ensureOutboxIsEmpty(page)
       await expect(page.getByText('Farajaland CRS')).toBeVisible()
 

--- a/e2e/testcases/events-rest-api/create-and-notify-event.spec.ts
+++ b/e2e/testcases/events-rest-api/create-and-notify-event.spec.ts
@@ -13,7 +13,9 @@ import {
   getClientToken,
   getToken,
   login,
-  switchEventTab
+  selectDeclarationAction,
+  switchEventTab,
+  validateActionMenuButton
 } from '../../helpers'
 import { addDays, format, subDays } from 'date-fns'
 import { faker } from '@faker-js/faker'
@@ -815,9 +817,7 @@ test.describe('Events REST API', () => {
         REQUIRED_VALIDATION_ERROR
       )
 
-      await expect(
-        page.getByRole('button', { name: 'Register' })
-      ).toBeDisabled()
+      await validateActionMenuButton(page, 'Register', false)
     })
 
     test('Fill missing child dob field', async () => {
@@ -858,8 +858,7 @@ test.describe('Events REST API', () => {
     })
 
     test('Register event', async () => {
-      await page.getByRole('button', { name: 'Register', exact: true }).click()
-      await page.locator('#confirm_Declare').click()
+      await selectDeclarationAction(page, 'Register')
     })
 
     test("Navigate to event via 'Ready to print' -workqueue", async () => {
@@ -975,7 +974,7 @@ test.describe('Events REST API', () => {
     })
 
     test('Reject event', async () => {
-      await page.getByRole('button', { name: 'Reject' }).click()
+      await selectDeclarationAction(page, 'Reject', false)
       await page.getByTestId('reject-reason').fill(faker.lorem.sentence())
       await page.getByRole('button', { name: 'Send For Update' }).click()
     })

--- a/e2e/testcases/form-state/form-state.spec.ts
+++ b/e2e/testcases/form-state/form-state.spec.ts
@@ -1,5 +1,11 @@
 import { expect, Page, test } from '@playwright/test'
-import { drawSignature, getToken, goToSection, login } from '../../helpers'
+import {
+  drawSignature,
+  getToken,
+  goToSection,
+  login,
+  selectDeclarationAction
+} from '../../helpers'
 import { faker } from '@faker-js/faker'
 import { fillChildDetails, openBirthDeclaration } from '../birth/helpers'
 import { CREDENTIALS } from '../../constants'
@@ -43,7 +49,7 @@ test.describe('Form state', () => {
       await page.getByRole('button', { name: 'Apply' }).click()
 
       // Save & Exit draft
-      await page.getByRole('button', { name: 'Save & Exit' }).click()
+      await selectDeclarationAction(page, 'Save & Exit', false)
       await page.getByRole('button', { name: 'Confirm' }).click()
     })
 
@@ -84,10 +90,10 @@ test.describe('Form state', () => {
       await login(page)
     })
 
-    // First create a draft event, which we will come back to later
     test('Create a draft', async () => {
       await openBirthDeclaration(page)
       actionableEventChildName = await fillChildDetails(page)
+
       await page.getByRole('button', { name: 'Save & Exit' }).click()
       await page.getByRole('button', { name: 'Confirm' }).click()
 
@@ -109,7 +115,7 @@ test.describe('Form state', () => {
       await page.getByRole('button', { name: 'Apply' }).click()
 
       // Save & Exit draft
-      await page.getByRole('button', { name: 'Save & Exit' }).click()
+      await selectDeclarationAction(page, 'Save & Exit', false)
       await page.getByRole('button', { name: 'Confirm' }).click()
     })
 

--- a/e2e/testcases/form-state/form-state.spec.ts
+++ b/e2e/testcases/form-state/form-state.spec.ts
@@ -86,6 +86,7 @@ test.describe('Form state', () => {
     test.afterAll(async () => {
       await page.close()
     })
+
     test('Login', async () => {
       await login(page)
     })

--- a/src/form/v2/birth/index.ts
+++ b/src/form/v2/birth/index.ts
@@ -271,6 +271,12 @@ export const birthEvent = defineConfig({
           'This is shown as the action name anywhere the user can trigger the action from',
         id: 'event.birth.action.validate.label'
       },
+      conditionals: [
+        {
+          type: ConditionalType.ENABLE,
+          conditional: not(flag('approval-required-for-late-registration'))
+        }
+      ],
       deduplication: {
         id: 'birth-deduplication',
         label: {
@@ -290,6 +296,12 @@ export const birthEvent = defineConfig({
           'This is shown as the action name anywhere the user can trigger the action from',
         id: 'event.birth.action.register.label'
       },
+      conditionals: [
+        {
+          type: ConditionalType.ENABLE,
+          conditional: not(flag('approval-required-for-late-registration'))
+        }
+      ],
       deduplication: {
         id: 'birth-deduplication',
         label: {


### PR DESCRIPTION
## Description

* Switch tests to use new declaration action menu
* Add new test case: 'Approval required for late registration' -flag blocks direct registration

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
