### PR TITLE
fix: add timeout to avoid false negatives

### DIFF
--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -92,6 +92,9 @@ export async function ensureAssigned(page: Page) {
 
     await page.getByRole('button', { name: 'Action' }).click()
 
+    // Seems that on slower environments actions are not immediately available after unassign.
+    // And end up having false negative for assignAction.isVisible().
+    await page.waitForTimeout(SAFE_INPUT_CHANGE_TIMEOUT_MS)
     assignAction = page
       .locator('#action-Dropdown-Content li')
       .filter({ hasText: new RegExp(`^Assign$`, 'i') })


### PR DESCRIPTION
## Description
Add timeout prior to visibility check
## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
