### PR TITLE
placeOfEvent configuration added for birth and death event

### DIFF
--- a/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
@@ -138,7 +138,7 @@ test.describe.serial('Correct record - 2', () => {
     firstNames: faker.person.firstName(),
     familyName: faker.person.lastName(),
     brn: faker.string.numeric(10),
-    age: faker.number.int({ min: 1, max: 100 }).toString(),
+    age: faker.number.int({ min: 18, max: 100 }).toString(),
     email: faker.internet.email()
   }
 


### PR DESCRIPTION
issue: https://github.com/opencrvs/opencrvs-core/issues/11148
core pr: https://github.com/opencrvs/opencrvs-core/pull/11246
country pr: https://github.com/opencrvs/opencrvs-countryconfig/pull/1185

> [!NOTE]
> Currently, we do **not** run e2e tests as a check on `opencrvs-countryconfig`-repo PRs. Please ensure your PR doesn't break any e2e tests.
>
> One method for doing this is to open a PR with these changes to `opencrvs-farajaland` as well, and see if the PR check passes there.

## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
