### PR TITLE
[OCRVS-10324] Implement supporting doc image in certificate

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@hapi/boom": "^9.1.1",
     "@hapi/hapi": "^20.0.1",
     "@hapi/inert": "^6.0.3",
-    "@opencrvs/toolkit": "1.9.5-rc.358ea81",
+    "@opencrvs/toolkit": "1.9.5-rc.141fdf1",
     "@types/chalk": "^2.2.0",
     "@types/csv2json": "^1.4.0",
     "@types/fhir": "^0.0.30",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@hapi/boom": "^9.1.1",
     "@hapi/hapi": "^20.0.1",
     "@hapi/inert": "^6.0.3",
-    "@opencrvs/toolkit": "1.9.5-rc.70d8c2e",
+    "@opencrvs/toolkit": "1.9.5-rc.358ea81",
     "@types/chalk": "^2.2.0",
     "@types/csv2json": "^1.4.0",
     "@types/fhir": "^0.0.30",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@hapi/hapi": "^20.0.1",
     "@hapi/inert": "^6.0.3",
     "@opencrvs/mosip": "1.9.0",
-    "@opencrvs/toolkit": "1.9.5-rc.5ccf91d",
+    "@opencrvs/toolkit": "1.9.5-rc.335ea9b",
     "@types/chalk": "^2.2.0",
     "@types/code": "^4.0.3",
     "@types/csv2json": "^1.4.0",

--- a/src/api/certificates/source/v2.tennis-club-membership-certificate-multipage.svg
+++ b/src/api/certificates/source/v2.tennis-club-membership-certificate-multipage.svg
@@ -119,6 +119,13 @@
         </text>
         <image x="312" y="300" height="50" width="100" xlink:href="{{ $lookup $declaration "applicant.idImage.ID_FRONT" }}" />
         <image x="422" y="300" height="50" width="100" xlink:href="{{ $lookup $declaration "applicant.idImage.ID_BACK" }}" />
+        {{else}} {{#if ($actions "PRINT_CERTIFICATE") }}
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
+        font-size="8" font-weight="bold" letter-spacing="0em">
+          <tspan x="90" y="327.208">Collector's signed affidavit</tspan>
+        </text>
+        <image x="312" y="300" height="50" width="100" xlink:href="{{ $lookup ($action "PRINT_CERTIFICATE") "annotation.collector.OTHER.signedAffidavit" }}" />
+        {{/if}}
         {{/if}}
         {{/if}}
         <mask id="mask2_5_2" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="312" y="278"

--- a/src/api/certificates/source/v2.tennis-club-membership-certificate-multipage.svg
+++ b/src/api/certificates/source/v2.tennis-club-membership-certificate-multipage.svg
@@ -106,6 +106,11 @@
         font-size="8" font-weight="bold" letter-spacing="0em">
         <tspan x="90" y="287.208">Recommender Full name</tspan>
         </text>
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
+        font-size="8" font-weight="bold" letter-spacing="0em">
+          <tspan x="90" y="327.208">Applicant Image</tspan>
+        </text>
+        <image x="312" y="300" height="50" width="50" xlink:href="{{ $lookup $declaration "applicant.image" }}" />
         <mask id="mask2_5_2" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="312" y="278"
         width="202" height="12">
         <path d="M514 278H312V290H514V278Z" fill="white" />

--- a/src/api/certificates/source/v2.tennis-club-membership-certificate-multipage.svg
+++ b/src/api/certificates/source/v2.tennis-club-membership-certificate-multipage.svg
@@ -106,11 +106,21 @@
         font-size="8" font-weight="bold" letter-spacing="0em">
         <tspan x="90" y="287.208">Recommender Full name</tspan>
         </text>
+        {{#if ($lookup $declaration "applicant.image") }}
         <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
         font-size="8" font-weight="bold" letter-spacing="0em">
           <tspan x="90" y="327.208">Applicant Image</tspan>
         </text>
         <image x="312" y="300" height="50" width="50" xlink:href="{{ $lookup $declaration "applicant.image" }}" />
+        {{else}} {{#if ($lookup $declaration "applicant.idImage") }} 
+        <text fill="black" xml:space="preserve" style="white-space: pre" font-family="Noto Sans"
+        font-size="8" font-weight="bold" letter-spacing="0em">
+          <tspan x="90" y="327.208">Applicant ID Image</tspan>
+        </text>
+        <image x="312" y="300" height="50" width="100" xlink:href="{{ $lookup $declaration "applicant.idImage.ID_FRONT" }}" />
+        <image x="422" y="300" height="50" width="100" xlink:href="{{ $lookup $declaration "applicant.idImage.ID_BACK" }}" />
+        {{/if}}
+        {{/if}}
         <mask id="mask2_5_2" style="mask-type:luminance" maskUnits="userSpaceOnUse" x="312" y="278"
         width="202" height="12">
         <path d="M514 278H312V290H514V278Z" fill="white" />

--- a/src/form/tennis-club-membership.ts
+++ b/src/form/tennis-club-membership.ts
@@ -184,6 +184,9 @@ const TENNIS_CLUB_DECLARATION_FORM = defineDeclarationForm({
           type: 'FILE',
           required: false,
           uncorrectable: true,
+          configuration: {
+            maxImageSize: { targetSize: { height: 600, width: 600 } }
+          },
           label: {
             defaultMessage: "Applicant's profile picture",
             description: 'This is the label for the field',

--- a/src/form/tennis-club-membership.ts
+++ b/src/form/tennis-club-membership.ts
@@ -1224,6 +1224,7 @@ export const tennisClubMembershipEvent = defineConfig({
         id: 'advancedSearch.form.registrationDetails'
       },
       fields: [
+        event('legalStatuses.REGISTERED.registrationNumber').exact(),
         event('legalStatuses.REGISTERED.createdAtLocation').within(),
         event('legalStatuses.REGISTERED.acceptedAt').range(),
         event('status').exact(),

--- a/src/form/tennis-club-membership.ts
+++ b/src/form/tennis-club-membership.ts
@@ -194,6 +194,35 @@ const TENNIS_CLUB_DECLARATION_FORM = defineDeclarationForm({
           }
         },
         {
+          id: 'applicant.idImage',
+          type: 'FILE_WITH_OPTIONS',
+          required: false,
+          uncorrectable: true,
+          options: [
+            {
+              label: {
+                id: 'event.tennis-club-membership.action.declare.form.section.who.field.idImage.option.front.label',
+                defaultMessage: 'Upload front side of ID',
+                description: 'Option to upload front side of ID'
+              },
+              value: 'ID_FRONT'
+            },
+            {
+              label: {
+                id: 'event.tennis-club-membership.action.declare.form.section.who.field.idImage.option.back.label',
+                defaultMessage: 'Upload back side of ID',
+                description: 'Option to upload back side of ID'
+              },
+              value: 'ID_BACK'
+            }
+          ],
+          label: {
+            defaultMessage: "Image of Applicant's ID",
+            description: 'This is the label for the field',
+            id: 'event.tennis-club-membership.action.declare.form.section.who.field.idImage.label'
+          }
+        },
+        {
           id: 'applicant.image.label',
           type: 'TEXT',
           required: false,

--- a/src/translations/client.csv
+++ b/src/translations/client.csv
@@ -2302,3 +2302,5 @@ wq.noRecords.readyToPrint,No records messages for ready to print tab,No records 
 wq.noRecords.requiresUpdate,No records messages for require updates tab,No records require updates,Aucun document ne nécessite de mise à jour
 wq.noRecords.sentForApproval,No records messages for sent for approval tab,No records sent for approval,Aucun document envoyé pour approbation
 wq.noRecords.sentForReview,No records messages for sent for review tab,No records sent for review,Aucun document envoyé pour examen
+imageEditorModal.title,Title for the image editor modal,Crop & resize image,Recadrer et redimensionner l'image
+imageEditorModal.description,Description for the image editor modal,Resize and position the chosen image,Redimensionner et positionner l'image choisie

--- a/src/translations/client.csv
+++ b/src/translations/client.csv
@@ -2293,3 +2293,5 @@ wq.noRecords.readyToPrint,No records messages for ready to print tab,No records 
 wq.noRecords.requiresUpdate,No records messages for require updates tab,No records require updates,Aucun document ne nécessite de mise à jour
 wq.noRecords.sentForApproval,No records messages for sent for approval tab,No records sent for approval,Aucun document envoyé pour approbation
 wq.noRecords.sentForReview,No records messages for sent for review tab,No records sent for review,Aucun document envoyé pour examen
+imageEditorModal.title,Title for the image editor modal,Crop & resize image,Recadrer et redimensionner l'image
+imageEditorModal.description,Description for the image editor modal,Resize and position the chosen image,Redimensionner et positionner l'image choisie

--- a/yarn.lock
+++ b/yarn.lock
@@ -1743,10 +1743,10 @@
   resolved "https://registry.yarnpkg.com/@opencrvs/mosip/-/mosip-1.9.0.tgz#453ee10f97bbbd5e8249604ee826d195f5843a14"
   integrity sha512-oY/Y+MfRKN+FZJLrtx4LJ2xIBKxs4iwRZxhiOSX1DDktifyKFvSd5v9rg0xlkiS5BXlzrL8Yz/xIheMm94DncQ==
 
-"@opencrvs/toolkit@1.9.5-rc.5ccf91d":
-  version "1.9.5-rc.5ccf91d"
-  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-1.9.5-rc.5ccf91d.tgz#7477f85f00fa90b8daba00616bbfd0701b726c9d"
-  integrity sha512-1ClKnUbPWE6g8Zfpbs1oCdZbT5ghSUSBIVznZ/bw2SCR1kIRoiOxWwMiUOx1VFD5TtAXcKO4N3aCnBy0Kn5RbQ==
+"@opencrvs/toolkit@1.9.5-rc.335ea9b":
+  version "1.9.5-rc.335ea9b"
+  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-1.9.5-rc.335ea9b.tgz#8c786f4d627820db8bcf764eda359b64507e8678"
+  integrity sha512-EH/0N1eDG45dJWznZILpVxAKKQvvB0qTMmXspvD+AmdiFZHXTBRjOhxlYXlcwhQsMPtaAuzIGkNgkuiCG+0ulA==
   dependencies:
     "@trpc/client" "11.4.3"
     "@trpc/server" "11.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,10 +834,10 @@
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
 
-"@opencrvs/toolkit@1.9.5-rc.70d8c2e":
-  version "1.9.5-rc.70d8c2e"
-  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-1.9.5-rc.70d8c2e.tgz#8798a25ab02555706289d7547217adb2d594fd3d"
-  integrity sha512-703j1OYX+V+AC/OiUNNwbMRuuqKyjZJH7eT75mKHo0FE8uJHG54cgylmAKj9wCmGjtfwBnYnw4+B/a/9EbKS7g==
+"@opencrvs/toolkit@1.9.5-rc.358ea81":
+  version "1.9.5-rc.358ea81"
+  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-1.9.5-rc.358ea81.tgz#440427fec4e73ae9072c34b95a5b909604dd88cf"
+  integrity sha512-ikkDy+6dfY+bvlDvTp3qUn+De5opkdGDYCQ9PHeIBep6A9YHkZvPR+LTUtsV2blN0eRu1tjFU1RUTmYz/xWBiQ==
   dependencies:
     "@trpc/client" "11.4.3"
     "@trpc/server" "11.4.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,10 +834,10 @@
   dependencies:
     "@octokit/openapi-types" "^18.0.0"
 
-"@opencrvs/toolkit@1.9.5-rc.358ea81":
-  version "1.9.5-rc.358ea81"
-  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-1.9.5-rc.358ea81.tgz#440427fec4e73ae9072c34b95a5b909604dd88cf"
-  integrity sha512-ikkDy+6dfY+bvlDvTp3qUn+De5opkdGDYCQ9PHeIBep6A9YHkZvPR+LTUtsV2blN0eRu1tjFU1RUTmYz/xWBiQ==
+"@opencrvs/toolkit@1.9.5-rc.141fdf1":
+  version "1.9.5-rc.141fdf1"
+  resolved "https://registry.yarnpkg.com/@opencrvs/toolkit/-/toolkit-1.9.5-rc.141fdf1.tgz#4e5826cc7248e2b6286ebcca3ac806fc0715a25c"
+  integrity sha512-jWQYgo6+pc3lpJtymSEYg730IPHtZTBxtnKbx4fWdKW6oiIUC+tjiAzkh/EOTi1Z5Thg8uCaH4s5WpYQAoBV9g==
   dependencies:
     "@trpc/client" "11.4.3"
     "@trpc/server" "11.4.3"


### PR DESCRIPTION
Added certificate handlebars implementation for attached images as supporting docs for both declaration and annotation forms in Tennis club membership event. 

Declaration form fields: `applicant.image`, `applicant.idImage`
Annotation form fields: `collector.OTHER.signedAffidavit` (print certificate action)