### PR TITLE
Add registrationNumber field to tennis club search

### DIFF
--- a/src/form/tennis-club-membership.ts
+++ b/src/form/tennis-club-membership.ts
@@ -1205,6 +1205,7 @@ export const tennisClubMembershipEvent = defineConfig({
         id: 'advancedSearch.form.registrationDetails'
       },
       fields: [
+        event('legalStatuses.REGISTERED.registrationNumber').exact(),
         event('legalStatuses.REGISTERED.createdAtLocation').within(),
         event('legalStatuses.REGISTERED.acceptedAt').range(),
         event('status').exact(),


### PR DESCRIPTION
## Description

Adds the registrationNumber field to tennis club advanced search so it can be QA'd
https://github.com/opencrvs/opencrvs-core/issues/11490

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
