### PR TITLE
Tests: record tab is available offline if record is downloaded

### DIFF
--- a/e2e/testcases/offline/offline-event-overview.spec.ts
+++ b/e2e/testcases/offline/offline-event-overview.spec.ts
@@ -1,0 +1,162 @@
+import { expect, Page, test } from '@playwright/test'
+
+import { ActionType } from '@opencrvs/toolkit/events'
+import { getToken, login } from '../../helpers'
+import { mockNetworkConditions } from '../../mock-network-conditions'
+import { createDeclaration, Declaration } from '../test-data/birth-declaration'
+import { CREDENTIALS } from '../../constants'
+import { formatV2ChildName } from '../birth/helpers'
+
+test.describe.serial('Can view non-downloaded event online', () => {
+  let page: Page
+  let declaration: Declaration
+  let childName: string
+  let trackingId: string
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+    const token = await getToken(
+      CREDENTIALS.REGISTRATION_OFFICER.USERNAME,
+      CREDENTIALS.REGISTRATION_OFFICER.PASSWORD
+    )
+    const res = await createDeclaration(token, undefined, ActionType.DECLARE)
+    declaration = res.declaration
+    childName = formatV2ChildName(declaration)
+    trackingId = res.trackingId!
+  })
+
+  test.afterAll(async () => {
+    await page.close()
+  })
+
+  test('Login', async () => {
+    await login(page, CREDENTIALS.REGISTRAR)
+    await page.getByRole('button', { name: 'Pending registration' }).click()
+  })
+
+  test('Open the event overview page', async () => {
+    await page.getByRole('button', { name: childName, exact: true }).click()
+  })
+
+  test('Verify user can only see non-secured details', async () => {
+    await expect(page.getByTestId('tracking-id-value')).toHaveText(trackingId)
+    await expect(page.getByTestId('informant.contact-value')).not.toHaveText(
+      'mothers@email.com'
+    )
+  })
+
+  test('Verify that user can see details on "Record"-tab', async () => {
+    await page.getByRole('button', { name: 'Record', exact: true }).click()
+    await expect(page.getByTestId('row-value-child.name')).toHaveText(childName)
+  })
+})
+
+test.describe.serial('Can partially view non-downloaded event offline', () => {
+  let page: Page
+  let declaration: Declaration
+  let childName: string
+  let trackingId: string
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+    const token = await getToken(
+      CREDENTIALS.REGISTRATION_OFFICER.USERNAME,
+      CREDENTIALS.REGISTRATION_OFFICER.PASSWORD
+    )
+    const res = await createDeclaration(token, undefined, ActionType.DECLARE)
+    declaration = res.declaration
+    childName = formatV2ChildName(declaration)
+    trackingId = res.trackingId!
+  })
+
+  test.afterAll(async () => {
+    await page.close()
+  })
+
+  test('Login', async () => {
+    await login(page, CREDENTIALS.REGISTRAR)
+    await page.getByRole('button', { name: 'Pending registration' }).click()
+  })
+
+  test('Go offline', async () => {
+    await mockNetworkConditions(page, 'offline')
+  })
+
+  test('Open the event overview page', async () => {
+    await page.getByRole('button', { name: childName, exact: true }).click()
+  })
+
+  test('Verify user can only see non-secured details', async () => {
+    await expect(page.getByTestId('tracking-id-value')).toHaveText(trackingId)
+    await expect(page.getByTestId('informant.contact-value')).not.toHaveText(
+      'mothers@email.com'
+    )
+  })
+
+  test('Verify user can not access "Record"-tab details', async () => {
+    await page.getByRole('button', { name: 'Record', exact: true }).click()
+    await expect(page.getByTestId('row-value-child.name')).not.toBeVisible()
+  })
+})
+
+test.describe.serial('Can view downloaded event offline', () => {
+  let page: Page
+  let declaration: Declaration
+  let childName: string
+  let trackingId: string
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+    const token = await getToken(
+      CREDENTIALS.REGISTRATION_OFFICER.USERNAME,
+      CREDENTIALS.REGISTRATION_OFFICER.PASSWORD
+    )
+    const res = await createDeclaration(token, undefined, ActionType.DECLARE)
+    declaration = res.declaration
+    childName = formatV2ChildName(declaration)
+    trackingId = res.trackingId!
+  })
+
+  test.afterAll(async () => {
+    await page.close()
+  })
+
+  test('Login', async () => {
+    await login(page, CREDENTIALS.REGISTRAR)
+    await page.getByRole('button', { name: 'Pending registration' }).click()
+  })
+
+  test('Download record', async () => {
+    const row = page.getByTestId('row-item').filter({ hasText: childName })
+
+    await row
+      .getByRole('button', { name: 'Assign record', exact: true })
+      .click()
+
+    await page.getByRole('button', { name: 'Assign', exact: true }).click()
+
+    await expect(
+      row.getByRole('button', { name: 'Assign record', exact: true })
+    ).not.toBeVisible()
+  })
+
+  test('Go offline', async () => {
+    await mockNetworkConditions(page, 'offline')
+  })
+
+  test('Open the event overview page', async () => {
+    await page.getByRole('button', { name: childName, exact: true }).click()
+  })
+
+  test('Verify that user can see secured details', async () => {
+    await expect(page.getByTestId('tracking-id-value')).toHaveText(trackingId)
+    await expect(page.getByTestId('informant.contact-value')).toHaveText(
+      'mothers@email.com'
+    )
+  })
+
+  test('Verify that user can see details on "Record"-tab', async () => {
+    await page.getByRole('button', { name: 'Record', exact: true }).click()
+    await expect(page.getByTestId('row-value-child.name')).toHaveText(childName)
+  })
+})

--- a/e2e/testcases/offline/offline-event-overview.spec.ts
+++ b/e2e/testcases/offline/offline-event-overview.spec.ts
@@ -135,11 +135,10 @@ test.describe.serial('Can view downloaded event offline', () => {
 
     await page.getByRole('button', { name: 'Assign', exact: true }).click()
 
-    await page.waitForLoadState('networkidle')
+    await expect(row.getByLabel('User avatar')).toBeVisible()
   })
 
   test('Go offline', async () => {
-    await page.waitForTimeout(5000) // wait for the record to be assigned
     await mockNetworkConditions(page, 'offline')
   })
 

--- a/e2e/testcases/offline/offline-event-overview.spec.ts
+++ b/e2e/testcases/offline/offline-event-overview.spec.ts
@@ -139,6 +139,7 @@ test.describe.serial('Can view downloaded event offline', () => {
   })
 
   test('Go offline', async () => {
+    await page.waitForTimeout(5000) // wait for the record to be assigned
     await mockNetworkConditions(page, 'offline')
   })
 

--- a/e2e/testcases/offline/offline-event-overview.spec.ts
+++ b/e2e/testcases/offline/offline-event-overview.spec.ts
@@ -135,9 +135,7 @@ test.describe.serial('Can view downloaded event offline', () => {
 
     await page.getByRole('button', { name: 'Assign', exact: true }).click()
 
-    await expect(
-      row.getByRole('button', { name: 'Assign record', exact: true })
-    ).not.toBeVisible()
+    await page.waitForLoadState('networkidle')
   })
 
   test('Go offline', async () => {

--- a/e2e/testcases/offline/offline-event-overview.spec.ts
+++ b/e2e/testcases/offline/offline-event-overview.spec.ts
@@ -135,7 +135,7 @@ test.describe.serial('Can view downloaded event offline', () => {
 
     await page.getByRole('button', { name: 'Assign', exact: true }).click()
 
-    await expect(row.getByLabel('User avatar')).toBeVisible()
+    await expect(row.getByLabel('User avatar')).toBeVisible({ timeout: 20000 })
   })
 
   test('Go offline', async () => {

--- a/e2e/testcases/test-data/birth-declaration.ts
+++ b/e2e/testcases/test-data/birth-declaration.ts
@@ -196,7 +196,8 @@ export async function createDeclaration(
 
     return {
       eventId,
-      declaration: declareAction?.declaration as Declaration
+      declaration: declareAction?.declaration as Declaration,
+      trackingId: declareRes.trackingId
     }
   }
 


### PR DESCRIPTION
## Description

Core PR: https://github.com/opencrvs/opencrvs-core/pull/11606

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
