### PR TITLE
Rename drafts workqueue test file, add test case for drafts workqueue CTA button

### DIFF
--- a/e2e/testcases/application/drafts-workqueue.spec.ts
+++ b/e2e/testcases/application/drafts-workqueue.spec.ts
@@ -90,12 +90,10 @@ test.describe.serial('1: Validate my draft tab', () => {
 
     await getRowByTitle(page, formattedName)
       .getByRole('button', {
-        name: 'Review'
+        name: 'Update'
       })
       .click()
 
-    await selectAction(page, 'Declare')
-    await goToSection(page, 'review')
     await selectDeclarationAction(page, 'Notify')
 
     await ensureOutboxIsEmpty(page)

--- a/e2e/testcases/application/drafts-workqueue.spec.ts
+++ b/e2e/testcases/application/drafts-workqueue.spec.ts
@@ -17,6 +17,7 @@ test.describe.serial('1: Validate my draft tab', () => {
     firstNames: faker.person.firstName('male'),
     familyName: faker.person.lastName('male')
   }
+  const formattedName = formatName(name)
 
   test.beforeAll(async ({ browser }) => {
     page = await browser.newPage()
@@ -31,7 +32,7 @@ test.describe.serial('1: Validate my draft tab', () => {
     await page.getByRole('button', { name: 'Drafts' }).click()
 
     await expect(page.getByTestId('search-result')).not.toContainText(
-      formatName(name)
+      formattedName
     )
   })
 
@@ -48,39 +49,46 @@ test.describe.serial('1: Validate my draft tab', () => {
     await page.getByRole('button', { name: 'Confirm' }).click()
   })
 
-  test('1.3 Record appears in draft ', async () => {
+  test('1.3 Record appears in draft', async () => {
     await ensureOutboxIsEmpty(page)
 
     await page.getByRole('button', { name: 'Drafts' }).click()
 
-    await expect(page.getByTestId('search-result')).toContainText(
-      formatName(name)
-    )
+    await expect(page.getByTestId('search-result')).toContainText(formattedName)
   })
 
-  test('1.4 Record does not appear in draft for other user: RO', async () => {
+  test('1.4 Record has "Update" -CTA', async () => {
+    const row = getRowByTitle(page, formattedName)
+    await row.getByRole('button', { name: 'Update' }).click()
+    await expect(page.getByTestId('row-value-child.name')).toHaveText(
+      formattedName
+    )
+    await expect(page.getByTestId('change-button-child.name')).toBeVisible()
+  })
+
+  test('1.5 Record does not appear in draft for other user: RO', async () => {
     await login(page, CREDENTIALS.REGISTRATION_OFFICER)
     await page.getByRole('button', { name: 'Drafts' }).click()
 
     await expect(page.getByTestId('search-result')).not.toContainText(
-      formatName(name)
+      formattedName
     )
   })
 
-  test('1.5 Record does not appear in draft for other user: LR ', async () => {
+  test('1.6 Record does not appear in draft for other user: LR ', async () => {
     await login(page, CREDENTIALS.REGISTRAR)
     await page.getByRole('button', { name: 'Drafts' }).click()
 
     await expect(page.getByTestId('search-result')).not.toContainText(
-      formatName(name)
+      formattedName
     )
   })
 
-  test('1.6 Record does not appear in draft after notifying ', async () => {
+  test('1.7 Record does not appear in draft after notifying ', async () => {
     await login(page, CREDENTIALS.FIELD_AGENT, true)
     await page.getByRole('button', { name: 'Drafts' }).click()
 
-    await getRowByTitle(page, formatName(name))
+    await getRowByTitle(page, formattedName)
       .getByRole('button', {
         name: 'Review'
       })
@@ -94,7 +102,7 @@ test.describe.serial('1: Validate my draft tab', () => {
 
     await expect(page.getByTestId('search-result')).toContainText('Drafts')
     await expect(page.getByTestId('search-result')).not.toContainText(
-      formatName(name)
+      formattedName
     )
   })
 })

--- a/e2e/testcases/birth/1-birth-event-declaration.spec.ts
+++ b/e2e/testcases/birth/1-birth-event-declaration.spec.ts
@@ -459,7 +459,7 @@ test.describe.serial('1. Birth event declaration', () => {
           })
           .click()
 
-        await selectAction(page, 'Declare')
+        await selectAction(page, 'Update')
 
         await expect(page.locator('#select_document')).toContainText(
           "Proof of mother's ID (Birth Certificate)"

--- a/e2e/testcases/birth/save-and-delete-drafts.spec.ts
+++ b/e2e/testcases/birth/save-and-delete-drafts.spec.ts
@@ -3,7 +3,7 @@ import { goToSection, login, logout } from '../../helpers'
 import { CREDENTIALS } from '../../constants'
 import { fillChildDetails, openBirthDeclaration } from './helpers'
 import { selectDeclarationAction } from '../../helpers'
-import { ensureOutboxIsEmpty } from '../../utils'
+import { ensureOutboxIsEmpty, selectAction } from '../../utils'
 
 /**
  * Skipping tests until the outbox workqueue is implemented.
@@ -56,9 +56,7 @@ test.describe('Save and delete drafts', () => {
     test('Delete saved draft', async () => {
       await page.getByRole('button', { name: 'Drafts' }).click()
       await page.getByRole('button', { name: childName, exact: true }).click()
-      await page.getByRole('button', { name: 'Action', exact: true }).click()
-
-      await page.getByText('Declare').click()
+      await selectAction(page, 'Update')
       await selectDeclarationAction(page, 'Delete declaration', false)
       await expect(
         page.getByText('Are you sure you want to delete this declaration?')

--- a/e2e/testcases/form-state/form-state.spec.ts
+++ b/e2e/testcases/form-state/form-state.spec.ts
@@ -131,7 +131,7 @@ test.describe('Form state', () => {
         .getByRole('button', { name: actionableEventChildName, exact: true })
         .click()
 
-      await selectAction(page, 'Declare')
+      await selectAction(page, 'Update')
 
       await expect(page.getByTestId('row-value-child.name')).not.toHaveText(
         REQUIRED_VALIDATION_ERROR

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -54,6 +54,7 @@ export async function selectAction(
     | 'Provincial registrar feedback'
     | 'Revoke registration'
     | 'Reinstate registration'
+    | 'Update'
 ) {
   if (await page.getByRole('button', { name: 'Assign record' }).isVisible()) {
     await ensureAssigned(page)


### PR DESCRIPTION
## Description

Core PR: https://github.com/opencrvs/opencrvs-core/pull/11705

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
