### PR TITLE
fix flaky verifiable credential test

### DIFF
--- a/e2e/testcases/custom-actions-and-flags/issue-verifiable-credential.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/issue-verifiable-credential.spec.ts
@@ -56,7 +56,7 @@ test.describe.serial('Issue verifiable credential', () => {
     await page.getByRole('button', { name: 'Generate', exact: true }).click()
 
     const actionQrCode = page.getByRole('dialog').locator('img')
-    await expect(actionQrCode).toBeVisible({ timeout: 1000 })
+    await expect(actionQrCode).toBeVisible()
     await expect(actionQrCode).toHaveAttribute(
       'src',
       /^data:image\/png;base64,/


### PR DESCRIPTION
## Description

Removes the timeout, as Playwrights default is 5 seconds which gives enough time for the call to country-config to return and render.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
