### PR TITLE
Add dynamic requester options to `Issue verifiable credential` action

### DIFF
--- a/e2e/testcases/action-menu/action-menu-options.spec.ts
+++ b/e2e/testcases/action-menu/action-menu-options.spec.ts
@@ -5,7 +5,7 @@ import { CREDENTIALS } from '../../constants'
 import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { ActionType } from '@opencrvs/toolkit/events'
 import { formatV2ChildName } from '../birth/helpers'
-import { selectAction } from '../../utils'
+import { ensureAssigned, selectAction } from '../../utils'
 
 async function getActionMenuOptions(page: Page, declaration: Declaration) {
   await searchFromSearchBar(page, formatV2ChildName(declaration))
@@ -114,6 +114,25 @@ test.describe('Action menu options', () => {
         'Print',
         'Correct',
         'Issue a verifiable credential'
+      ])
+    })
+
+    test('Registrar (assigned)', async () => {
+      await login(page, CREDENTIALS.REGISTRAR)
+      await searchFromSearchBar(page, formatV2ChildName(declaration))
+      await ensureAssigned(page)
+
+      await page.getByRole('button', { name: 'Action', exact: true }).click()
+      const options = await page
+        .locator('#action-Dropdown-Content li')
+        .allTextContents()
+
+      expect(options).toStrictEqual([
+        'Escalate',
+        'Print',
+        'Correct',
+        'Issue a verifiable credential',
+        'Unassign'
       ])
     })
   })

--- a/e2e/testcases/custom-actions-and-flags/issue-verifiable-credential.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/issue-verifiable-credential.spec.ts
@@ -9,6 +9,7 @@ import {
 } from '../../utils'
 import {
   createDeclaration,
+  getDeclaration,
   type Declaration
 } from '../test-data/birth-declaration'
 import { formatV2ChildName } from '../birth/helpers'
@@ -19,8 +20,18 @@ import {
 
 test.describe.serial('Issue verifiable credential', () => {
   let page: Page
-  let declaration: Declaration
-  let childName: string
+  let motherInformantDeclaration: Declaration
+  let motherInformantChildName: string
+  let nonParentInformantDeclaration: Declaration
+  let nonParentInformantChildName: string
+
+  async function openIssueVerifiableCredentialAction() {
+    await page.getByRole('button', { name: 'Action', exact: true }).click()
+    await page
+      .locator('#action-Dropdown-Content')
+      .getByText('Issue a verifiable credential', { exact: true })
+      .click()
+  }
 
   test.beforeAll(async ({ browser }) => {
     const token = await getToken(
@@ -28,9 +39,24 @@ test.describe.serial('Issue verifiable credential', () => {
       CREDENTIALS.REGISTRAR.PASSWORD
     )
 
-    const res = await createDeclaration(token)
-    declaration = res.declaration
-    childName = formatV2ChildName(declaration)
+    const motherInformantRes = await createDeclaration(token)
+    motherInformantDeclaration = motherInformantRes.declaration
+    motherInformantChildName = formatV2ChildName(motherInformantDeclaration)
+
+    const nonParentInformantDec = await getDeclaration({
+      token,
+      informantRelation: 'BROTHER'
+    })
+
+    const nonParentInformantRes = await createDeclaration(
+      token,
+      nonParentInformantDec
+    )
+    nonParentInformantDeclaration = nonParentInformantRes.declaration
+    nonParentInformantChildName = formatV2ChildName(
+      nonParentInformantDeclaration
+    )
+
     page = await browser.newPage()
   })
 
@@ -38,21 +64,53 @@ test.describe.serial('Issue verifiable credential', () => {
     await page?.close()
   })
 
-  test('Log in and navigate to the record', async () => {
+  test('Log in and navigate to mother informant record', async () => {
     await login(page, CREDENTIALS.REGISTRAR)
-    await searchFromSearchBar(page, childName)
+    await searchFromSearchBar(page, motherInformantChildName)
     await ensureAssigned(page)
   })
 
-  test('Generate QR code from Issue verifiable credential custom action', async () => {
-    await page.getByRole('button', { name: 'Action', exact: true }).click()
-    await page
-      .locator('#action-Dropdown-Content')
-      .getByText('Issue a verifiable credential', { exact: true })
-      .click()
+  test('Requester dropdown spec: mother informant only shows mother (and father if available)', async () => {
+    await openIssueVerifiableCredentialAction()
 
     await page.locator('#requester____type').click()
+
+    await expect(page.getByText('Mother', { exact: true })).toBeVisible()
+    await expect(page.getByText('Father', { exact: true })).toHaveCount(0)
+    await expect(
+      page.getByText('Brother (informant)', { exact: true })
+    ).toHaveCount(0)
+
     await page.getByText('Mother', { exact: true }).click()
+    await page.getByRole('button', { name: 'Generate', exact: true }).click()
+
+    const actionQrCode = page.getByRole('dialog').locator('img')
+    await expect(actionQrCode).toBeVisible()
+    await expect(actionQrCode).toHaveAttribute(
+      'src',
+      /^data:image\/png;base64,/
+    )
+
+    await page.getByRole('button', { name: 'Confirm' }).click()
+    await ensureOutboxIsEmpty(page)
+  })
+
+  test('Requester dropdown spec: non-parent informant shows available parent(s) plus informant relation', async () => {
+    await navigateToWorkqueue(page, 'Pending certification')
+    await searchFromSearchBar(page, nonParentInformantChildName)
+    await ensureAssigned(page)
+
+    await openIssueVerifiableCredentialAction()
+
+    await page.locator('#requester____type').click()
+
+    await expect(page.getByText('Mother', { exact: true })).toBeVisible()
+    await expect(page.getByText('Father', { exact: true })).toHaveCount(0)
+    await expect(
+      page.getByText('Brother (informant)', { exact: true })
+    ).toBeVisible()
+
+    await page.getByText('Brother (informant)', { exact: true }).click()
     await page.getByRole('button', { name: 'Generate', exact: true }).click()
 
     const actionQrCode = page.getByRole('dialog').locator('img')
@@ -68,7 +126,7 @@ test.describe.serial('Issue verifiable credential', () => {
 
   test('Show verifiable credential QR code in Birth Certificate', async () => {
     await navigateToWorkqueue(page, 'Pending certification')
-    await searchFromSearchBar(page, childName)
+    await searchFromSearchBar(page, motherInformantChildName)
     await ensureAssigned(page)
 
     await selectAction(page, 'Print')

--- a/src/form/v2/birth/index.ts
+++ b/src/form/v2/birth/index.ts
@@ -264,8 +264,8 @@ export const birthEvent = defineConfig({
     ActionType.REQUEST_CORRECTION,
     'REVOKE_REGISTRATION',
     'REINSTATE_REVOKE_REGISTRATION',
-    ActionType.UNASSIGN,
-    'ISSUE_VERIFIABLE_CREDENTIAL'
+    'ISSUE_VERIFIABLE_CREDENTIAL',
+    ActionType.UNASSIGN
   ],
   actions: [
     {

--- a/src/verifiable-credentials/issue-birth-credential-action.ts
+++ b/src/verifiable-credentials/issue-birth-credential-action.ts
@@ -10,6 +10,11 @@ import {
   window,
   status
 } from '@opencrvs/toolkit/events'
+import {
+  InformantType,
+  InformantTypeKey
+} from '@countryconfig/form/v2/birth/forms/pages/informant'
+import { informantMessageDescriptors } from '@countryconfig/form/common/messages'
 import { CREDENTIAL_OFFER_HANDLER_URL } from './routes'
 
 const qrGenerated = not(
@@ -17,6 +22,131 @@ const qrGenerated = not(
     .get('data.credential_offer_uri_qr')
     .isUndefined()
 )
+
+const motherExists = not(field('mother.name').isFalsy())
+const fatherExists = not(field('father.name').isFalsy())
+
+const motherAndFatherExist = and(motherExists, fatherExists)
+const onlyMotherExists = and(motherExists, not(fatherExists))
+const onlyFatherExists = and(fatherExists, not(motherExists))
+const motherAndFatherMissing = and(not(motherExists), not(fatherExists))
+
+const requesterLabel = {
+  defaultMessage: 'Requester',
+  description: 'Select who is requesting the VC',
+  id: 'event.birth.custom.action.issue-vc.field.requester.label'
+}
+
+const motherOption = {
+  value: 'MOTHER',
+  label: {
+    defaultMessage: 'Mother',
+    description: 'Option label for mother requester type',
+    id: 'event.birth.custom.action.issue-vc.field.requester.option.mother'
+  }
+}
+
+const fatherOption = {
+  value: 'FATHER',
+  label: {
+    defaultMessage: 'Father',
+    description: 'Option label for father requester type',
+    id: 'event.birth.custom.action.issue-vc.field.requester.option.father'
+  }
+}
+
+const getInformantOption = (informantType: InformantTypeKey) => {
+  const defaultMessage =
+    informantType === InformantType.OTHER
+      ? '{informant.other.relation} (informant)'
+      : `${informantMessageDescriptors[informantType].defaultMessage} (informant)`
+
+  return {
+    value: 'INFORMANT',
+    label: {
+      defaultMessage,
+      description: 'Option label for informant requester type',
+      id: `event.birth.custom.action.issue-vc.field.requester.option.informant.${informantType.toLowerCase()}`
+    }
+  }
+}
+
+const getFieldConfigForInformant = (informantType: InformantTypeKey) => {
+  const informantRelationMatch =
+    field('informant.relation').isEqualTo(informantType)
+  const informantOption = getInformantOption(informantType)
+
+  return [
+    {
+      id: 'requester.type',
+      type: FieldType.SELECT,
+      required: true,
+      conditionals: [
+        {
+          type: ConditionalType.SHOW,
+          conditional: and(
+            not(qrGenerated),
+            informantRelationMatch,
+            onlyMotherExists
+          )
+        }
+      ],
+      options: [motherOption, informantOption],
+      label: requesterLabel
+    },
+    {
+      id: 'requester.type',
+      type: FieldType.SELECT,
+      required: true,
+      conditionals: [
+        {
+          type: ConditionalType.SHOW,
+          conditional: and(
+            not(qrGenerated),
+            informantRelationMatch,
+            onlyFatherExists
+          )
+        }
+      ],
+      options: [fatherOption, informantOption],
+      label: requesterLabel
+    },
+    {
+      id: 'requester.type',
+      type: FieldType.SELECT,
+      required: true,
+      conditionals: [
+        {
+          type: ConditionalType.SHOW,
+          conditional: and(
+            not(qrGenerated),
+            informantRelationMatch,
+            motherAndFatherExist
+          )
+        }
+      ],
+      options: [motherOption, fatherOption, informantOption],
+      label: requesterLabel
+    },
+    {
+      id: 'requester.type',
+      type: FieldType.SELECT,
+      required: true,
+      conditionals: [
+        {
+          type: ConditionalType.SHOW,
+          conditional: and(
+            not(qrGenerated),
+            informantRelationMatch,
+            motherAndFatherMissing
+          )
+        }
+      ],
+      options: [informantOption],
+      label: requesterLabel
+    }
+  ]
+}
 
 export const issueBirthCredentialAction = {
   type: ActionType.CUSTOM,
@@ -77,33 +207,73 @@ export const issueBirthCredentialAction = {
       conditionals: [
         {
           type: ConditionalType.SHOW,
-          conditional: not(qrGenerated)
+          conditional: and(
+            not(qrGenerated),
+            field('informant.relation').isEqualTo(InformantType.MOTHER),
+            fatherExists
+          )
         }
       ],
-      options: [
-        {
-          value: 'MOTHER',
-          label: {
-            defaultMessage: 'Mother',
-            description: 'Option label for mother requester type',
-            id: 'event.birth.custom.action.issue-vc.field.requester.option.mother'
-          }
-        },
-        {
-          value: 'FATHER',
-          label: {
-            defaultMessage: 'Father',
-            description: 'Option label for father requester type',
-            id: 'event.birth.custom.action.issue-vc.field.requester.option.father'
-          }
-        }
-      ],
-      label: {
-        defaultMessage: 'Requester',
-        description: 'Select who is requesting the VC',
-        id: 'event.birth.custom.action.issue-vc.field.requester.label'
-      }
+      options: [motherOption, fatherOption],
+      label: requesterLabel
     },
+    {
+      id: 'requester.type',
+      type: FieldType.SELECT,
+      required: true,
+      conditionals: [
+        {
+          type: ConditionalType.SHOW,
+          conditional: and(
+            not(qrGenerated),
+            field('informant.relation').isEqualTo(InformantType.MOTHER),
+            not(fatherExists)
+          )
+        }
+      ],
+      options: [motherOption],
+      label: requesterLabel
+    },
+    {
+      id: 'requester.type',
+      type: FieldType.SELECT,
+      required: true,
+      conditionals: [
+        {
+          type: ConditionalType.SHOW,
+          conditional: and(
+            not(qrGenerated),
+            field('informant.relation').isEqualTo(InformantType.FATHER),
+            motherExists
+          )
+        }
+      ],
+      options: [fatherOption, motherOption],
+      label: requesterLabel
+    },
+    {
+      id: 'requester.type',
+      type: FieldType.SELECT,
+      required: true,
+      conditionals: [
+        {
+          type: ConditionalType.SHOW,
+          conditional: and(
+            not(qrGenerated),
+            field('informant.relation').isEqualTo(InformantType.FATHER),
+            not(motherExists)
+          )
+        }
+      ],
+      options: [fatherOption],
+      label: requesterLabel
+    },
+    ...getFieldConfigForInformant(InformantType.OTHER),
+    ...getFieldConfigForInformant(InformantType.BROTHER),
+    ...getFieldConfigForInformant(InformantType.GRANDFATHER),
+    ...getFieldConfigForInformant(InformantType.GRANDMOTHER),
+    ...getFieldConfigForInformant(InformantType.SISTER),
+    ...getFieldConfigForInformant(InformantType.LEGAL_GUARDIAN),
     {
       parent: field('requester.type'),
       id: 'padding-for-layout-1',
@@ -183,6 +353,40 @@ export const issueBirthCredentialAction = {
           { fieldId: 'father.dob' },
           { fieldId: 'father.age' },
           { fieldId: 'father.nationality' }
+        ]
+      }
+    },
+    {
+      parent: field('requester.type'),
+      id: 'requester.data.informant.other',
+      type: FieldType.DATA,
+      conditionals: [
+        {
+          type: ConditionalType.SHOW,
+          conditional: and(
+            field('requester.type').isEqualTo('INFORMANT'),
+            not(field('informant.relation').isEqualTo('MOTHER')),
+            not(field('informant.relation').isEqualTo('FATHER')),
+            not(qrGenerated)
+          )
+        }
+      ],
+      label: {
+        defaultMessage: 'Details in the birth record',
+        description: 'Title for the data section',
+        id: 'event.birth.custom.action.issue-vc.field.requester.label'
+      },
+      configuration: {
+        data: [
+          { fieldId: 'informant.idType' },
+          { fieldId: 'informant.nid' },
+          { fieldId: 'informant.passport' },
+          { fieldId: 'informant.brn' },
+          { fieldId: 'informant.name' },
+          { fieldId: 'informant.dob' },
+          { fieldId: 'informant.age' },
+          { fieldId: 'informant.other.relation' },
+          { fieldId: 'informant.nationality' }
         ]
       }
     },

--- a/src/verifiable-credentials/issue-birth-credential-action.ts
+++ b/src/verifiable-credentials/issue-birth-credential-action.ts
@@ -58,7 +58,7 @@ const fatherOption = {
 const getInformantOption = (informantType: InformantTypeKey) => {
   const defaultMessage =
     informantType === InformantType.OTHER
-      ? '{informant.other.relation} (informant)'
+      ? 'Informant'
       : `${informantMessageDescriptors[informantType].defaultMessage} (informant)`
 
   return {


### PR DESCRIPTION
## Description

The requester options were hardcoded, but after discussion in Slack, we decided to make them dynamic if possible.

>if Mother is the informant:
>
>Mother
>Father (if available)

>if Grandfather is informant:
>
>Mother (if available)
>Father (if available)
>Grandfather (informant) or Grandfather

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
