### PR TITLE
check the checkbox in verifiable credential e2es

### DIFF
--- a/e2e/testcases/custom-actions-and-flags/issue-verifiable-credential.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/issue-verifiable-credential.spec.ts
@@ -129,6 +129,10 @@ test.describe.serial('Issue verifiable credential', () => {
       /^data:image\/png;base64,/
     )
 
+    const acceptedOfferCheckbox = page.locator('#requester____acceptedVcOffer')
+    await expect(acceptedOfferCheckbox).toBeVisible()
+    await acceptedOfferCheckbox.check()
+
     await page.getByRole('button', { name: 'Confirm' }).click()
     await ensureOutboxIsEmpty(page)
   })


### PR DESCRIPTION
## Description

Fixes one verifiable credential e2e not checking the box to enable Confirm -button.

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
