### PR TITLE
fix: separate root step. Add similar cache as in e2e

### DIFF
--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -73,7 +73,7 @@ jobs:
 
   discover-tests:
     name: Discover test directories
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     needs: [get-core-commit, get-country-config-commit]
     outputs:
       test_matrix: ${{ steps.list-tests.outputs.test_matrix }}
@@ -96,8 +96,7 @@ jobs:
           path: |
             node_modules
             ~/.cache/yarn/v6
-            ~/.cache/ms-playwright
-          key: ${{github.event.inputs.countryconfig-image-tag || needs.get-country-config-commit.outputs.short_sha}}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node-
 
@@ -142,23 +141,32 @@ jobs:
           node-version-file: .nvmrc
 
       - name: Cache Node.js dependencies
+        id: node-cache
         uses: actions/cache@v5
-        id: cache
         with:
           path: |
             node_modules
             ~/.cache/yarn/v6
-            ~/.cache/ms-playwright
-          key: ${{github.event.inputs.countryconfig-image-tag || needs.get-country-config-commit.outputs.short_sha}}
+          key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-node-
 
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
       - name: Install Dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+        if: steps.node-cache.outputs.cache-hit != 'true'
         run: yarn
 
-      - uses: nick-fields/retry@v4
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Install Playwright
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 10
           max_attempts: 3
@@ -175,6 +183,7 @@ jobs:
           [ -d ctrf ] && \
             echo "ctrf=true" >> $GITHUB_OUTPUT || \
             echo "ctrf=false" >> $GITHUB_OUTPUT
+
       - name: Publish Test Summary Results
         run: npx github-actions-ctrf ctrf/ctrf-report.json
         if: always() && steps.ctrf_check.outputs.ctrf == 'true'

--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -102,6 +102,23 @@ jobs:
 
       - name: Install Dependencies
         run: yarn
+
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+
+      - name: Install Playwright
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: npx playwright install --with-deps
   test:
     needs: [deploy, discover-tests, get-core-commit, get-country-config-commit]
     runs-on: ubuntu-24.04

--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Install Playwright system dependencies
         if: steps.cache.outputs.cache-hit != 'true'
-        run: npx playwright install-deps chromium
+        run: npx playwright install-deps
 
       - name: Install Playwright browsers
         if: steps.cache.outputs.cache-hit != 'true'
@@ -167,7 +167,7 @@ jobs:
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: npx playwright install chromium
+          command: npx playwright install
 
       - name: Run Playwright Tests
         run: npx playwright test --shard=${{ matrix.shard }}/20

--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -157,17 +157,12 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: yarn
 
-      - name: Install Playwright system dependencies
+      - uses: nick-fields/retry@v4
         if: steps.cache.outputs.cache-hit != 'true'
-        run: npx playwright install-deps
-
-      - name: Install Playwright browsers
-        if: steps.cache.outputs.cache-hit != 'true'
-        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: npx playwright install
+          command: npx playwright install --with-deps
 
       - name: Run Playwright Tests
         run: npx playwright test --shard=${{ matrix.shard }}/20

--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -96,6 +96,7 @@ jobs:
           path: |
             node_modules
             ~/.cache/yarn/v6
+            ~/.cache/ms-playwright
           key: ${{github.event.inputs.countryconfig-image-tag || needs.get-country-config-commit.outputs.short_sha}}
           restore-keys: |
             ${{ runner.os }}-node-
@@ -142,22 +143,31 @@ jobs:
 
       - name: Cache Node.js dependencies
         uses: actions/cache@v5
+        id: cache
         with:
           path: |
             node_modules
             ~/.cache/yarn/v6
+            ~/.cache/ms-playwright
           key: ${{github.event.inputs.countryconfig-image-tag || needs.get-country-config-commit.outputs.short_sha}}
           restore-keys: |
             ${{ runner.os }}-node-
 
       - name: Install Dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
         run: yarn
 
-      - uses: nick-fields/retry@v4
+      - name: Install Playwright system dependencies
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: npx playwright install-deps chromium
+
+      - name: Install Playwright browsers
+        if: steps.cache.outputs.cache-hit != 'true'
+        uses: nick-fields/retry@v4
         with:
           timeout_minutes: 10
           max_attempts: 3
-          command: npx playwright install --with-deps
+          command: npx playwright install chromium
 
       - name: Run Playwright Tests
         run: npx playwright test --shard=${{ matrix.shard }}/20


### PR DESCRIPTION
## Description
playwright steps fails intermittently.
```
Attempt 1
  Installing dependencies...
  Switching to root user to install dependencies...
...

/home/runner/work/_actions/nick-fields/retry/v4/dist/index.js:1931
              throw err;  
  Error: kill EPERM
 ```
 
`nick-retry` tries to kill and retry but does not have the permission (EPERM) since the install command was run as root.

On farajaland runs, each e2e shard runs the playwright installations.

- Add similar caching as e2e repo has for playwright
- separate playwright install and deps to their own steps.
