### PR TITLE
fix: update default value of addresses

### DIFF
--- a/e2e/testcases/advanced-search/3-search-birth-event-declaration-child-event-details.spec.ts
+++ b/e2e/testcases/advanced-search/3-search-birth-event-declaration-child-event-details.spec.ts
@@ -204,10 +204,6 @@ test.describe
       page.locator('#searchable-select-province').getByText('Central')
       page.locator('#searchable-select-district').getByText('Ibombo')
 
-      await page.locator('#province').fill('Cent')
-      await page.getByText('Central', { exact: true }).click()
-      await page.locator('#district').fill('Ibo')
-      await page.getByText('Ibombo', { exact: true }).click()
       await page.locator('#village').fill('Klo')
       await page.getByText('Klow', { exact: true }).click()
       await page.locator('#town').fill('Dhaka')

--- a/e2e/testcases/birth/declarations/birth-declaration-11.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-11.spec.ts
@@ -1,0 +1,88 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ *
+ * OpenCRVS is also distributed under the terms of the Civil Registration
+ * & Healthcare Disclaimer located at http://opencrvs.org/license.
+ *
+ * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
+ */
+
+import { test, expect, type Page } from '@playwright/test'
+import {
+  continueForm,
+  formatName,
+  goToSection,
+  login,
+  selectDeclarationAction
+} from '../../../helpers'
+import { faker } from '@faker-js/faker'
+import { CREDENTIALS } from '../../../constants'
+import { ensureOutboxIsEmpty } from '../../../utils'
+
+test.describe.serial('11. Birth declaration case - 11', () => {
+  let page: Page
+  const declaration = {
+    child: {
+      name: {
+        firstNames: faker.person.firstName(),
+        familyName: faker.person.lastName()
+      }
+    }
+  }
+
+  test.beforeAll(async ({ browser }) => {
+    page = await browser.newPage()
+  })
+
+  test.afterAll(async () => {
+    await page.close()
+  })
+
+  test.describe('11.1 Hospital official can notify with blank mother/father address', () => {
+    test.beforeAll(async () => {
+      await login(page, CREDENTIALS.HOSPITAL_OFFICIAL)
+      await page.click('#header-new-event')
+      await page.getByLabel('Birth').click()
+      await page.getByRole('button', { name: 'Continue' }).click()
+      await page.getByRole('button', { name: 'Continue' }).click()
+    })
+
+    test('11.1.1 Fill child details', async () => {
+      await page.locator('#firstname').fill(declaration.child.name.firstNames)
+      await page.locator('#surname').fill(declaration.child.name.familyName)
+
+      await continueForm(page)
+    })
+
+    test('11.1.2 Skip informant details', async () => {
+      await continueForm(page)
+    })
+
+    test("11.1.3 Skip mother's details", async () => {
+      await continueForm(page)
+    })
+
+    test("11.1.4 Skip father's details", async () => {
+      await continueForm(page)
+    })
+
+    test('11.1.5 Go to review', async () => {
+      await goToSection(page, 'review')
+    })
+
+    test('11.1.6 Notify', async () => {
+      await selectDeclarationAction(page, 'Notify')
+
+      await ensureOutboxIsEmpty(page)
+      await page.getByText('Recent').click()
+
+      await expect(
+        page.getByRole('button', {
+          name: formatName(declaration.child.name)
+        })
+      ).toBeVisible()
+    })
+  })
+})

--- a/e2e/testcases/birth/declarations/birth-declaration-11.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-11.spec.ts
@@ -56,23 +56,11 @@ test.describe.serial('11. Birth declaration case - 11', () => {
       await continueForm(page)
     })
 
-    test('11.1.2 Skip informant details', async () => {
-      await continueForm(page)
-    })
-
-    test("11.1.3 Skip mother's details", async () => {
-      await continueForm(page)
-    })
-
-    test("11.1.4 Skip father's details", async () => {
-      await continueForm(page)
-    })
-
-    test('11.1.5 Go to review', async () => {
+    test('11.1.2 Go to review', async () => {
       await goToSection(page, 'review')
     })
 
-    test('11.1.6 Notify', async () => {
+    test('11.1.3 Notify', async () => {
       await selectDeclarationAction(page, 'Notify')
 
       await ensureOutboxIsEmpty(page)

--- a/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
@@ -225,10 +225,6 @@ test.describe.serial('Correct record - 2', () => {
         .getByText('Farajaland', { exact: true })
         .click()
 
-      await page.locator('#province').click()
-      await page.getByText('Central', { exact: true }).click()
-      await page.locator('#district').click()
-      await page.getByText('Ibombo', { exact: true }).click()
       await page.locator('#village').click()
       await page.getByText('Klow', { exact: true }).click()
 

--- a/e2e/testcases/correction-birth/correct-birth-record-3.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-3.spec.ts
@@ -488,6 +488,16 @@ test.describe.serial(' Correct record - 3', () => {
           .getByText(updatedMotherDetails.address.country, { exact: true })
           .click()
 
+        await page.locator('#province').click()
+        await page
+          .getByText(updatedMotherDetails.address.province, { exact: true })
+          .click()
+
+        await page.locator('#district').click()
+        await page
+          .getByText(updatedMotherDetails.address.district, { exact: true })
+          .click()
+
         await page.locator('#village').click()
         await page
           .getByText(updatedMotherDetails.address.village, { exact: true })
@@ -673,12 +683,6 @@ test.describe.serial(' Correct record - 3', () => {
 
       await page.locator('#child____placeOfBirth').click()
       await page.getByText(updatedChildDetails.placeOfBirth).click()
-
-      // await page.locator('#province').click()
-      // await page.getByText(updatedChildDetails.birthLocation.province).click()
-
-      // await page.locator('#district').click()
-      // await page.getByText(updatedChildDetails.birthLocation.district).click()
 
       await page.locator('#village').click()
       await page.getByText(updatedChildDetails.birthLocation.village).click()

--- a/e2e/testcases/correction-birth/correct-birth-record-3.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-3.spec.ts
@@ -488,16 +488,6 @@ test.describe.serial(' Correct record - 3', () => {
           .getByText(updatedMotherDetails.address.country, { exact: true })
           .click()
 
-        await page.locator('#province').click()
-        await page
-          .getByText(updatedMotherDetails.address.province, { exact: true })
-          .click()
-
-        await page.locator('#district').click()
-        await page
-          .getByText(updatedMotherDetails.address.district, { exact: true })
-          .click()
-
         await page.locator('#village').click()
         await page
           .getByText(updatedMotherDetails.address.village, { exact: true })
@@ -684,11 +674,11 @@ test.describe.serial(' Correct record - 3', () => {
       await page.locator('#child____placeOfBirth').click()
       await page.getByText(updatedChildDetails.placeOfBirth).click()
 
-      await page.locator('#province').click()
-      await page.getByText(updatedChildDetails.birthLocation.province).click()
+      // await page.locator('#province').click()
+      // await page.getByText(updatedChildDetails.birthLocation.province).click()
 
-      await page.locator('#district').click()
-      await page.getByText(updatedChildDetails.birthLocation.district).click()
+      // await page.locator('#district').click()
+      // await page.getByText(updatedChildDetails.birthLocation.district).click()
 
       await page.locator('#village').click()
       await page.getByText(updatedChildDetails.birthLocation.village).click()

--- a/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-1.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-1.spec.ts
@@ -469,12 +469,6 @@ test.describe
         .getByText('Farajaland', { exact: true })
         .click()
 
-      await page.locator('#province').click()
-      await page.getByText('Central', { exact: true }).click()
-
-      await page.locator('#district').click()
-      await page.getByText('Ibombo', { exact: true }).click()
-
       await page.locator('#village').click()
       await page.getByText('Klow', { exact: true }).click()
 

--- a/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-2.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-2.spec.ts
@@ -271,12 +271,6 @@ test.describe
         .getByText('Farajaland', { exact: true })
         .click()
 
-      await page.locator('#province').click()
-      await page.getByText('Central', { exact: true }).click()
-
-      await page.locator('#district').click()
-      await page.getByText('Ibombo', { exact: true }).click()
-
       await page.locator('#village').click()
       await page.getByText('Klow', { exact: true }).click()
 

--- a/e2e/testcases/death/death-event-summary.spec.tsx
+++ b/e2e/testcases/death/death-event-summary.spec.tsx
@@ -106,14 +106,6 @@ test.describe.serial('Death event summary', () => {
       .getByText(declaration.eventDetails.placeOfDeath, { exact: true })
       .click()
 
-    await page.locator('#province').click()
-    await page
-      .getByText(declaration.eventDetails.address.province, { exact: true })
-      .click()
-    await page.locator('#district').click()
-    await page
-      .getByText(declaration.eventDetails.address.district, { exact: true })
-      .click()
     await page.locator('#village').click()
     await page
       .getByText(declaration.eventDetails.address.village, { exact: true })

--- a/e2e/testcases/death/declaration/death-declaration-5.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-5.spec.ts
@@ -168,18 +168,6 @@ test.describe.serial('5. Death declaration case - 5', () => {
         .getByText(declaration.eventDetails.placeOfDeath, { exact: true })
         .click()
 
-      await page.locator('#province').click()
-      await page
-        .getByText(declaration.eventDetails.deathLocationOther.province, {
-          exact: true
-        })
-        .click()
-      await page.locator('#district').click()
-      await page
-        .getByText(declaration.eventDetails.deathLocationOther.district, {
-          exact: true
-        })
-        .click()
       await page.locator('#village').click()
       await page
         .getByText(declaration.eventDetails.deathLocationOther.village, {

--- a/e2e/testcases/death/declaration/death-declaration-6.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-6.spec.ts
@@ -172,18 +172,6 @@ test.describe.serial('6. Death declaration case - 6', () => {
         .getByText(declaration.eventDetails.placeOfDeath, { exact: true })
         .click()
 
-      await page.locator('#province').click()
-      await page
-        .getByText(declaration.eventDetails.deathLocationOther.province, {
-          exact: true
-        })
-        .click()
-      await page.locator('#district').click()
-      await page
-        .getByText(declaration.eventDetails.deathLocationOther.district, {
-          exact: true
-        })
-        .click()
       await page.locator('#village').click()
       await page
         .getByText(declaration.eventDetails.deathLocationOther.village, {

--- a/e2e/testcases/jurisdiction/birth-form-jurisdiction-restrictions.spec.ts
+++ b/e2e/testcases/jurisdiction/birth-form-jurisdiction-restrictions.spec.ts
@@ -68,12 +68,6 @@ test.describe('Birth form - child place of birth jurisdiction restrictions', () 
     await page.locator('#child____placeOfBirth').click()
     await page.getByText('Residential address', { exact: true }).click()
 
-    await page.locator('#province').click()
-    await page.getByText('Central', { exact: true }).click()
-
-    await page.locator('#district').click()
-    await page.getByText('Ibombo', { exact: true }).click()
-
     await expect(
       page.locator(
         '#child____birthLocation____privateHome-form-input #province'
@@ -101,12 +95,6 @@ test.describe('Birth form - child place of birth jurisdiction restrictions', () 
 
     await page.locator('#child____placeOfBirth').click()
     await page.getByText('Other', { exact: true }).click()
-
-    await page.locator('#province').click()
-    await page.getByText('Central', { exact: true }).click()
-
-    await page.locator('#district').click()
-    await page.getByText('Ibombo', { exact: true }).click()
 
     await expect(
       page.locator('#child____birthLocation____other-form-input #province')

--- a/src/events/birth/forms/pages/child.ts
+++ b/src/events/birth/forms/pages/child.ts
@@ -347,7 +347,7 @@ export const child = defineFormPage({
       defaultValue: {
         country: 'FAR',
         addressType: AddressType.DOMESTIC,
-        administrativeArea: user('primaryOfficeId').locationLevel('village')
+        administrativeArea: user('administrativeAreaId')
       },
       configuration: {
         streetAddressForm: defaultStreetAddressConfiguration,

--- a/src/events/birth/forms/pages/child.ts
+++ b/src/events/birth/forms/pages/child.ts
@@ -363,7 +363,7 @@ export const child = defineFormPage({
       defaultValue: {
         country: 'FAR',
         addressType: AddressType.DOMESTIC,
-        administrativeArea: user('primaryOfficeId').locationLevel('village')
+        administrativeArea: user('administrativeAreaId')
       },
       configuration: {
         streetAddressForm: defaultStreetAddressConfiguration,
@@ -410,7 +410,7 @@ export const child = defineFormPage({
       defaultValue: {
         country: 'FAR',
         addressType: AddressType.DOMESTIC,
-        administrativeArea: user('primaryOfficeId').locationLevel('village')
+        administrativeArea: user('administrativeAreaId')
       },
       configuration: {
         streetAddressForm: defaultStreetAddressConfiguration,

--- a/src/events/birth/forms/pages/father.ts
+++ b/src/events/birth/forms/pages/father.ts
@@ -491,7 +491,7 @@ export const father = defineFormPage({
       defaultValue: {
         country: 'FAR',
         addressType: AddressType.DOMESTIC,
-        administrativeArea: user('primaryOfficeId').locationLevel('village')
+        administrativeArea: user('administrativeAreaId')
       },
       configuration: {
         streetAddressForm: defaultStreetAddressConfiguration

--- a/src/events/birth/forms/pages/informant.ts
+++ b/src/events/birth/forms/pages/informant.ts
@@ -512,7 +512,7 @@ export const informant = defineFormPage({
       defaultValue: {
         country: 'FAR',
         addressType: AddressType.DOMESTIC,
-        administrativeArea: user('primaryOfficeId').locationLevel('village')
+        administrativeArea: user('administrativeAreaId')
       },
       configuration: {
         streetAddressForm: defaultStreetAddressConfiguration

--- a/src/events/birth/forms/pages/mother.ts
+++ b/src/events/birth/forms/pages/mother.ts
@@ -463,7 +463,7 @@ export const mother = defineFormPage({
       defaultValue: {
         country: 'FAR',
         addressType: AddressType.DOMESTIC,
-        administrativeArea: user('primaryOfficeId').locationLevel('village')
+        administrativeArea: user('administrativeAreaId')
       },
       configuration: {
         streetAddressForm: defaultStreetAddressConfiguration

--- a/src/events/death/forms/pages/deceased.ts
+++ b/src/events/death/forms/pages/deceased.ts
@@ -406,7 +406,7 @@ export const deceased = defineFormPage({
       defaultValue: {
         country: 'FAR',
         addressType: AddressType.DOMESTIC,
-        administrativeArea: user('primaryOfficeId').locationLevel('village')
+        administrativeArea: user('administrativeAreaId')
       },
       configuration: {
         streetAddressForm: defaultStreetAddressConfiguration

--- a/src/events/death/forms/pages/eventDetails.ts
+++ b/src/events/death/forms/pages/eventDetails.ts
@@ -276,7 +276,7 @@ export const eventDetails = defineFormPage({
       defaultValue: {
         country: 'FAR',
         addressType: AddressType.DOMESTIC,
-        administrativeArea: user('primaryOfficeId').locationLevel('village')
+        administrativeArea: user('administrativeAreaId')
       },
       configuration: {
         streetAddressForm: defaultStreetAddressConfiguration,

--- a/src/events/death/forms/pages/informant.ts
+++ b/src/events/death/forms/pages/informant.ts
@@ -543,7 +543,7 @@ export const informant = defineFormPage({
       defaultValue: {
         country: 'FAR',
         addressType: AddressType.DOMESTIC,
-        administrativeArea: user('primaryOfficeId').locationLevel('village')
+        administrativeArea: user('administrativeAreaId')
       },
       configuration: {
         streetAddressForm: defaultStreetAddressConfiguration

--- a/src/events/death/forms/pages/spouse.ts
+++ b/src/events/death/forms/pages/spouse.ts
@@ -477,7 +477,7 @@ export const spouse = defineFormPage({
       defaultValue: {
         country: 'FAR',
         addressType: AddressType.DOMESTIC,
-        administrativeArea: user('primaryOfficeId').locationLevel('village')
+        administrativeArea: user('administrativeAreaId')
       },
       configuration: {
         streetAddressForm: defaultStreetAddressConfiguration


### PR DESCRIPTION
Fixes https://github.com/opencrvs/opencrvs-core/issues/12413

CC branch: https://github.com/opencrvs/opencrvs-countryconfig/pull/1398

## Problem

Hospital officials were unable to NOTIFY birth/death records when mother's, father's, or other persons' usual place of residence was left blank.

The address fields were defaulting `administrativeArea` to `user('primaryOfficeId').locationLevel('village')`. For hospital officials like `k.bwalya`, their administrative hierarchy doesn't include a village, thus it fails to resolve the hierarchy and returns `""` (empty string). That empty string gets submitted as `administrativeArea` in the NOTIFY payload, which is rejected by the core schema:

```typescript
// packages/commons/src/events/CompositeFieldValue.ts
administrativeArea: z.string().uuid().nullish()
```

This accepts a valid UUID, `null`, or `undefined` — but not `""`. The request fails with `BAD_REQUEST` before it ever reaches country-config validation.

## Fix

Switch `administrativeArea` to `user('administrativeAreaId')` across all affected address fields (birth and death events). This uses the user's administrative area ID directly when available, and returns `undefined` — not `""` — when the user does not have one. `undefined` satisfies `.nullish()` and no longer blocks NOTIFY.

## Why not fix in core?

The deeper root cause is that the address component in core emits `""` instead of `undefined` for an unfilled `administrativeArea`. That is being addressed in [opencrvs-core#12401](https://github.com/opencrvs/opencrvs-core/pull/12401/changes/0644c59677b417328ee1fa6e7660d248ec22404f), which refactors form initialization to avoid emitting empty strings for blank fields. Until that lands, this country-config fix unblocks hospital officials immediately.

## Testing

Added `birth-declaration-11.spec.ts`: hospital official creates a birth record with only child name filled (all address fields blank), notifies, and asserts the outbox is empty.