### PR TITLE
fix: unbound variable logic

### DIFF
--- a/infrastructure/postgres/setup-reference-data.sh
+++ b/infrastructure/postgres/setup-reference-data.sh
@@ -7,10 +7,10 @@ set -euo pipefail
 : "${POSTGRES_PASSWORD:?Must set POSTGRES_PASSWORD}"
 : "${POSTGRES_USER:?Must set POSTGRES_USER}"
 
-if [[ -z "$REFERENCE_DATA_POSTGRES_PASSWORD" ||
-      -z "$REFERENCE_DATA_POSTGRES_USER" ||
-      -z "$REFERENCE_DATA_EDITOR_PASSWORD" ||
-      -z "$REFERENCE_DATA_EDITOR_USER" ]]; then
+if [[ -z "${REFERENCE_DATA_POSTGRES_PASSWORD:-}" ||
+      -z "${REFERENCE_DATA_POSTGRES_USER:-}" ||
+      -z "${REFERENCE_DATA_EDITOR_PASSWORD:-}" ||
+      -z "${REFERENCE_DATA_EDITOR_USER:-}" ]]; then
   echo "Required variables are not set, skipping..."
   exit 0
 fi


### PR DESCRIPTION
## Description

Script `infrastructure/postgres/setup-reference-data.sh` fails with following error:
```
line 13: REFERENCE_DATA_POSTGRES_PASSWORD: unbound variable
```

Root cause:

Error coming from Bash strict mode, specifically:
```
set -u   # or: set -o nounset
```

## Testing

<img width="885" height="114" alt="image" src="https://github.com/user-attachments/assets/060777cd-2c4c-4122-9de2-5301d0ae897a" />


## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
