### PR TITLE
fix (release-automation): re-organize `init-release` workflow steps 

### DIFF
--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -95,15 +95,27 @@ jobs:
           git checkout -b "release/${{ inputs.version }}"
           git push origin "release/${{ inputs.version }}"
 
+      # A dedicated merge-back branch is used for the develop PR so that any
+      # conflict-resolution commits do not land on the release branch itself.
+      - name: Create merge-back branch for develop PR
+        run: |
+          MERGEBACK_BRANCH="merge-back/release-${{ inputs.version }}-to-develop"
+          if git ls-remote --exit-code --heads origin "$MERGEBACK_BRANCH" > /dev/null 2>&1; then
+            echo "Branch $MERGEBACK_BRANCH already exists, skipping."
+          else
+            git fetch origin "release/${{ inputs.version }}"
+            git checkout -b "$MERGEBACK_BRANCH" "origin/release/${{ inputs.version }}"
+            git push origin "$MERGEBACK_BRANCH"
+          fi
+
       # Two PRs are always created:
       #
       #   PR 1 — release/<version> → master
       #     The release PR. Merging this ships the version to production.
       #
-      #   PR 2 — release/<version> → develop
-      #     The merge-back PR. Ensures any fixes cherry-picked onto the release
-      #     branch flow back into develop.
-      #     This PR is always created regardless of what the base branch was:
+      #   PR 2 — merge-back/release-<version>-to-develop → develop
+      #     Uses a dedicated branch so conflict-resolution commits stay off
+      #     the release branch.
       #       - z=0 (base is develop): initially an empty diff; useful once
       #         release-branch fixes are cherry-picked.
       #       - z>0 (base is a prior release branch): backports patch fixes.
@@ -112,6 +124,7 @@ jobs:
       - name: Create Pull Requests
         run: |
           PR_BRANCH="release/${{ inputs.version }}"
+          MERGEBACK_BRANCH="merge-back/release-${{ inputs.version }}-to-develop"
           TARGET_BRANCH="${{ steps.get_base_branch.outputs.target_branch }}"
 
           if [ -f .github/TEMPLATES/RELEASE_PR_TEMPLATE.md ]; then
@@ -128,18 +141,18 @@ jobs:
               --title "Release v${{ inputs.version }}" \
               --body "$BODY"
           else
-            echo "PR release/${{ inputs.version }} → $TARGET_BRANCH already exists (#$EXISTING_MASTER_PR), skipping."
+            echo "PR $PR_BRANCH → $TARGET_BRANCH already exists (#$EXISTING_MASTER_PR), skipping."
           fi
 
-          EXISTING_DEVELOP_PR=$(gh pr list --head "$PR_BRANCH" --base "develop" --state open --json number --jq '.[0].number // ""')
+          EXISTING_DEVELOP_PR=$(gh pr list --head "$MERGEBACK_BRANCH" --base "develop" --state open --json number --jq '.[0].number // ""')
           if [ -z "$EXISTING_DEVELOP_PR" ]; then
             gh pr create \
               --base "develop" \
-              --head "$PR_BRANCH" \
+              --head "$MERGEBACK_BRANCH" \
               --title "chore: merge release v${{ inputs.version }} back to develop" \
               --body "Merge release branch back to develop to keep develop in sync with any release-branch fixes."
           else
-            echo "PR release/${{ inputs.version }} → develop already exists (#$EXISTING_DEVELOP_PR), skipping."
+            echo "PR $MERGEBACK_BRANCH → develop already exists (#$EXISTING_DEVELOP_PR), skipping."
           fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -77,9 +77,21 @@ jobs:
           echo "target_branch=master" >> $GITHUB_OUTPUT
           echo "base_branch=$base_branch" >> $GITHUB_OUTPUT
 
+      - name: Check if release branch already exists
+        id: check_branch
+        run: |
+          if git ls-remote --exit-code --heads origin "release/${{ inputs.version }}" > /dev/null 2>&1; then
+            echo "Branch release/${{ inputs.version }} already exists, skipping creation."
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
       # Create the release branch from the base and push it immediately.
       # PRs are opened only after the branch exists on the remote.
+      # Skipped if the release branch was already created by a previous run.
       - name: Create release branch
+        if: steps.check_branch.outputs.exists == 'false'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -100,6 +112,8 @@ jobs:
       #       - z=0 (base is develop): initially an empty diff; useful once
       #         release-branch fixes are cherry-picked.
       #       - z>0 (base is a prior release branch): backports patch fixes.
+      # Each PR is checked individually — one may already exist while the other
+      # does not, so both are always evaluated.
       - name: Create Pull Requests
         run: |
           PR_BRANCH="release/${{ inputs.version }}"
@@ -111,16 +125,26 @@ jobs:
             BODY=""
           fi
 
-          gh pr create \
-            --base "$TARGET_BRANCH" \
-            --head "$PR_BRANCH" \
-            --title "Release v${{ inputs.version }}" \
-            --body "$BODY"
+          EXISTING_MASTER_PR=$(gh pr list --head "$PR_BRANCH" --base "$TARGET_BRANCH" --state open --json number --jq '.[0].number // ""')
+          if [ -z "$EXISTING_MASTER_PR" ]; then
+            gh pr create \
+              --base "$TARGET_BRANCH" \
+              --head "$PR_BRANCH" \
+              --title "Release v${{ inputs.version }}" \
+              --body "$BODY"
+          else
+            echo "PR release/${{ inputs.version }} → $TARGET_BRANCH already exists (#$EXISTING_MASTER_PR), skipping."
+          fi
 
-          gh pr create \
-            --base "develop" \
-            --head "$PR_BRANCH" \
-            --title "chore: merge release v${{ inputs.version }} back to develop" \
-            --body "Merge release branch back to develop to keep develop in sync with any release-branch fixes."
+          EXISTING_DEVELOP_PR=$(gh pr list --head "$PR_BRANCH" --base "develop" --state open --json number --jq '.[0].number // ""')
+          if [ -z "$EXISTING_DEVELOP_PR" ]; then
+            gh pr create \
+              --base "develop" \
+              --head "$PR_BRANCH" \
+              --title "chore: merge release v${{ inputs.version }} back to develop" \
+              --body "Merge release branch back to develop to keep develop in sync with any release-branch fixes."
+          else
+            echo "PR release/${{ inputs.version }} → develop already exists (#$EXISTING_DEVELOP_PR), skipping."
+          fi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -12,15 +12,20 @@
 # Triggered by opencrvs-core's init-release workflow (or manually) with a
 # semver version string (e.g. 1.7.2).
 #
-# Farajaland only maintains release branches — no versioned packages or
-# CHANGELOG are managed here. What this workflow does, in order:
+# Farajaland is a mirror of opencrvs-countryconfig with farajaland-specific
+# modifications on top. Version bumps and CHANGELOG entries live in
+# countryconfig; farajaland inherits them by merging countryconfig's release
+# branch. What this workflow does, in order:
 #   1. Derives the base branch:
 #        - patch release (z > 0)  → release/<x>.<y>.<z-1>  (must already exist)
 #        - minor/major (z = 0)    → develop
-#   2. Creates a release branch (release/<version>) from the base branch.
-#   3. Opens two PRs:
-#        a. release/<version> → master   (the release PR)
-#        b. release/<version> → develop  (merge-back PR, keeps develop in sync)
+#   2. Waits for countryconfig's release/<version> branch to appear (both
+#      workflows are triggered in parallel by core's init-release).
+#   3. Creates a release branch from the farajaland base branch, then merges
+#      countryconfig's release branch in to inherit version-bump commits.
+#   4. Opens two PRs:
+#        a. release/<version> → master                          (the release PR)
+#        b. merge-back/release-<version>-to-develop → develop  (merge-back PR)
 name: Release - Start a new release
 on:
   workflow_dispatch:
@@ -82,8 +87,33 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
-      # Create the release branch from the base and push it immediately.
-      # PRs are opened only after the branch exists on the remote.
+      # Poll for countryconfig's release branch before creating farajaland's.
+      # Both workflows are triggered at the same time by core's init-release,
+      # so countryconfig may not have pushed its branch yet.
+      # Skipped if the farajaland release branch was already created by a
+      # previous run (countryconfig's branch must exist at that point already).
+      - name: Wait for countryconfig release branch
+        if: steps.check_branch.outputs.exists == 'false'
+        run: |
+          RELEASE_BRANCH="release/${{ inputs.version }}"
+          for i in $(seq 1 20); do
+            if git ls-remote --exit-code --heads \
+                https://github.com/opencrvs/opencrvs-countryconfig.git \
+                "$RELEASE_BRANCH" > /dev/null 2>&1; then
+              echo "countryconfig/$RELEASE_BRANCH is available."
+              exit 0
+            fi
+            if [ "$i" -eq 20 ]; then
+              echo "Timed out waiting for countryconfig/$RELEASE_BRANCH." >&2
+              exit 1
+            fi
+            echo "Attempt $i/20: waiting 30s for countryconfig/$RELEASE_BRANCH..."
+            sleep 30
+          done
+
+      # Create farajaland's release branch from its own base, then merge
+      # countryconfig's release branch in. This brings version-bump commits
+      # into farajaland so PRs have a real diff.
       # Skipped if the release branch was already created by a previous run.
       - name: Create release branch
         if: steps.check_branch.outputs.exists == 'false'
@@ -93,6 +123,11 @@ jobs:
 
           git checkout "${{ steps.get_base_branch.outputs.base_branch }}"
           git checkout -b "release/${{ inputs.version }}"
+
+          git remote add countryconfig https://github.com/opencrvs/opencrvs-countryconfig.git
+          git fetch countryconfig "release/${{ inputs.version }}"
+          git merge --no-edit "countryconfig/release/${{ inputs.version }}"
+
           git push origin "release/${{ inputs.version }}"
 
       # A dedicated merge-back branch is used for the develop PR so that any

--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -33,15 +33,18 @@ on:
 jobs:
   release_workflow:
     runs-on: ubuntu-latest
+    # Explicitly declare required permissions as a safety net — org-level
+    # defaults may vary. contents: write for git push; pull-requests: write
+    # for gh pr create.
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       # Full history is needed for git operations below.
-      # GH_TOKEN (PAT) is used instead of GITHUB_TOKEN so that git push has
-      # write access — GITHUB_TOKEN may be read-only depending on repo settings.
       - name: Checkout the repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
 
       # Derive base_branch and target_branch from the version number.
       #   - patch (z > 0): base = release/<x>.<y>.<z-1>, target = master
@@ -120,4 +123,4 @@ jobs:
             --title "chore: merge release v${{ inputs.version }} back to develop" \
             --body "Merge release branch back to develop to keep develop in sync with any release-branch fixes."
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -6,24 +6,47 @@
 # & Healthcare Disclaimer located at http://opencrvs.org/license.
 #
 # Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
-name: Release - Start a new release 
+
+# Gitflow release initialisation workflow.
+#
+# Triggered by opencrvs-core's init-release workflow (or manually) with a
+# semver version string (e.g. 1.7.2).
+#
+# Farajaland only maintains release branches — no versioned packages or
+# CHANGELOG are managed here. What this workflow does, in order:
+#   1. Derives the base branch:
+#        - patch release (z > 0)  → release/<x>.<y>.<z-1>  (must already exist)
+#        - minor/major (z = 0)    → develop
+#   2. Creates a release branch (release/<version>) from the base branch.
+#   3. Opens two PRs:
+#        a. release/<version> → master   (the release PR)
+#        b. release/<version> → develop  (merge-back PR, keeps develop in sync)
+name: Release - Start a new release
 on:
   workflow_dispatch:
     inputs:
       version:
         type: string
         required: true
-        description: "Version to release"
-  
+        description: 'Version to release'
+
 jobs:
   release_workflow:
     runs-on: ubuntu-latest
     steps:
+      # Full history is needed for git operations below.
       - name: Checkout the repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Derive base_branch and target_branch from the version number.
+      #   - patch (z > 0): base = release/<x>.<y>.<z-1>, target = master
+      #     The previous release branch must already exist; if not, the step
+      #     fails early with a clear message rather than branching from an
+      #     unexpected point.
+      #   - minor/major (z = 0): base = develop, target = master
       - name: Determine the Base Branch
         id: get_base_branch
         run: |
@@ -41,20 +64,58 @@ jobs:
           else
             previous_version="$((x)).$((y)).$((z-1))"
             base_branch="release/$previous_version"
-            if ! git ls-remote --exit-code --heads origin $base_branch; then
-              echo "The branch $base_branch does not exist. Please create it before starting a new Hot-fix release." >> GITHUB_STEP_SUMMARY
+            if ! git ls-remote --exit-code --heads origin "$base_branch"; then
+              echo "The branch $base_branch does not exist. Please create it before starting a new patch release." >> "$GITHUB_STEP_SUMMARY"
               exit 1
             fi
           fi
+          echo "target_branch=master" >> $GITHUB_OUTPUT
           echo "base_branch=$base_branch" >> $GITHUB_OUTPUT
-      
-      - name: Create a new release branch
+
+      # Create the release branch from the base and push it immediately.
+      # PRs are opened only after the branch exists on the remote.
+      - name: Create release branch
         run: |
-          git checkout $base_branch
-          version="${{ inputs.version }}"
-          release_branch="release/$version"
-          git checkout -b $release_branch
-          git push origin $release_branch
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          git checkout "${{ steps.get_base_branch.outputs.base_branch }}"
+          git checkout -b "release/${{ inputs.version }}"
+          git push origin "release/${{ inputs.version }}"
 
-    
+      # Two PRs are always created:
+      #
+      #   PR 1 — release/<version> → master
+      #     The release PR. Merging this ships the version to production.
+      #
+      #   PR 2 — release/<version> → develop
+      #     The merge-back PR. Ensures any fixes cherry-picked onto the release
+      #     branch flow back into develop.
+      #     This PR is always created regardless of what the base branch was:
+      #       - z=0 (base is develop): initially an empty diff; useful once
+      #         release-branch fixes are cherry-picked.
+      #       - z>0 (base is a prior release branch): backports patch fixes.
+      - name: Create Pull Requests
+        run: |
+          PR_BRANCH="release/${{ inputs.version }}"
+          TARGET_BRANCH="${{ steps.get_base_branch.outputs.target_branch }}"
+
+          if [ -f .github/TEMPLATES/RELEASE_PR_TEMPLATE.md ]; then
+            BODY=$(cat .github/TEMPLATES/RELEASE_PR_TEMPLATE.md)
+          else
+            BODY=""
+          fi
+
+          gh pr create \
+            --base "$TARGET_BRANCH" \
+            --head "$PR_BRANCH" \
+            --title "Release v${{ inputs.version }}" \
+            --body "$BODY"
+
+          gh pr create \
+            --base "develop" \
+            --head "$PR_BRANCH" \
+            --title "chore: merge release v${{ inputs.version }} back to develop" \
+            --body "Merge release branch back to develop to keep develop in sync with any release-branch fixes."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -39,6 +39,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       # Derive base_branch and target_branch from the version number.
       #   - patch (z > 0): base = release/<x>.<y>.<z-1>, target = master
@@ -86,8 +87,6 @@ jobs:
       # Skipped if the release branch was already created by a previous run.
       - name: Create release branch
         if: steps.check_branch.outputs.exists == 'false'
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_AUTOMATION_PAT }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -143,4 +142,4 @@ jobs:
             echo "PR release/${{ inputs.version }} → develop already exists (#$EXISTING_DEVELOP_PR), skipping."
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_AUTOMATION_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -33,12 +33,6 @@ on:
 jobs:
   release_workflow:
     runs-on: ubuntu-latest
-    # Explicitly declare required permissions as a safety net — org-level
-    # defaults may vary. contents: write for git push; pull-requests: write
-    # for gh pr create.
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       # Full history is needed for git operations below.
       - name: Checkout the repository
@@ -92,6 +86,8 @@ jobs:
       # Skipped if the release branch was already created by a previous run.
       - name: Create release branch
         if: steps.check_branch.outputs.exists == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_AUTOMATION_PAT }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -147,4 +143,4 @@ jobs:
             echo "PR release/${{ inputs.version }} → develop already exists (#$EXISTING_DEVELOP_PR), skipping."
           fi
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_AUTOMATION_PAT }}

--- a/.github/workflows/init-release.yml
+++ b/.github/workflows/init-release.yml
@@ -35,11 +35,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Full history is needed for git operations below.
+      # GH_TOKEN (PAT) is used instead of GITHUB_TOKEN so that git push has
+      # write access — GITHUB_TOKEN may be read-only depending on repo settings.
       - name: Checkout the repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
 
       # Derive base_branch and target_branch from the version number.
       #   - patch (z > 0): base = release/<x>.<y>.<z-1>, target = master
@@ -118,4 +120,4 @@ jobs:
             --title "chore: merge release v${{ inputs.version }} back to develop" \
             --body "Merge release branch back to develop to keep develop in sync with any release-branch fixes."
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
## Why

The previous farajaland workflow only created a release branch (a plain copy of the base branch with no commits on top) and stopped there — it had no PR creation step at all. Two problems followed:

1. **No PRs were created.** The workflow never called `gh pr create`, so the release and merge-back PRs had to be opened manually after the fact.
2. **Empty diff.** Farajaland has no version-bump commits of its own. Even if PRs had been created, GitHub would have rejected them ("no commits between head and base"). The fix is to merge countryconfig's release branch into farajaland's — farajaland mirrors countryconfig with farajaland-specific modifications on top, so this is the natural source of the diff.

Additionally, the base branch derivation used an unquoted variable (`$base_branch`) which could silently break on branch names with special characters, and the error message referenced "Hot-fix release" rather than "patch release".

## What changes

- Added PR creation step with idempotency checks — opens `release/<version> → master` and `merge-back/release-<version>-to-develop → develop`
- Introduces a dedicated `merge-back/release-<version>-to-develop` branch for the develop PR so conflict-resolution commits never land on the release branch
- New "Wait for countryconfig release branch" step: polls every 30s (up to 10 min) before proceeding — both farajaland and countryconfig are triggered in parallel by core, so countryconfig's branch may not exist yet
- Release branch creation now merges countryconfig's `release/<version>` branch in, inheriting version-bump commits and producing a real diff for both PRs
- Release branch creation is idempotent — skipped if the branch already exists; the wait step is also skipped in that case
- Fixed variable quoting in base branch references
- Fixed error message: "Hot-fix release" → "patch release"

## How to test

1. Trigger via core's init-release workflow run from any branch that contains these changes
2. Confirm: farajaland waits for countryconfig's `release/<version>` to appear, then proceeds
3. Confirm: `release/<version>` in farajaland contains countryconfig's version-bump commits (non-empty diff)
4. Confirm: two PRs are opened — `release/<version> → master` and `merge-back/release-<version>-to-develop → develop` — both with non-empty diffs
5. Re-run the workflow with the same version — all steps should complete cleanly with "already exists, skipping" messages