### PR TITLE
fix: wait 30s before resolving commt hashes on deploy and e2e

### DIFF
--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -29,6 +29,13 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  wait-30s:
+    name: wait 30s
+    runs-on: ubuntu-latest
+    steps:
+      - name: wait 30s
+        run: sleep 30
+
   get-core-commit:
     name: Resolve latest core tag
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -30,6 +30,8 @@ concurrency:
 
 jobs:
   wait-30s:
+    # Avoid a race condition when PRs exist in both farajaland and core.
+    # The delay gives the other PR time to merge before reading develop.
     name: wait 30s
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
