### PR TITLE
workqueue url param changed to backTo in e2e testcases

### DIFF
--- a/e2e/testcases/application/4a-validate-pending-updates-FA.spec.ts
+++ b/e2e/testcases/application/4a-validate-pending-updates-FA.spec.ts
@@ -100,7 +100,10 @@ test.describe.serial('4(a) Validate "Pending updates"-workqueue for HO', () => {
     await page.getByRole('button', { name: formattedChildName }).click()
 
     // User should navigate to record audit page
-    await expectInUrl(page, `events/${eventId}?workqueue=pending-updates`)
+    await expectInUrl(
+      page,
+      `events/${eventId}?backTo=%2Fworkqueue%2Fpending-updates`
+    )
   })
 
   test('4.5 Acting directly from workqueue should redirect to the same workqueue', async () => {

--- a/e2e/testcases/application/4b-validate-pending-updates-RA.spec.ts
+++ b/e2e/testcases/application/4b-validate-pending-updates-RA.spec.ts
@@ -94,7 +94,10 @@ test.describe.serial('4(b) Validate "Pending updates"-workqueue for RO', () => {
       .click()
 
     // User should navigate to record audit page
-    await expectInUrl(page, `events/${eventId}?workqueue=pending-updates`)
+    await expectInUrl(
+      page,
+      `events/${eventId}?backTo=%2Fworkqueue%2Fpending-updates`
+    )
   })
 
   test('4.4 Click Edit -action', async () => {

--- a/e2e/testcases/application/5a-validate-pending-validation-RA.spec.ts
+++ b/e2e/testcases/application/5a-validate-pending-validation-RA.spec.ts
@@ -73,7 +73,10 @@ test.describe
       .getByRole('button', { name: formatV2ChildName(declaration) })
       .click()
 
-    await expectInUrl(page, `events/${eventId}?workqueue=pending-validation`)
+    await expectInUrl(
+      page,
+      `events/${eventId}?backTo=%2Fworkqueue%2Fpending-validation`
+    )
   })
 
   test('5.4 Click "Validate"-action', async () => {

--- a/e2e/testcases/application/5b-validate-pending-registration-for-registrar.spec.ts
+++ b/e2e/testcases/application/5b-validate-pending-registration-for-registrar.spec.ts
@@ -68,7 +68,10 @@ test.describe
       .getByRole('button', { name: formatV2ChildName(declaration) })
       .click()
 
-    await expectInUrl(page, `events/${eventId}?workqueue=pending-registration`)
+    await expectInUrl(
+      page,
+      `events/${eventId}?backTo=%2Fworkqueue%2Fpending-registration`
+    )
   })
 
   test('5.5 Register action should be available for declared and validated record', async () => {

--- a/e2e/testcases/application/6-validate-pending-certification.spec.ts
+++ b/e2e/testcases/application/6-validate-pending-certification.spec.ts
@@ -69,7 +69,10 @@ test.describe.serial('6 Validate "Pending certification"-workqueue', () => {
       .getByRole('button', { name: formatV2ChildName(declaration) })
       .click()
 
-    await expectInUrl(page, `events/${eventId}?workqueue=pending-certification`)
+    await expectInUrl(
+      page,
+      `events/${eventId}?backTo=%2Fworkqueue%2Fpending-certification`
+    )
   })
 
   test('6.5 Click Print action', async () => {
@@ -78,7 +81,7 @@ test.describe.serial('6 Validate "Pending certification"-workqueue', () => {
     await expect(page.locator('#content-name')).toHaveText('Certify record')
     await expectInUrl(
       page,
-      `/events/print-certificate/${eventId}/pages/collector?workqueue=pending-certification`
+      `/events/print-certificate/${eventId}/pages/collector?backTo=%2Fworkqueue%2Fpending-certification`
     )
   })
 })

--- a/e2e/testcases/birth/save-and-delete-drafts.spec.ts
+++ b/e2e/testcases/birth/save-and-delete-drafts.spec.ts
@@ -64,7 +64,7 @@ test.describe('Save and delete drafts', () => {
       await page.getByRole('button', { name: 'Confirm' }).click()
 
       await ensureOutboxIsEmpty(page)
-      await page.getByText('Drafts').click()
+      await expect(page.getByText('No records in drafts')).toBeVisible()
 
       await expect(
         page.getByRole('button', { name: childName, exact: true })

--- a/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
@@ -274,7 +274,7 @@ test.describe('1. Correct record - 1', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=pending-certification#child____name`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____name`
         )
 
         await page
@@ -321,7 +321,7 @@ test.describe('1. Correct record - 1', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=pending-certification#child____gender`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____gender`
         )
 
         await page.getByTestId('select__child____gender').locator('svg').click()
@@ -359,7 +359,7 @@ test.describe('1. Correct record - 1', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=pending-certification#child____dob`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____dob`
         )
 
         const birthDay = updatedChildDetails.birthDate.split('-')
@@ -400,7 +400,7 @@ test.describe('1. Correct record - 1', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=pending-certification#child____placeOfBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____placeOfBirth`
         )
 
         await page
@@ -450,7 +450,7 @@ test.describe('1. Correct record - 1', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=pending-certification#child____attendantAtBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____attendantAtBirth`
         )
 
         await page.getByTestId('select__child____attendantAtBirth').click()
@@ -491,7 +491,7 @@ test.describe('1. Correct record - 1', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=pending-certification#child____birthType`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____birthType`
         )
 
         await page.getByTestId('select__child____birthType').click()
@@ -552,7 +552,7 @@ test.describe('1. Correct record - 1', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=pending-certification#child____weightAtBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____weightAtBirth`
         )
 
         await page

--- a/e2e/testcases/correction-birth/correct-birth-record-10.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-10.spec.ts
@@ -188,7 +188,7 @@ test.describe('10. Correct record', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=pending-certification#child____name`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____name`
         )
 
         await page
@@ -235,7 +235,7 @@ test.describe('10. Correct record', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=pending-certification#child____gender`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____gender`
         )
 
         await page.getByTestId('select__child____gender').locator('svg').click()
@@ -273,7 +273,7 @@ test.describe('10. Correct record', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=pending-certification#child____dob`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____dob`
         )
 
         const birthDay = updatedChildDetails.birthDate.split('-')
@@ -314,7 +314,7 @@ test.describe('10. Correct record', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=pending-certification#child____placeOfBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____placeOfBirth`
         )
 
         await page
@@ -364,7 +364,7 @@ test.describe('10. Correct record', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=pending-certification#child____attendantAtBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____attendantAtBirth`
         )
 
         await page.getByTestId('select__child____attendantAtBirth').click()
@@ -405,7 +405,7 @@ test.describe('10. Correct record', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=pending-certification#child____birthType`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____birthType`
         )
 
         await page.getByTestId('select__child____birthType').click()
@@ -466,7 +466,7 @@ test.describe('10. Correct record', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&workqueue=pending-certification#child____weightAtBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____weightAtBirth`
         )
 
         await page

--- a/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
@@ -155,7 +155,7 @@ test.describe.serial('Correct record - 2', () => {
 
       await expectInUrl(
         page,
-        `/events/request-correction/${eventId}/pages/informant?from=review&workqueue=pending-certification#informant____relation`
+        `/events/request-correction/${eventId}/pages/informant?from=review&backTo=%2Fworkqueue%2Fpending-certification#informant____relation`
       )
 
       await page.locator('#informant____relation').click()
@@ -202,7 +202,7 @@ test.describe.serial('Correct record - 2', () => {
 
       await expectInUrl(
         page,
-        `/events/request-correction/${eventId}/pages/child?from=review&workqueue=pending-certification#child____placeOfBirth`
+        `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____placeOfBirth`
       )
 
       await page.locator('#child____placeOfBirth').click()

--- a/e2e/testcases/navigation/navigating-in-and-out-of-action-from-workqueue.spec.ts
+++ b/e2e/testcases/navigation/navigating-in-and-out-of-action-from-workqueue.spec.ts
@@ -66,7 +66,7 @@ test.describe.skip('Navigating in and out of action', () => {
     await page.goBack()
     await expectInUrl(
       page,
-      `/events/${eventId}/record?workqueue=pending-registration`
+      `/events/${eventId}/record?backTo=%2Fworkqueue%2Fpending-registration`
     )
   })
 
@@ -107,7 +107,7 @@ test.describe.skip('Navigating in and out of action', () => {
     await page.waitForURL(/\/review/)
     await expectInUrl(
       page,
-      `/events/print-certificate/${eventId}/review?templateId=v2.birth-certificate&workqueue=pending-certification`
+      `/events/print-certificate/${eventId}/review?templateId=v2.birth-certificate&backTo=%2Fworkqueue%2Fpending-certification`
     )
   })
 

--- a/e2e/testcases/navigation/navigating-in-and-out-of-action.spec.ts
+++ b/e2e/testcases/navigation/navigating-in-and-out-of-action.spec.ts
@@ -91,7 +91,7 @@ test.describe.serial('Navigating in and out of action', () => {
     await page.goForward()
     await expectInUrl(
       page,
-      `/events/${eventId}?workqueue=pending-certification`
+      `/events/${eventId}?backTo=%2Fworkqueue%2Fpending-certification`
     )
   })
 })


### PR DESCRIPTION
## Description

https://github.com/opencrvs/opencrvs-core/issues/12732
core: https://github.com/opencrvs/opencrvs-core/pull/12750

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
