### PR TITLE
Fire-and-forget MOSIP death registration & `await` MOSIP received birth/death message

### DIFF
--- a/src/api/registration/index.ts
+++ b/src/api/registration/index.ts
@@ -189,8 +189,7 @@ export async function onMosipBirthRegisterHandler(
     )
     const informantPsut = getInformantPsut(declaration, birthInformantSection)
 
-    // @TODO: Check whether this might crash country-config if MOSIP doesn't respond
-    mosipInteropClient.register({
+    await mosipInteropClient.register({
       trackingId: event.trackingId,
       requestFields: {
         birthCertificateNumber: registrationNumber,

--- a/src/api/registration/index.ts
+++ b/src/api/registration/index.ts
@@ -260,8 +260,7 @@ export async function onMosipDeathRegisterHandler(
         : 'informant'
     const informantPsut = getInformantPsut(declaration, deathInformantSection)
 
-    // @TODO: Check whether this might crash country-config if MOSIP doesn't respond
-    mosipInteropClient.register({
+    await mosipInteropClient.register({
       trackingId: event.trackingId,
       requestFields: {
         deathCertificateNumber: registrationNumber,
@@ -285,7 +284,7 @@ export async function onMosipDeathRegisterHandler(
       audit: {}
     })
 
-    return h.response().code(202)
+    return h.response({ registrationNumber }).code(200)
   } catch (error) {
     return h
       .response({


### PR DESCRIPTION
https://github.com/opencrvs/opencrvs-core/issues/12205
As specified in the ticket, don't wait for MOSIP to respond in death registrations.