### PR TITLE
Fix/e2e flakyness

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -523,7 +523,7 @@ export const dateToIsoDateString = (date: Date) =>
  *  Useful for generating child.dob and others.
  *
  * @param daysBack how many days in the past the range takes a sample from
- * @returns date in DATE format
+ * @returns date in ISO format
  */
 export const randomPastDate = (daysBack = 14) => {
   const today = new Date()

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -15,6 +15,7 @@ import fetch from 'node-fetch'
 import { isMobile } from './mobile-helpers'
 import { createClient } from '@opencrvs/toolkit/api'
 import { UUID } from 'crypto'
+import { faker } from '@faker-js/faker'
 
 export async function createPIN(page: Page) {
   await page.click('#pin-input')
@@ -515,3 +516,19 @@ export const formatDateObjectTo_dMMMMyyyy = ({
   mm: string
   dd: string
 }) => format(new Date(Number(yyyy), Number(mm) - 1, Number(dd)), 'd MMMM yyyy')
+
+export const dateToIsoDateString = (date: Date) =>
+  date.toISOString().split('T')[0]
+/**
+ *  Useful for generating child.dob and others.
+ *
+ * @param daysBack how many days in the past the range takes a sample from
+ * @returns date in DATE format
+ */
+export const randomPastDate = (daysBack = 14) => {
+  const today = new Date()
+  const pastDate = new Date()
+  pastDate.setDate(today.getDate() - daysBack)
+
+  return dateToIsoDateString(faker.date.between({ from: pastDate, to: today }))
+}

--- a/e2e/testcases/advanced-search/2-search-birth-event-declaration-child-details.spec.ts
+++ b/e2e/testcases/advanced-search/2-search-birth-event-declaration-child-details.spec.ts
@@ -4,7 +4,7 @@ import { createDeclaration } from '../test-data/birth-declaration-with-father-br
 import { CREDENTIALS } from '../../constants'
 import { faker } from '@faker-js/faker'
 import { getMonthFormatted } from './helper'
-import { assertTexts, type } from '../../utils'
+import { assertTexts, expectInUrl, type } from '../../utils'
 
 test.describe
   .serial("Advanced Search - Birth Event Declaration - Child's details", () => {
@@ -35,7 +35,8 @@ test.describe
   test('2.1 - Validate log in and load search page', async () => {
     await login(page)
     await page.click('#searchType')
-    await expect(page).toHaveURL(/.*\/advanced-search/)
+    await expectInUrl(page, 'advanced-search')
+
     await page.getByText('Birth').click()
   })
 

--- a/e2e/testcases/advanced-search/4-search-birth-event-declaration-mother-details.spec.ts
+++ b/e2e/testcases/advanced-search/4-search-birth-event-declaration-mother-details.spec.ts
@@ -3,7 +3,7 @@ import { getToken, login } from '../../helpers'
 import { createDeclaration } from '../test-data/birth-declaration-with-father-brother'
 import { CREDENTIALS } from '../../constants'
 import { getMonthFormatted } from './helper'
-import { assertTexts, type } from '../../utils'
+import { assertTexts, expectInUrl, type } from '../../utils'
 
 test.describe
   .serial("Advanced Search - Birth Event Declaration - Mother's details", () => {
@@ -26,7 +26,7 @@ test.describe
   test('2.1 - Validate log in and load search page', async () => {
     await login(page)
     await page.click('#searchType')
-    await expect(page).toHaveURL(/.*\/advanced-search/)
+    await expectInUrl(page, 'advanced-search')
     await page.getByText('Birth').click()
   })
 

--- a/e2e/testcases/advanced-search/5-search-birth-event-declaration-father-details.spec.ts
+++ b/e2e/testcases/advanced-search/5-search-birth-event-declaration-father-details.spec.ts
@@ -7,7 +7,7 @@ import {
 import { CREDENTIALS } from '../../constants'
 import { faker } from '@faker-js/faker'
 import { getMonthFormatted } from './helper'
-import { assertTexts, type } from '../../utils'
+import { assertTexts, expectInUrl, type } from '../../utils'
 
 test.describe
   .serial("Advanced Search - Birth Event Declaration - Father's details", () => {
@@ -29,7 +29,7 @@ test.describe
   test('2.1 - Validate log in and load search page', async () => {
     await login(page)
     await page.click('#searchType')
-    await expect(page).toHaveURL(/.*\/advanced-search/)
+    await expectInUrl(page, 'advanced-search')
     await page.getByText('Birth').click()
   })
 

--- a/e2e/testcases/advanced-search/6-search-birth-event-declaration-informant-details.spec.ts
+++ b/e2e/testcases/advanced-search/6-search-birth-event-declaration-informant-details.spec.ts
@@ -3,7 +3,7 @@ import { getToken, login } from '../../helpers'
 import { createDeclaration } from '../test-data/birth-declaration-with-father-brother'
 import { CREDENTIALS } from '../../constants'
 import { getMonthFormatted } from './helper'
-import { assertTexts, type } from '../../utils'
+import { assertTexts, expectInUrl, type } from '../../utils'
 
 test.describe
   .serial("Advanced Search - Birth Event Declaration - Informant's details", () => {
@@ -25,7 +25,7 @@ test.describe
   test('2.1 - Validate log in and load search page', async () => {
     await login(page)
     await page.click('#searchType')
-    await expect(page).toHaveURL(/.*\/advanced-search/)
+    await expectInUrl(page, 'advanced-search')
     await page.getByText('Birth').click()
   })
 

--- a/e2e/testcases/advanced-search/7-search-birth-event-declaration-stauts.spec.ts
+++ b/e2e/testcases/advanced-search/7-search-birth-event-declaration-stauts.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from '@playwright/test'
 import { joinValuesWith, login } from '../../helpers'
 import { faker } from '@faker-js/faker'
-import { ensureOutboxIsEmpty, type } from '../../utils'
+import { ensureOutboxIsEmpty, expectInUrl, type } from '../../utils'
 
 test.describe
   .serial("Advanced Search - Birth Event Declaration - Informant's details", () => {
@@ -73,7 +73,8 @@ test.describe
     const searchResult = await page.locator('#content-name').textContent()
     const searchResultCountNumberInBracketsRegex = /\((\d+)\)$/
     expect(searchResult).toMatch(searchResultCountNumberInBracketsRegex)
-    expect(page.url()).toContain(`event.status=ALL`)
+    expectInUrl(page, 'event.status=ALL')
+
     expect(page.url()).toContain(
       `child.name=${encodeURIComponent(JSON.stringify({ firstname, surname }))}`
     )

--- a/e2e/testcases/advanced-search/9-search-birth-event-declaration-child-nid.spec.ts
+++ b/e2e/testcases/advanced-search/9-search-birth-event-declaration-child-nid.spec.ts
@@ -64,8 +64,7 @@ test.describe
       .poll(
         async () => {
           const event = await client.event.get.query({
-            eventId,
-            waitFor: false
+            eventId
           })
           const aggregated = aggregateActionDeclarations(event)
           childNid = aggregated['child.nid'] as string

--- a/e2e/testcases/application/4a-validate-pending-updates-FA.spec.ts
+++ b/e2e/testcases/application/4a-validate-pending-updates-FA.spec.ts
@@ -102,7 +102,7 @@ test.describe.serial('4(a) Validate "Pending updates"-workqueue for HO', () => {
     // User should navigate to record audit page
     await expectInUrl(
       page,
-      `events/${eventId}?backTo=%2Fworkqueue%2Fpending-updates`
+      `events/${eventId}?backTo=/workqueue/pending-updates`
     )
   })
 

--- a/e2e/testcases/application/4b-validate-pending-updates-RA.spec.ts
+++ b/e2e/testcases/application/4b-validate-pending-updates-RA.spec.ts
@@ -96,7 +96,7 @@ test.describe.serial('4(b) Validate "Pending updates"-workqueue for RO', () => {
     // User should navigate to record audit page
     await expectInUrl(
       page,
-      `events/${eventId}?backTo=%2Fworkqueue%2Fpending-updates`
+      `events/${eventId}?backTo=/workqueue/pending-updates`
     )
   })
 

--- a/e2e/testcases/application/5a-validate-pending-validation-RA.spec.ts
+++ b/e2e/testcases/application/5a-validate-pending-validation-RA.spec.ts
@@ -75,7 +75,7 @@ test.describe
 
     await expectInUrl(
       page,
-      `events/${eventId}?backTo=%2Fworkqueue%2Fpending-validation`
+      `events/${eventId}?backTo=/workqueue/pending-validation`
     )
   })
 

--- a/e2e/testcases/application/5b-validate-pending-registration-for-registrar.spec.ts
+++ b/e2e/testcases/application/5b-validate-pending-registration-for-registrar.spec.ts
@@ -70,7 +70,7 @@ test.describe
 
     await expectInUrl(
       page,
-      `events/${eventId}?backTo=%2Fworkqueue%2Fpending-registration`
+      `events/${eventId}?backTo=/workqueue/pending-registration`
     )
   })
 

--- a/e2e/testcases/application/6-validate-pending-certification.spec.ts
+++ b/e2e/testcases/application/6-validate-pending-certification.spec.ts
@@ -71,7 +71,7 @@ test.describe.serial('6 Validate "Pending certification"-workqueue', () => {
 
     await expectInUrl(
       page,
-      `events/${eventId}?backTo=%2Fworkqueue%2Fpending-certification`
+      `events/${eventId}?backTo=/workqueue/pending-certification`
     )
   })
 
@@ -81,7 +81,7 @@ test.describe.serial('6 Validate "Pending certification"-workqueue', () => {
     await expect(page.locator('#content-name')).toHaveText('Certify record')
     await expectInUrl(
       page,
-      `/events/print-certificate/${eventId}/pages/collector?backTo=%2Fworkqueue%2Fpending-certification`
+      `/events/print-certificate/${eventId}/pages/collector?backTo=/workqueue/pending-certification`
     )
   })
 })

--- a/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
@@ -83,7 +83,7 @@ test.describe('1. Correct record - 1', () => {
         page.getByRole('button', { name: 'Action' }).first()
       ).toBeVisible()
 
-      expect(page.url().includes(`/events/${eventId}`)).toBeTruthy()
+      await expectInUrl(page, `/events/${eventId}`)
 
       await expect(page.getByText(`StatusRegistered`)).toBeVisible()
       await expect(page.getByText(`EventBirth`)).toBeVisible()

--- a/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
@@ -274,7 +274,7 @@ test.describe('1. Correct record - 1', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____name`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=/workqueue/pending-certification#child____name`
         )
 
         await page
@@ -321,7 +321,7 @@ test.describe('1. Correct record - 1', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____gender`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=/workqueue/pending-certification#child____gender`
         )
 
         await page.getByTestId('select__child____gender').locator('svg').click()
@@ -359,7 +359,7 @@ test.describe('1. Correct record - 1', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____dob`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=/workqueue/pending-certification#child____dob`
         )
 
         const birthDay = updatedChildDetails.birthDate.split('-')
@@ -400,7 +400,7 @@ test.describe('1. Correct record - 1', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____placeOfBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=/workqueue/pending-certification#child____placeOfBirth`
         )
 
         await page
@@ -450,7 +450,7 @@ test.describe('1. Correct record - 1', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____attendantAtBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=/workqueue/pending-certification#child____attendantAtBirth`
         )
 
         await page.getByTestId('select__child____attendantAtBirth').click()
@@ -491,7 +491,7 @@ test.describe('1. Correct record - 1', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____birthType`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=/workqueue/pending-certification#child____birthType`
         )
 
         await page.getByTestId('select__child____birthType').click()
@@ -552,7 +552,7 @@ test.describe('1. Correct record - 1', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____weightAtBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=/workqueue/pending-certification#child____weightAtBirth`
         )
 
         await page

--- a/e2e/testcases/correction-birth/correct-birth-record-10.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-10.spec.ts
@@ -188,7 +188,7 @@ test.describe('10. Correct record', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____name`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=/workqueue/pending-certification#child____name`
         )
 
         await page
@@ -235,7 +235,7 @@ test.describe('10. Correct record', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____gender`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=/workqueue/pending-certification#child____gender`
         )
 
         await page.getByTestId('select__child____gender').locator('svg').click()
@@ -273,7 +273,7 @@ test.describe('10. Correct record', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____dob`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=/workqueue/pending-certification#child____dob`
         )
 
         const birthDay = updatedChildDetails.birthDate.split('-')
@@ -314,7 +314,7 @@ test.describe('10. Correct record', () => {
          */
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____placeOfBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=/workqueue/pending-certification#child____placeOfBirth`
         )
 
         await page
@@ -364,7 +364,7 @@ test.describe('10. Correct record', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____attendantAtBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=/workqueue/pending-certification#child____attendantAtBirth`
         )
 
         await page.getByTestId('select__child____attendantAtBirth').click()
@@ -405,7 +405,7 @@ test.describe('10. Correct record', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____birthType`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=/workqueue/pending-certification#child____birthType`
         )
 
         await page.getByTestId('select__child____birthType').click()
@@ -466,7 +466,7 @@ test.describe('10. Correct record', () => {
 
         await expectInUrl(
           page,
-          `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____weightAtBirth`
+          `/events/request-correction/${eventId}/pages/child?from=review&backTo=/workqueue/pending-certification#child____weightAtBirth`
         )
 
         await page

--- a/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
@@ -155,7 +155,7 @@ test.describe.serial('Correct record - 2', () => {
 
       await expectInUrl(
         page,
-        `/events/request-correction/${eventId}/pages/informant?from=review&backTo=%2Fworkqueue%2Fpending-certification#informant____relation`
+        `/events/request-correction/${eventId}/pages/informant?from=review&backTo=/workqueue/pending-certification#informant____relation`
       )
 
       await page.locator('#informant____relation').click()
@@ -202,7 +202,7 @@ test.describe.serial('Correct record - 2', () => {
 
       await expectInUrl(
         page,
-        `/events/request-correction/${eventId}/pages/child?from=review&backTo=%2Fworkqueue%2Fpending-certification#child____placeOfBirth`
+        `/events/request-correction/${eventId}/pages/child?from=review&backTo=/workqueue/pending-certification#child____placeOfBirth`
       )
 
       await page.locator('#child____placeOfBirth').click()

--- a/e2e/testcases/correction-birth/correct-birth-record-3.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-3.spec.ts
@@ -254,8 +254,8 @@ test.describe.serial(' Correct record - 3', () => {
     /*
      * Expected result: should navigate to review page
      */
-    expect(page.url().includes('correction')).toBeTruthy()
-    expect(page.url().includes('review')).toBeTruthy()
+    await expectInUrl(page, 'correction')
+    await expectInUrl(page, 'review')
   })
 
   test.describe('3.4 Make correction', async () => {
@@ -268,9 +268,9 @@ test.describe.serial(' Correct record - 3', () => {
          * - redirect to mother's details page
          * - focus on mother's family name
          */
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('mother')).toBeTruthy()
-        expect(page.url().includes('#mother____name')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'mother')
+        await expectInUrl(page, '#mother____name')
 
         await page.locator('#firstname').fill(updatedMotherDetails.firstNames)
         await page.locator('#surname').fill(updatedMotherDetails.familyName)
@@ -283,8 +283,8 @@ test.describe.serial(' Correct record - 3', () => {
          * - show previous name with strikethrough
          * - show updated name
          */
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('review')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'review')
 
         await expect(
           await page.getByTestId('row-value-mother.name').getByRole('deletion')
@@ -312,9 +312,9 @@ test.describe.serial(' Correct record - 3', () => {
          * - redirect to mother's details page
          * - focus on mother's age
          */
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('mother')).toBeTruthy()
-        expect(page.url().includes('#mother____dob')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'mother')
+        await expectInUrl(page, '#mother____dob')
 
         await page.locator('#mother____dobUnknown').click()
         await page
@@ -329,8 +329,8 @@ test.describe.serial(' Correct record - 3', () => {
          * - show previous gender with strikethrough
          * - show updated gender
          */
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('review')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'review')
 
         await expect(
           await page
@@ -351,9 +351,9 @@ test.describe.serial(' Correct record - 3', () => {
          * - redirect to mother's details page
          * - focus on mother's nationality
          */
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('mother')).toBeTruthy()
-        expect(page.url().includes('#mother____nationality')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'mother')
+        await expectInUrl(page, '#mother____nationality')
 
         await page.locator('#mother____nationality').click()
         await page.getByText(updatedMotherDetails.nationality).click()
@@ -366,8 +366,8 @@ test.describe.serial(' Correct record - 3', () => {
          * - show previous nationality with strikethrough
          * - show updated nationality
          */
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('review')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'review')
 
         await expect(
           await page
@@ -390,9 +390,9 @@ test.describe.serial(' Correct record - 3', () => {
          * - redirect to mother's details page
          * - focus on mother's id type
          */
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('mother')).toBeTruthy()
-        expect(page.url().includes('#mother____idType')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'mother')
+        await expectInUrl(page, '#mother____idType')
 
         await page.locator('#mother____idType').click()
         await page.getByText(updatedMotherDetails.idType).click()
@@ -405,8 +405,8 @@ test.describe.serial(' Correct record - 3', () => {
          * - show previous id type with strikethrough
          * - show updated id type
          */
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('review')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'review')
 
         await expect(
           await page
@@ -435,9 +435,9 @@ test.describe.serial(' Correct record - 3', () => {
          * - redirect to mother's details page
          * - focus on mother's id
          */
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('mother')).toBeTruthy()
-        expect(page.url().includes('#mother____passport')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'mother')
+        await expectInUrl(page, '#mother____passport')
 
         await page
           .locator('#mother____passport')
@@ -451,8 +451,8 @@ test.describe.serial(' Correct record - 3', () => {
          * - show previous id with strikethrough
          * - show updated id
          */
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('review')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'review')
 
         await expect(
           await page
@@ -475,9 +475,9 @@ test.describe.serial(' Correct record - 3', () => {
          * - redirect to mother's details page
          * - focus on mother's Usual place of resiedence
          */
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('mother')).toBeTruthy()
-        expect(page.url().includes('#mother____address')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'mother')
+        await expectInUrl(page, '#mother____address')
 
         await page.locator('#country').click()
         await page
@@ -526,8 +526,8 @@ test.describe.serial(' Correct record - 3', () => {
          * - show updated Usual place of resiedence
          */
 
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('review')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'review')
 
         await expect(
           await page
@@ -592,9 +592,9 @@ test.describe.serial(' Correct record - 3', () => {
          * - redirect to mother's details page
          * - focus on mother's marital status
          */
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('mother')).toBeTruthy()
-        expect(page.url().includes('#mother____maritalStatus')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'mother')
+        await expectInUrl(page, '#mother____maritalStatus')
 
         await page.locator('#mother____maritalStatus').click()
         await page.getByText(updatedMotherDetails.maritalStatus).click()
@@ -607,9 +607,8 @@ test.describe.serial(' Correct record - 3', () => {
          * - show previous marital status with strikethrough
          * - show updated marital status
          */
-
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('review')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'review')
 
         await expect(
           await page
@@ -636,11 +635,9 @@ test.describe.serial(' Correct record - 3', () => {
          * - redirect to mother's details page
          * - focus on mother's level of education
          */
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('mother')).toBeTruthy()
-        expect(
-          page.url().includes('#mother____educationalAttainment')
-        ).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'mother')
+        await expectInUrl(page, '#mother____educationalAttainment')
 
         await page.locator('#mother____educationalAttainment').click()
         await page.getByText(updatedMotherDetails.educationLevel).click()
@@ -653,8 +650,8 @@ test.describe.serial(' Correct record - 3', () => {
          * - show previous level of education with strikethrough
          * - show updated level of education
          */
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('review')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'review')
 
         await expect(
           await page
@@ -677,9 +674,9 @@ test.describe.serial(' Correct record - 3', () => {
        * - redirect to child's details page
        * - focus on childType
        */
-      expect(page.url().includes('correction')).toBeTruthy()
-      expect(page.url().includes('child')).toBeTruthy()
-      expect(page.url().includes('#child____placeOfBirth')).toBeTruthy()
+      await expectInUrl(page, 'correction')
+      await expectInUrl(page, 'child')
+      await expectInUrl(page, '#child____placeOfBirth')
 
       await page.locator('#child____placeOfBirth').click()
       await page.getByText(updatedChildDetails.placeOfBirth).click()
@@ -713,8 +710,8 @@ test.describe.serial(' Correct record - 3', () => {
        * - show previous place of birth with strikethrough
        * - show updated place of birth
        */
-      expect(page.url().includes('correction')).toBeTruthy()
-      expect(page.url().includes('review')).toBeTruthy()
+      await expectInUrl(page, 'correction')
+      await expectInUrl(page, 'review')
 
       await expect(
         page
@@ -765,8 +762,8 @@ test.describe.serial(' Correct record - 3', () => {
      * - Send for approval button is disabled
      */
 
-    expect(page.url().includes('correction')).toBeTruthy()
-    expect(page.url().includes('summary')).toBeTruthy()
+    await expectInUrl(page, 'correction')
+    await expectInUrl(page, 'summary')
 
     await expect(
       page.getByRole('button', { name: 'Submit correction request' })
@@ -914,7 +911,7 @@ test.describe.serial(' Correct record - 3', () => {
       .click()
     await page.getByRole('button', { name: 'Confirm' }).click()
 
-    expect(page.url().includes(`events/${eventId}`)).toBeTruthy()
+    await expectInUrl(page, `events/${eventId}`)
 
     await page.getByTestId('exit-event').click()
     await page.getByRole('button', { name: 'Outbox' }).click()
@@ -1112,7 +1109,7 @@ test.describe.serial(' Correct record - 3', () => {
       await page.getByRole('button', { name: 'Approve', exact: true }).click()
       await page.getByRole('button', { name: 'Confirm', exact: true }).click()
 
-      expect(page.url().includes(`events/${eventId}`)).toBeTruthy()
+      await expectInUrl(page, `events/${eventId}`)
     })
 
     test('3.8.4 Assign record', async () => {

--- a/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
@@ -729,7 +729,7 @@ test.describe.serial('Correct record - 4', () => {
      */
 
     await expectInUrl(page, 'correction')
-    await expectInUrl(page, 'review')
+    await expectInUrl(page, 'summary')
 
     await expect(
       page.getByRole('button', { name: 'Correct record' })

--- a/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
@@ -21,7 +21,7 @@ import {
 import { IdType } from '@countryconfig/events/utils'
 import { random } from 'lodash'
 import { formatV2ChildName, REQUIRED_VALIDATION_ERROR } from '../birth/helpers'
-import { ensureAssignedToUser, selectAction } from '../../utils'
+import { ensureAssignedToUser, expectInUrl, selectAction } from '../../utils'
 
 test.describe.serial('Correct record - 4', () => {
   let declaration: DeclarationV2
@@ -183,9 +183,8 @@ test.describe.serial('Correct record - 4', () => {
      * - navigate to supporting document
      * - continue button is disabled
      */
-    expect(page.url().includes('correction')).toBeTruthy()
-
-    expect(page.url().includes('onboarding/documents')).toBeTruthy()
+    await expectInUrl(page, 'correction')
+    await expectInUrl(page, 'onboarding/documents')
 
     await expect(page.getByRole('button', { name: 'Continue' })).toBeEnabled()
 
@@ -214,8 +213,8 @@ test.describe.serial('Correct record - 4', () => {
     /*
      * Expected result: should navigate to review page
      */
-    expect(page.url().includes('correction')).toBeTruthy()
-    expect(page.url().includes('review')).toBeTruthy()
+    await expectInUrl(page, 'correction')
+    await expectInUrl(page, 'review')
   })
 
   test.describe('4.4 Make correction', async () => {
@@ -249,9 +248,9 @@ test.describe.serial('Correct record - 4', () => {
          * - focus on father's family name
          */
 
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('father')).toBeTruthy()
-        expect(page.url().includes('#father____name')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'father')
+        await expectInUrl(page, '#father____name')
 
         await page.locator('#firstname').fill(updatedFatherDetails.firstNames)
         await page.locator('#surname').fill(updatedFatherDetails.familyName)
@@ -264,9 +263,8 @@ test.describe.serial('Correct record - 4', () => {
          * - show previous name with strikethrough
          * - show updated name
          */
-
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('review')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'review')
 
         await expect(
           await page.getByTestId('row-value-father.name').getByRole('deletion')
@@ -291,9 +289,9 @@ test.describe.serial('Correct record - 4', () => {
          * - redirect to father's details page
          * - focus on father's date of birth
          */
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('father')).toBeTruthy()
-        expect(page.url().includes('#father____dob')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'father')
+        await expectInUrl(page, '#father____dob')
 
         const birthDay = updatedFatherDetails.birthDate.split('-')
 
@@ -310,8 +308,8 @@ test.describe.serial('Correct record - 4', () => {
          * - show updated gender
          */
 
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('review')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'review')
 
         await expect(
           await page.getByTestId('row-value-father.dob').getByRole('deletion')
@@ -333,9 +331,9 @@ test.describe.serial('Correct record - 4', () => {
          * - focus on father's nationality
          */
 
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('father')).toBeTruthy()
-        expect(page.url().includes('#father____nationality')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'father')
+        await expectInUrl(page, '#father____nationality')
 
         await page.locator('#father____nationality').click()
         await page.getByText(updatedFatherDetails.nationality).click()
@@ -349,8 +347,8 @@ test.describe.serial('Correct record - 4', () => {
          * - show updated nationality
          */
 
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('review')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'review')
 
         await expect(
           await page
@@ -374,9 +372,9 @@ test.describe.serial('Correct record - 4', () => {
          * - focus on father's id type
          */
 
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('father')).toBeTruthy()
-        expect(page.url().includes('#father____idType')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'father')
+        await expectInUrl(page, '#father____idType')
 
         await page.locator('#father____idType').click()
         await page.getByText(updatedFatherDetails.idType).click()
@@ -389,9 +387,8 @@ test.describe.serial('Correct record - 4', () => {
          * - show previous id type with strikethrough
          * - show updated id type
          */
-
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('review')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'review')
 
         await expect(
           await page
@@ -415,9 +412,9 @@ test.describe.serial('Correct record - 4', () => {
          * - focus on father's id
          */
 
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('father')).toBeTruthy()
-        expect(page.url().includes('#father____passport')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'father')
+        await expectInUrl(page, '#father____passport')
 
         await page
           .locator('#father____passport')
@@ -432,8 +429,8 @@ test.describe.serial('Correct record - 4', () => {
          * - show updated id
          */
 
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('review')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'review')
 
         await expect(
           await page
@@ -451,9 +448,9 @@ test.describe.serial('Correct record - 4', () => {
          * - focus on father's Usual place of resiedence
          */
 
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('father')).toBeTruthy()
-        expect(page.url().includes('#father____addressSameAs')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'father')
+        await expectInUrl(page, '#father____addressSameAs')
 
         await page
           .locator('#father____addressSameAs-form-input')
@@ -520,9 +517,8 @@ test.describe.serial('Correct record - 4', () => {
          * - show previous Usual place of resiedence with strikethrough
          * - show updated Usual place of resiedence
          */
-
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('review')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'review')
 
         await expect(
           await page
@@ -582,9 +578,9 @@ test.describe.serial('Correct record - 4', () => {
          * - focus on father's marital status
          */
 
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('father')).toBeTruthy()
-        expect(page.url().includes('#father____maritalStatus')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'father')
+        await expectInUrl(page, '#father____maritalStatus')
 
         await page.locator('#father____maritalStatus').click()
         await page.getByText(updatedFatherDetails.maritalStatus).click()
@@ -597,9 +593,8 @@ test.describe.serial('Correct record - 4', () => {
          * - show previous marital status with strikethrough
          * - show updated marital status
          */
-
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('review')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'review')
 
         await expect(
           await page
@@ -625,11 +620,9 @@ test.describe.serial('Correct record - 4', () => {
          * - focus on father's level of education
          */
 
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('father')).toBeTruthy()
-        expect(
-          await page.url().includes('#father____educationalAttainment')
-        ).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'father')
+        await expectInUrl(page, '#father____educationalAttainment')
 
         await page.locator('#father____educationalAttainment').click()
         await page.getByText(updatedFatherDetails.educationLevel).click()
@@ -642,9 +635,8 @@ test.describe.serial('Correct record - 4', () => {
          * - show previous level of education with strikethrough
          * - show updated level of education
          */
-
-        expect(page.url().includes('correction')).toBeTruthy()
-        expect(page.url().includes('review')).toBeTruthy()
+        await expectInUrl(page, 'correction')
+        await expectInUrl(page, 'review')
 
         await expect(
           await page
@@ -669,9 +661,9 @@ test.describe.serial('Correct record - 4', () => {
        * - focus on child's placeOfBirth
        */
 
-      expect(page.url().includes('correction')).toBeTruthy()
-      expect(page.url().includes('child')).toBeTruthy()
-      expect(page.url().includes('#child____placeOfBirth')).toBeTruthy()
+      await expectInUrl(page, 'correction')
+      await expectInUrl(page, 'child')
+      await expectInUrl(page, '#child____placeOfBirth')
 
       await page.locator('#child____placeOfBirth').click()
       await page
@@ -691,9 +683,8 @@ test.describe.serial('Correct record - 4', () => {
        * - show previous placeOfBirth with strikethrough
        * - show updated placeOfBirth
        */
-
-      expect(page.url().includes('correction')).toBeTruthy()
-      expect(page.url().includes('review')).toBeTruthy()
+      await expectInUrl(page, 'correction')
+      await expectInUrl(page, 'review')
 
       await expect(
         await page
@@ -737,8 +728,8 @@ test.describe.serial('Correct record - 4', () => {
      * - Send for approval button is disabled
      */
 
-    expect(page.url().includes('correction')).toBeTruthy()
-    expect(page.url().includes('summary')).toBeTruthy()
+    await expectInUrl(page, 'correction')
+    await expectInUrl(page, 'review')
 
     await expect(
       page.getByRole('button', { name: 'Correct record' })
@@ -877,7 +868,7 @@ test.describe.serial('Correct record - 4', () => {
     await page.getByRole('button', { name: 'Correct record' }).click()
     await page.getByRole('button', { name: 'Confirm' }).click()
 
-    expect(page.url().includes(`events/${eventId}`)).toBeTruthy()
+    await expectInUrl(page, `events/${eventId}`)
     await page.getByTestId('exit-event').click()
     await page.getByRole('button', { name: 'Outbox' }).click()
 

--- a/e2e/testcases/correction-birth/correct-birth-record-change-ages-address.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-change-ages-address.spec.ts
@@ -14,7 +14,7 @@ import {
 } from '../test-data/birth-declaration'
 import { CREDENTIALS } from '../../constants'
 import { formatV2ChildName, getAdministrativeAreas } from '../birth/helpers'
-import { ensureAssignedToUser, selectAction } from '../../utils'
+import { ensureAssignedToUser, expectInUrl, selectAction } from '../../utils'
 import { getIdByName } from '../birth/helpers'
 import { AddressType } from '@opencrvs/toolkit/events'
 
@@ -144,9 +144,8 @@ test.describe.serial('Correct record - Change ages', () => {
   })
 
   test('Upload supporting documents', async () => {
-    expect(page.url().includes('correction')).toBeTruthy()
-
-    expect(page.url().includes('onboarding/documents')).toBeTruthy()
+    await expectInUrl(page, 'correction')
+    await expectInUrl(page, 'onboarding/documents')
 
     await expect(page.getByRole('button', { name: 'Continue' })).toBeEnabled()
 
@@ -171,8 +170,8 @@ test.describe.serial('Correct record - Change ages', () => {
 
     await page.getByRole('button', { name: 'Continue' }).click()
 
-    expect(page.url().includes('correction')).toBeTruthy()
-    expect(page.url().includes('review')).toBeTruthy()
+    await expectInUrl(page, 'correction')
+    await expectInUrl(page, 'review')
   })
 
   test('Change informant age', async () => {
@@ -246,8 +245,8 @@ test.describe.serial('Correct record - Change ages', () => {
   test('Correction summary', async () => {
     await page.getByRole('button', { name: 'Continue', exact: true }).click()
 
-    expect(page.url().includes('correction')).toBeTruthy()
-    expect(page.url().includes('summary')).toBeTruthy()
+    await expectInUrl(page, 'correction')
+    await expectInUrl(page, 'summary')
 
     await expect(page.getByText("Father's details")).not.toBeVisible()
     await expect(page.getByText("Child's details")).not.toBeVisible()

--- a/e2e/testcases/correction-birth/correct-birth-record-change-father-id-number.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-change-father-id-number.spec.ts
@@ -14,7 +14,7 @@ import {
 import { format, subDays, subYears } from 'date-fns'
 import { CREDENTIALS } from '../../constants'
 import { formatV2ChildName } from '../birth/helpers'
-import { ensureAssignedToUser, selectAction } from '../../utils'
+import { ensureAssignedToUser, expectInUrl, selectAction } from '../../utils'
 
 test.describe.serial("Correct record - Change father's ID number", () => {
   let declaration: DeclarationV2
@@ -120,9 +120,8 @@ test.describe.serial("Correct record - Change father's ID number", () => {
   })
 
   test('Upload supporting documents', async () => {
-    expect(page.url().includes('correction')).toBeTruthy()
-
-    expect(page.url().includes('onboarding/documents')).toBeTruthy()
+    await expectInUrl(page, 'correction')
+    await expectInUrl(page, 'onboarding/documents')
 
     await expect(page.getByRole('button', { name: 'Continue' })).toBeEnabled()
 
@@ -147,8 +146,8 @@ test.describe.serial("Correct record - Change father's ID number", () => {
 
     await page.getByRole('button', { name: 'Continue' }).click()
 
-    expect(page.url().includes('correction')).toBeTruthy()
-    expect(page.url().includes('review')).toBeTruthy()
+    await expectInUrl(page, 'correction')
+    await expectInUrl(page, 'review')
   })
 
   test('Change father id number', async () => {
@@ -172,8 +171,8 @@ test.describe.serial("Correct record - Change father's ID number", () => {
   test('Correction summary', async () => {
     await page.getByRole('button', { name: 'Continue', exact: true }).click()
 
-    expect(page.url().includes('correction')).toBeTruthy()
-    expect(page.url().includes('summary')).toBeTruthy()
+    await expectInUrl(page, 'correction')
+    await expectInUrl(page, 'review')
 
     await expect(page.getByText("Child's details")).not.toBeVisible()
     await expect(page.getByText("Mother's details")).not.toBeVisible()

--- a/e2e/testcases/correction-birth/correct-birth-record-change-father-id-number.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-change-father-id-number.spec.ts
@@ -172,7 +172,7 @@ test.describe.serial("Correct record - Change father's ID number", () => {
     await page.getByRole('button', { name: 'Continue', exact: true }).click()
 
     await expectInUrl(page, 'correction')
-    await expectInUrl(page, 'review')
+    await expectInUrl(page, 'summary')
 
     await expect(page.getByText("Child's details")).not.toBeVisible()
     await expect(page.getByText("Mother's details")).not.toBeVisible()

--- a/e2e/testcases/correction-birth/correct-birth-record-change-informant.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-change-informant.spec.ts
@@ -19,7 +19,7 @@ import {
 import { IdType } from '@countryconfig/events/utils'
 import { random } from 'lodash'
 import { formatV2ChildName, REQUIRED_VALIDATION_ERROR } from '../birth/helpers'
-import { ensureAssignedToUser, selectAction } from '../../utils'
+import { ensureAssignedToUser, expectInUrl, selectAction } from '../../utils'
 
 test.describe.serial('Correct record - change informant type', () => {
   let declaration: DeclarationV2
@@ -318,7 +318,7 @@ test.describe.serial('Correct record - change informant type', () => {
     await page.getByRole('button', { name: 'Correct record' }).click()
     await page.getByRole('button', { name: 'Confirm' }).click()
 
-    await expect(page.url().includes(`events/${eventId}`)).toBeTruthy()
+    await expectInUrl(page, `events/${eventId}`)
     await page.getByTestId('exit-event').click()
     await page.getByRole('button', { name: 'Outbox' }).click()
 

--- a/e2e/testcases/correction-birth/direct-correction-offline.spec.ts
+++ b/e2e/testcases/correction-birth/direct-correction-offline.spec.ts
@@ -8,7 +8,7 @@ import {
 import { format, subDays, subYears } from 'date-fns'
 import { CREDENTIALS, SAFE_OUTBOX_TIMEOUT_MS } from '../../constants'
 import { formatV2ChildName } from '../birth/helpers'
-import { ensureAssignedToUser, selectAction } from '../../utils'
+import { ensureAssignedToUser, expectInUrl, selectAction } from '../../utils'
 
 test.describe.serial('Direct correction offline', () => {
   let declaration: DeclarationV2
@@ -144,7 +144,7 @@ test.describe.serial('Direct correction offline', () => {
     await page.getByRole('button', { name: 'Correct record' }).click()
     await page.getByRole('button', { name: 'Confirm' }).click()
 
-    expect(page.url().includes(`events/${eventId}`)).toBeTruthy()
+    await expectInUrl(page, `events/${eventId}`)
 
     // We expect to see the optimistically updated new child name instead of the old one
     await expect(

--- a/e2e/testcases/correction-birth/request-and-accept-correction-offline.spec.ts
+++ b/e2e/testcases/correction-birth/request-and-accept-correction-offline.spec.ts
@@ -8,7 +8,12 @@ import {
 import { format, subDays, subYears } from 'date-fns'
 import { CREDENTIALS, SAFE_OUTBOX_TIMEOUT_MS } from '../../constants'
 import { formatV2ChildName } from '../birth/helpers'
-import { ensureAssignedToUser, selectAction, type } from '../../utils'
+import {
+  ensureAssignedToUser,
+  expectInUrl,
+  selectAction,
+  type
+} from '../../utils'
 
 test.describe.serial('Request and accept correction (offline)', () => {
   let declaration: DeclarationV2
@@ -149,7 +154,7 @@ test.describe.serial('Request and accept correction (offline)', () => {
         .click()
       await page.getByRole('button', { name: 'Confirm' }).click()
 
-      expect(page.url().includes(`events/${eventId}`)).toBeTruthy()
+      await expectInUrl(page, `events/${eventId}`)
 
       await expect(
         page.locator('#content-name', {
@@ -192,7 +197,7 @@ test.describe.serial('Request and accept correction (offline)', () => {
       await page.getByRole('button', { name: 'Approve', exact: true }).click()
       await page.getByRole('button', { name: 'Confirm', exact: true }).click()
 
-      expect(page.url().includes(`events/${eventId}`)).toBeTruthy()
+      await expectInUrl(page, `events/${eventId}`)
 
       // We expect to see the optimistically updated new child name instead of the old one
       await expect(

--- a/e2e/testcases/correction-birth/request-escalate-approve-correction.spec.ts
+++ b/e2e/testcases/correction-birth/request-escalate-approve-correction.spec.ts
@@ -103,10 +103,9 @@ test('Request correction, escalate, then approve as Local Registrar', async ({
     await page.getByText('Legal Guardian', { exact: true }).click()
     await page.locator('#reason____option').click()
     await page
-      .getByText(
-        'Informant provided incorrect information (Material error)',
-        { exact: true }
-      )
+      .getByText('Informant provided incorrect information (Material error)', {
+        exact: true
+      })
       .click()
     await page.getByRole('button', { name: 'Continue' }).click()
   })
@@ -169,9 +168,7 @@ test('Request correction, escalate, then approve as Local Registrar', async ({
   })
 
   await test.step("Event should not yet have an 'Escalated' flag", async () => {
-    await expect(
-      page.getByText('Escalated', { exact: true })
-    ).not.toBeVisible()
+    await expect(page.getByText('Escalated', { exact: true })).not.toBeVisible()
   })
 
   await test.step('Escalate from the action menu', async () => {
@@ -275,6 +272,7 @@ test('Request correction, escalate, then approve as Local Registrar', async ({
 
   await test.step('Audit history records the correction request and approval', async () => {
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
+
     await page.getByRole('button', { name: 'Audit' }).click()
 
     await expect(
@@ -285,5 +283,9 @@ test('Request correction, escalate, then approve as Local Registrar', async ({
     await expect(
       page.getByRole('button', { name: 'Correction approved', exact: true })
     ).toBeVisible()
-  })
+  }),
+    {
+      // Explicit longer timeout. test.step pattern seems to behave differently with respect to timeouts and kill the test before all steps have completed.
+      timeout: 120_000
+    }
 })

--- a/e2e/testcases/correction-birth/request-escalate-approve-correction.spec.ts
+++ b/e2e/testcases/correction-birth/request-escalate-approve-correction.spec.ts
@@ -8,7 +8,12 @@ import {
 import { format, subDays, subYears } from 'date-fns'
 import { CREDENTIALS, SAFE_OUTBOX_TIMEOUT_MS } from '../../constants'
 import { formatV2ChildName } from '../birth/helpers'
-import { ensureAssignedToUser, selectAction, type } from '../../utils'
+import {
+  ensureAssignedToUser,
+  expectInUrl,
+  selectAction,
+  type
+} from '../../utils'
 
 test('Request correction, escalate, then approve as Local Registrar', async ({
   page
@@ -141,7 +146,7 @@ test('Request correction, escalate, then approve as Local Registrar', async ({
       .click()
     await page.getByRole('button', { name: 'Confirm' }).click()
 
-    expect(page.url().includes(`events/${eventId}`)).toBeTruthy()
+    await expectInUrl(page, `events/${eventId}`)
 
     await expect(
       page.locator('#content-name', {
@@ -261,7 +266,7 @@ test('Request correction, escalate, then approve as Local Registrar', async ({
     await page.getByRole('button', { name: 'Approve', exact: true }).click()
     await page.getByRole('button', { name: 'Confirm', exact: true }).click()
 
-    expect(page.url().includes(`events/${eventId}`)).toBeTruthy()
+    await expectInUrl(page, `events/${eventId}`)
 
     await expect(
       page.locator('#content-name', {

--- a/e2e/testcases/custom-actions-and-flags/escalate-keeps-rejected-flag.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/escalate-keeps-rejected-flag.spec.ts
@@ -8,7 +8,12 @@ import {
   SAFE_OUTBOX_TIMEOUT_MS
 } from '../../constants'
 import { getToken, login } from '../../helpers'
-import { ensureAssignedToUser, selectAction, type } from '../../utils'
+import {
+  ensureAssignedToUser,
+  expectInUrl,
+  selectAction,
+  type
+} from '../../utils'
 import {
   createDeclaration,
   type Declaration
@@ -74,7 +79,7 @@ test('Escalating a rejected record preserves the Rejected flag', async ({
       .getByRole('button', { name: formatV2ChildName(declaration) })
       .click()
 
-    expect(page.url().includes(`events/${eventId}`)).toBeTruthy()
+    await expectInUrl(page, `events/${eventId}`)
 
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
   })

--- a/e2e/testcases/death/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/death/8-validate-declaration-review-page.spec.ts
@@ -17,6 +17,7 @@ import { CREDENTIALS } from '../../constants'
 import {
   ensureAssignedToUser,
   ensureOutboxIsEmpty,
+  expectInUrl,
   selectAction
 } from '../../utils'
 
@@ -692,7 +693,7 @@ test.describe.serial('8. Validate declaration review page', () => {
       /*
        * Expected result: should redirect to assigned to you workqueue
        */
-      expect(page.url().includes('assigned-to-you')).toBeTruthy()
+      await expectInUrl(page, 'assigned-to-you')
 
       await page.getByText('Recent').click()
       /*

--- a/e2e/testcases/death/declaration/death-declaration-1.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-1.spec.ts
@@ -13,7 +13,11 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import { ensureAssignedToUser, ensureOutboxIsEmpty } from '../../../utils'
+import {
+  ensureAssignedToUser,
+  ensureOutboxIsEmpty,
+  expectInUrl
+} from '../../../utils'
 
 test.describe.serial('1. Death declaration case - 1', () => {
   let page: Page
@@ -565,7 +569,7 @@ test.describe.serial('1. Death declaration case - 1', () => {
       /*
        * Expected result: should redirect to assigned to you workqueue
        */
-      expect(page.url().includes('assigned-to-you')).toBeTruthy()
+      await expectInUrl(page, 'assigned-to-you')
 
       await page.getByText('Recent').click()
 

--- a/e2e/testcases/death/declaration/death-declaration-10.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-10.spec.ts
@@ -11,6 +11,7 @@ import { CREDENTIALS } from '../../../constants'
 import {
   ensureAssignedToUser,
   ensureOutboxIsEmpty,
+  expectInUrl,
   selectAction
 } from '../../../utils'
 import { REQUIRED_VALIDATION_ERROR } from '../../birth/helpers'
@@ -253,7 +254,7 @@ test.describe.serial('10. Death declaration case - 10', () => {
       /*
        * Expected result: should redirect to assigned to you workqueue
        */
-      expect(page.url().includes('assigned-to-you')).toBeTruthy()
+      await expectInUrl(page, 'assigned-to-you')
 
       await page.getByText('Recent').click()
 

--- a/e2e/testcases/death/declaration/death-declaration-11.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-11.spec.ts
@@ -13,7 +13,11 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import { ensureAssignedToUser, ensureOutboxIsEmpty } from '../../../utils'
+import {
+  ensureAssignedToUser,
+  ensureOutboxIsEmpty,
+  expectInUrl
+} from '../../../utils'
 
 test.describe.serial('11. Death declaration case - 11', () => {
   let page: Page
@@ -672,7 +676,7 @@ test.describe.serial('11. Death declaration case - 11', () => {
       /*
        * Expected result: should redirect to assigned to you workqueue
        */
-      expect(page.url().includes('assigned-to-you')).toBeTruthy()
+      await expectInUrl(page, 'assigned-to-you')
 
       await page.getByText('Recent').click()
 

--- a/e2e/testcases/death/declaration/death-declaration-2.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-2.spec.ts
@@ -13,7 +13,11 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import { ensureAssignedToUser, ensureOutboxIsEmpty } from '../../../utils'
+import {
+  ensureAssignedToUser,
+  ensureOutboxIsEmpty,
+  expectInUrl
+} from '../../../utils'
 
 test.describe.serial('2. Death declaration case - 2', () => {
   let page: Page
@@ -710,7 +714,7 @@ test.describe.serial('2. Death declaration case - 2', () => {
       /*
        * Expected result: should redirect to assigned to you workqueue
        */
-      expect(page.url().includes('assigned-to-you')).toBeTruthy()
+      await expectInUrl(page, 'assigned-to-you')
 
       await page.getByText('Recent').click()
 

--- a/e2e/testcases/death/declaration/death-declaration-3.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-3.spec.ts
@@ -13,7 +13,11 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import { ensureAssignedToUser, ensureOutboxIsEmpty } from '../../../utils'
+import {
+  ensureAssignedToUser,
+  ensureOutboxIsEmpty,
+  expectInUrl
+} from '../../../utils'
 
 test.describe.serial('3. Death declaration case - 3', () => {
   let page: Page
@@ -672,7 +676,7 @@ test.describe.serial('3. Death declaration case - 3', () => {
       /*
        * Expected result: should redirect to assigned to you workqueue
        */
-      expect(page.url().includes('assigned-to-you')).toBeTruthy()
+      await expectInUrl(page, 'assigned-to-you')
 
       await page.getByText('Recent').click()
 

--- a/e2e/testcases/death/declaration/death-declaration-4.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-4.spec.ts
@@ -16,6 +16,7 @@ import { CREDENTIALS } from '../../../constants'
 import {
   ensureAssignedToUser,
   ensureOutboxIsEmpty,
+  expectInUrl,
   selectAction
 } from '../../../utils'
 
@@ -804,7 +805,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
       /*
        * Expected result: should redirect to assigned to you workqueue
        */
-      expect(page.url().includes('assigned-to-you')).toBeTruthy()
+      await expectInUrl(page, 'assigned-to-you')
 
       await page.getByText('Recent').click()
 

--- a/e2e/testcases/death/declaration/death-declaration-5.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-5.spec.ts
@@ -13,7 +13,11 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import { ensureAssignedToUser, ensureOutboxIsEmpty } from '../../../utils'
+import {
+  ensureAssignedToUser,
+  ensureOutboxIsEmpty,
+  expectInUrl
+} from '../../../utils'
 
 test.describe.serial('5. Death declaration case - 5', () => {
   let page: Page
@@ -531,7 +535,7 @@ test.describe.serial('5. Death declaration case - 5', () => {
       /*
        * Expected result: should redirect to assigned to you workqueue
        */
-      expect(page.url().includes('assigned-to-you')).toBeTruthy()
+      await expectInUrl(page, 'assigned-to-you')
 
       await page.getByText('Recent').click()
 

--- a/e2e/testcases/death/declaration/death-declaration-6.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-6.spec.ts
@@ -12,7 +12,11 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import { ensureAssignedToUser, ensureOutboxIsEmpty } from '../../../utils'
+import {
+  ensureAssignedToUser,
+  ensureOutboxIsEmpty,
+  expectInUrl
+} from '../../../utils'
 
 test.describe.serial('6. Death declaration case - 6', () => {
   let page: Page
@@ -535,7 +539,7 @@ test.describe.serial('6. Death declaration case - 6', () => {
       /*
        * Expected result: should redirect to assigned to you workqueue
        */
-      expect(page.url().includes('assigned-to-you')).toBeTruthy()
+      await expectInUrl(page, 'assigned-to-you')
 
       await page.getByText('Pending certification').click()
 

--- a/e2e/testcases/death/declaration/death-declaration-7.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-7.spec.ts
@@ -12,7 +12,11 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import { ensureAssignedToUser, ensureOutboxIsEmpty } from '../../../utils'
+import {
+  ensureAssignedToUser,
+  ensureOutboxIsEmpty,
+  expectInUrl
+} from '../../../utils'
 
 test.describe.serial('7. Death declaration case - 7', () => {
   let page: Page
@@ -540,7 +544,7 @@ test.describe.serial('7. Death declaration case - 7', () => {
       /*
        * Expected result: should redirect to assigned to you workqueue
        */
-      expect(page.url().includes('assigned-to-you')).toBeTruthy()
+      await expectInUrl(page, 'assigned-to-you')
 
       await page.getByText('Pending certification').click()
 

--- a/e2e/testcases/death/declaration/death-declaration-8.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-8.spec.ts
@@ -12,6 +12,7 @@ import { CREDENTIALS } from '../../../constants'
 import {
   ensureAssignedToUser,
   ensureOutboxIsEmpty,
+  expectInUrl,
   selectAction
 } from '../../../utils'
 import { REQUIRED_VALIDATION_ERROR } from '../../birth/helpers'
@@ -268,7 +269,7 @@ test.describe.serial('8. Death declaration case - 8', () => {
       /*
        * Expected result: should redirect to assigned to you workqueue
        */
-      expect(page.url().includes('assigned-to-you')).toBeTruthy()
+      await expectInUrl(page, 'assigned-to-you')
 
       await page.getByText('Recent').click()
 

--- a/e2e/testcases/death/declaration/death-declaration-9.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-9.spec.ts
@@ -12,6 +12,7 @@ import { CREDENTIALS } from '../../../constants'
 import {
   ensureAssignedToUser,
   ensureOutboxIsEmpty,
+  expectInUrl,
   selectAction
 } from '../../../utils'
 import { REQUIRED_VALIDATION_ERROR } from '../../birth/helpers'
@@ -268,7 +269,7 @@ test.describe.serial('9. Death declaration case - 9', () => {
       /*
        * Expected result: should redirect to assigned to you workqueue
        */
-      expect(page.url().includes('assigned-to-you')).toBeTruthy()
+      await expectInUrl(page, 'assigned-to-you')
 
       await page.getByText('Recent').click()
 

--- a/e2e/testcases/events-rest-api/events-correction-request.spec.ts
+++ b/e2e/testcases/events-rest-api/events-correction-request.spec.ts
@@ -71,8 +71,7 @@ test.describe
     )
 
     const eventDocument = await client.event.get.query({
-      eventId,
-      waitFor: false
+      eventId
     })
     const { trackingId } = eventDocument
 

--- a/e2e/testcases/events-rest-api/events-notify.spec.ts
+++ b/e2e/testcases/events-rest-api/events-notify.spec.ts
@@ -624,7 +624,9 @@ test.describe('POST /api/events/events/{eventId}/notify', () => {
     test("Navigate to event via 'Notifications' -workqueue", async () => {
       await page.getByRole('button', { name: 'Notifications' }).click()
       await page
-        .getByText(await formatV2ChildName({ 'child.name': childName }))
+        .getByRole('button', {
+          name: await formatV2ChildName({ 'child.name': childName })
+        })
         .click()
     })
 
@@ -686,7 +688,9 @@ test.describe('POST /api/events/events/{eventId}/notify', () => {
     test("Navigate to event via 'Pending certification' -workqueue", async () => {
       await page.getByRole('button', { name: 'Pending certification' }).click()
       await page
-        .getByText(await formatV2ChildName({ 'child.name': newChildName }))
+        .getByRole('button', {
+          name: await formatV2ChildName({ 'child.name': newChildName })
+        })
         .click()
     })
 
@@ -794,7 +798,9 @@ test.describe('POST /api/events/events/{eventId}/notify', () => {
     test("Navigate to event via 'Notifications' -workqueue", async () => {
       await page.getByRole('button', { name: 'Notifications' }).click()
       await page
-        .getByText(await formatV2ChildName({ 'child.name': childName }))
+        .getByRole('button', {
+          name: await formatV2ChildName({ 'child.name': childName })
+        })
         .click()
     })
 
@@ -809,8 +815,11 @@ test.describe('POST /api/events/events/{eventId}/notify', () => {
       await page.getByRole('button', { name: 'Search' }).click()
       await page.getByPlaceholder('Search').fill(trackingId)
       await page.getByRole('button', { name: 'Search' }).click()
+
       await page
-        .getByText(formatV2ChildName({ 'child.name': childName }))
+        .getByRole('button', {
+          name: await formatV2ChildName({ 'child.name': childName })
+        })
         .click()
     })
 

--- a/e2e/testcases/form-state/esignet-psut-persistence.spec.ts
+++ b/e2e/testcases/form-state/esignet-psut-persistence.spec.ts
@@ -134,8 +134,7 @@ test.describe('E-Signet PSUT persistence', () => {
       .poll(
         async () => {
           const eventDocument = await client.event.get.query({
-            eventId,
-            waitFor: false
+            eventId
           })
           const declareAction = eventDocument.actions.find(
             (action) =>

--- a/e2e/testcases/mosip/birth-correction-forwarding.spec.ts
+++ b/e2e/testcases/mosip/birth-correction-forwarding.spec.ts
@@ -22,7 +22,7 @@ import {
 
 async function getEventById(eventId: string, token: string) {
   const client = createClient(`${GATEWAY_HOST}/events`, `Bearer ${token}`)
-  return client.event.get.query({ eventId, waitFor: false })
+  return client.event.get.query({ eventId })
 }
 
 test.describe.serial('Birth correction trigger eligibility checks', () => {

--- a/e2e/testcases/mosip/birth-registration-forwarding.spec.ts
+++ b/e2e/testcases/mosip/birth-registration-forwarding.spec.ts
@@ -11,7 +11,7 @@ import {
 
 async function getEventById(eventId: string, token: string) {
   const client = createClient(`${GATEWAY_HOST}/events`, `Bearer ${token}`)
-  return client.event.get.query({ eventId, waitFor: false })
+  return client.event.get.query({ eventId })
 }
 
 test.describe.serial('Birth registration forwarding to MOSIP', () => {

--- a/e2e/testcases/navigation/navigating-in-and-out-of-action-from-workqueue.spec.ts
+++ b/e2e/testcases/navigation/navigating-in-and-out-of-action-from-workqueue.spec.ts
@@ -66,7 +66,7 @@ test.describe.skip('Navigating in and out of action', () => {
     await page.goBack()
     await expectInUrl(
       page,
-      `/events/${eventId}/record?backTo=%2Fworkqueue%2Fpending-registration`
+      `/events/${eventId}/record?backTo=/workqueue/pending-registration`
     )
   })
 
@@ -107,7 +107,7 @@ test.describe.skip('Navigating in and out of action', () => {
     await page.waitForURL(/\/review/)
     await expectInUrl(
       page,
-      `/events/print-certificate/${eventId}/review?templateId=v2.birth-certificate&backTo=%2Fworkqueue%2Fpending-certification`
+      `/events/print-certificate/${eventId}/review?templateId=v2.birth-certificate&backTo=/workqueue/pending-certification`
     )
   })
 

--- a/e2e/testcases/navigation/navigating-in-and-out-of-action.spec.ts
+++ b/e2e/testcases/navigation/navigating-in-and-out-of-action.spec.ts
@@ -91,7 +91,7 @@ test.describe.serial('Navigating in and out of action', () => {
     await page.goForward()
     await expectInUrl(
       page,
-      `/events/${eventId}?backTo=%2Fworkqueue%2Fpending-certification`
+      `/events/${eventId}?backTo=/workqueue/pending-certification`
     )
   })
 })

--- a/e2e/testcases/navigation/navigating-in-and-out-of-dashboard.spec.ts
+++ b/e2e/testcases/navigation/navigating-in-and-out-of-dashboard.spec.ts
@@ -71,7 +71,7 @@ test.describe.serial('Navigating in and out of dashboard', () => {
       )
       await expectInUrl(
         page,
-        `/search-result/birth?child.dob=${declaration['child.dob']}&child.name=${encodeURIComponent(JSON.stringify({ firstname: declaration['child.name'].firstname, surname: declaration['child.name'].surname }))}`
+        `/search-result/birth?child.dob=${declaration['child.dob']}&child.name=${JSON.stringify({ firstname: declaration['child.name'].firstname, surname: declaration['child.name'].surname })}`
       )
     })
   })

--- a/e2e/testcases/print-certificate/birth/helpers.ts
+++ b/e2e/testcases/print-certificate/birth/helpers.ts
@@ -37,13 +37,9 @@ export async function navigateToCertificatePrintAction(
 }
 
 export function getRowByTitle(page: Page, title: string) {
-  const button = page.getByRole('button', {
-    name: title
-  })
-  const parentRow = button.locator(
-    'xpath=ancestor::*[starts-with(@id, "row_")]'
-  )
-  return parentRow
+  return page
+    .locator('[id^="row_"]')
+    .filter({ has: page.getByRole('button', { name: title }) })
 }
 
 export async function printAndExpectPopup(page: Page) {

--- a/e2e/testcases/team/2-team-page-national-administrator.spec.ts
+++ b/e2e/testcases/team/2-team-page-national-administrator.spec.ts
@@ -6,6 +6,7 @@ import {
   drawSignature,
   login
 } from '../../helpers'
+import { expectInUrl } from '../../utils'
 
 test('Basic UI check', async ({ browser }) => {
   const page = await browser.newPage()
@@ -81,7 +82,7 @@ test('User Account Actions', async ({ browser }) => {
   await test.step('Submit the form', async () => {
     await continueUntilReview(page)
     await page.getByRole('button', { name: 'Confirm' }).click()
-    expect(page.url()).toContain('view')
+    expectInUrl(page, 'view')
   })
 
   await test.step('Verify Phone Number Changed', async () => {

--- a/e2e/testcases/test-data/birth-declaration.ts
+++ b/e2e/testcases/test-data/birth-declaration.ts
@@ -176,8 +176,6 @@ export async function createDeclaration(
     transactionId: uuidv4()
   })
 
-  console.log('createResponse', createResponse)
-
   const eventId = createResponse.id as string
 
   const filename = await uploadFile(getSignatureFile(), token)
@@ -216,9 +214,6 @@ export async function createDeclaration(
     annotation,
     keepAssignment: action !== ActionType.DECLARE
   })
-  console.log('keepAssignment', action !== ActionType.DECLARE)
-
-  console.log('declareRes', declareRes)
 
   if (action === ActionType.DECLARE) {
     const declareAction = declareRes.actions.find(
@@ -236,16 +231,12 @@ export async function createDeclaration(
     }
   }
 
-  console.log('Registering declaration with action:', action)
-
   const registerRes = await client.event.actions.register.request.mutate({
     eventId,
     transactionId: uuidv4(),
     declaration,
     annotation
   })
-
-  console.log('registerRes', registerRes)
 
   const registerAction = registerRes.actions.find(
     (action: ActionDocument) => action.type === ActionType.REGISTER

--- a/e2e/testcases/test-data/birth-declaration.ts
+++ b/e2e/testcases/test-data/birth-declaration.ts
@@ -14,6 +14,7 @@ import {
   AddressType
 } from '@opencrvs/toolkit/events'
 import { getSignatureFile, uploadFile } from './utils'
+import { dateToIsoDateString, randomPastDate } from '../../helpers'
 
 type InformantRelation = 'MOTHER' | 'BROTHER'
 
@@ -97,6 +98,9 @@ export async function getDeclaration({
 
   const village = getIdByName(administrativeAreas, 'Klow')
 
+  /**
+   * NOTE: This will inevitably result to duplicate detected, unless we introduce more randomness.
+   */
   const mockDeclaration = {
     'father.detailsNotAvailable': true,
     // Only include 'father.reason' if partialDeclaration doesn't have 'father.detailsNotAvailable'
@@ -107,7 +111,12 @@ export async function getDeclaration({
       firstname: faker.person.firstName(),
       surname: faker.person.lastName()
     },
-    'mother.dob': '1995-09-12',
+    'mother.dob': dateToIsoDateString(
+      faker.date
+        // DOB must be at least 18 years after mother.dob to pass validation
+        // Upper bound ensures the record appears on the first page of search results
+        .between({ from: '1995-09-12', to: '2000-11-28' })
+    ),
     'mother.nationality': 'FAR',
     'mother.idType': 'NATIONAL_ID',
     'mother.nid': faker.string.numeric(10),
@@ -121,9 +130,7 @@ export async function getDeclaration({
       surname: faker.person.lastName()
     },
     'child.gender': 'female',
-    'child.dob': new Date(Date.now() - 60 * 60 * 24 * 1000)
-      .toISOString()
-      .split('T')[0], // yesterday
+    'child.dob': randomPastDate(14),
     ...(await getPlaceOfBirth(placeOfBirthType, token)),
     ...getInformantDetails(informantRelation, village)
   }
@@ -169,6 +176,8 @@ export async function createDeclaration(
     transactionId: uuidv4()
   })
 
+  console.log('createResponse', createResponse)
+
   const eventId = createResponse.id as string
 
   const filename = await uploadFile(getSignatureFile(), token)
@@ -207,6 +216,9 @@ export async function createDeclaration(
     annotation,
     keepAssignment: action !== ActionType.DECLARE
   })
+  console.log('keepAssignment', action !== ActionType.DECLARE)
+
+  console.log('declareRes', declareRes)
 
   if (action === ActionType.DECLARE) {
     const declareAction = declareRes.actions.find(
@@ -224,12 +236,16 @@ export async function createDeclaration(
     }
   }
 
+  console.log('Registering declaration with action:', action)
+
   const registerRes = await client.event.actions.register.request.mutate({
     eventId,
     transactionId: uuidv4(),
     declaration,
     annotation
   })
+
+  console.log('registerRes', registerRes)
 
   const registerAction = registerRes.actions.find(
     (action: ActionDocument) => action.type === ActionType.REGISTER

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -119,8 +119,6 @@ export async function ensureAssignedToUser(
   // Wait for the assign modal to appear
   await page.getByRole('button', { name: 'Assign', exact: true }).click()
 
-  await expect(page.locator(`#undefined-download-loading`)).not.toBeVisible()
-
   await expect(
     page.getByTestId('assignedTo-value').locator('span')
   ).toContainText(userFullName, { timeout: SAFE_OUTBOX_TIMEOUT_MS })

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -133,7 +133,7 @@ export async function ensureAssignedToUser(
 
 export async function expectInUrl(page: Page, assertionString: string) {
   await expect(page).toHaveURL((url) =>
-    decodeURIComponent(url.href).includes(assertionString)
+    decodeURIComponent(url.toString()).includes(assertionString)
   )
 }
 

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -119,6 +119,13 @@ export async function ensureAssignedToUser(
   // Wait for the assign modal to appear
   await page.getByRole('button', { name: 'Assign', exact: true }).click()
 
+  // Wait for the assignment API call to complete and the UI to update.
+  await page.waitForResponse(
+    (res) =>
+      res.url().includes('event.actions.assignment.assign') &&
+      res.status() === 200
+  )
+
   await expect(
     page.getByTestId('assignedTo-value').locator('span')
   ).toContainText(userFullName, { timeout: SAFE_OUTBOX_TIMEOUT_MS })

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -119,6 +119,8 @@ export async function ensureAssignedToUser(
   // Wait for the assign modal to appear
   await page.getByRole('button', { name: 'Assign', exact: true }).click()
 
+  await expect(page.locator(`#undefined-download-loading`)).not.toBeVisible()
+
   await expect(
     page.getByTestId('assignedTo-value').locator('span')
   ).toContainText(userFullName, { timeout: SAFE_OUTBOX_TIMEOUT_MS })

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -125,7 +125,7 @@ export async function ensureAssignedToUser(
 }
 
 export async function expectInUrl(page: Page, assertionString: string) {
-  await expect(page.url().includes(assertionString)).toBeTruthy()
+  await expect(page).toHaveURL((url) => url.href.includes(assertionString))
 }
 
 /**

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -132,7 +132,9 @@ export async function ensureAssignedToUser(
 }
 
 export async function expectInUrl(page: Page, assertionString: string) {
-  await expect(page).toHaveURL((url) => url.href.includes(assertionString))
+  await expect(page).toHaveURL((url) =>
+    decodeURIComponent(url.href).includes(assertionString)
+  )
 }
 
 /**


### PR DESCRIPTION
## Description
- Introducing polling for workqueues switched up position of rows. Change helpers to take it into account.
- Introduce randomness to avoid false `DUPLICATE_DETECTED` issues.
- Remove `waitFor: false`
- Use auto-retryable url check method `toHaveURL` to increase stability
- Add explicit timeout for one long-running test


Other:
Might need to be reopened, and the possible issue with the condition is not addressed on this PR
https://github.com/opencrvs/opencrvs-core/issues/10907

```
const motherIdMatchesIfGiven = or(
  differentMotherIdTypes,
  motherIdNotProvided,
  field('mother.nid').strictMatches(),
  field('mother.passport').strictMatches(),
  field('mother.brn').strictMatches(),
  //  Seems off
  field('mother.verified').strictMatches({
    value: 'authenticated'
  })
)
```

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
