### PR TITLE
fix: set smtp host to falsy to prevent crash on e2e

### DIFF
--- a/infrastructure/docker-compose.e2e-deploy.yml
+++ b/infrastructure/docker-compose.e2e-deploy.yml
@@ -114,7 +114,7 @@ services:
   mosip-mock:
     environment:
       # dev environments use localhost as SMTP_HOST which is handled gracefully. In Mosip, SMPT_HOST is used to determine whether to send emails or not. Use empty string as falsy
-      - SMTP_HOST=""
+      SMTP_HOST: ''
 
 configs:
   postgres-reference-data-on-deploy.{{ts}}:

--- a/infrastructure/docker-compose.e2e-deploy.yml
+++ b/infrastructure/docker-compose.e2e-deploy.yml
@@ -82,12 +82,11 @@ services:
 
   postgres-on-update:
     image: postgres:17.6
-    command:
-      [
-        "bash",
-        "-c",
-        "bash /on-deploy.sh && bash /setup-analytics.sh && bash
-          /setup-reference-data.sh",
+    command: [
+        'bash',
+        '-c',
+        'bash /on-deploy.sh && bash /setup-analytics.sh && bash
+        /setup-reference-data.sh'
       ]
     configs:
       - source: postgres-reference-data-on-deploy.{{ts}}
@@ -111,6 +110,11 @@ services:
       - KEEP_ALIVE_SECONDS=10
     networks:
       - overlay_net
+
+  mosip-mock:
+    environment:
+      # dev environments use localhost as SMTP_HOST which is handled gracefully. In Mosip, SMPT_HOST is used to determine whether to send emails or not. Use empty string as falsy
+      - SMTP_HOST=""
 
 configs:
   postgres-reference-data-on-deploy.{{ts}}:

--- a/infrastructure/docker-compose.e2e-deploy.yml
+++ b/infrastructure/docker-compose.e2e-deploy.yml
@@ -113,8 +113,8 @@ services:
 
   mosip-mock:
     environment:
-      # dev environments use localhost as SMTP_HOST which is handled gracefully. In Mosip, SMTP_HOST is used to determine whether to send emails or not. Use empty string as falsy
-      SMTP_HOST:
+      # dev environments use localhost as SMTP_HOST which is handled gracefully. In Mosip, SMTP_HOST is used to determine whether to send emails or not.
+      SMTP_HOST: 0
 
 configs:
   postgres-reference-data-on-deploy.{{ts}}:

--- a/infrastructure/docker-compose.e2e-deploy.yml
+++ b/infrastructure/docker-compose.e2e-deploy.yml
@@ -113,8 +113,8 @@ services:
 
   mosip-mock:
     environment:
-      # dev environments use localhost as SMTP_HOST which is handled gracefully. In Mosip, SMTP_HOST is used to determine whether to send emails or not.
-      SMTP_HOST: 0
+      # dev environments use localhost as SMTP_HOST which is handled gracefully. In Mosip, SMTP_HOST is used to determine whether to send emails or not. Empty string gets wrapped down the line, so we use imaginary env.
+      - SMTP_HOST=${NONEXISTENT_VAR:-}
 
 configs:
   postgres-reference-data-on-deploy.{{ts}}:

--- a/infrastructure/docker-compose.e2e-deploy.yml
+++ b/infrastructure/docker-compose.e2e-deploy.yml
@@ -113,8 +113,8 @@ services:
 
   mosip-mock:
     environment:
-      # dev environments use localhost as SMTP_HOST which is handled gracefully. In Mosip, SMPT_HOST is used to determine whether to send emails or not. Use empty string as falsy
-      SMTP_HOST: ''
+      # dev environments use localhost as SMTP_HOST which is handled gracefully. In Mosip, SMTP_HOST is used to determine whether to send emails or not. Use empty string as falsy
+      SMTP_HOST:
 
 configs:
   postgres-reference-data-on-deploy.{{ts}}:


### PR DESCRIPTION
## Description

Clearly describe what has been changed. Include relevant context or background.
Explain how the issue was fixed (if applicable) and the root cause.

Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
