### PR TITLE
e2e test: Add note on client when viewing record tab while offline

### DIFF
--- a/e2e/testcases/offline/offline-event-overview.spec.ts
+++ b/e2e/testcases/offline/offline-event-overview.spec.ts
@@ -87,8 +87,10 @@ test.describe.serial('Can partially view non-downloaded event offline', () => {
     )
   })
 
-  test('Verify user can not access "Record"-tab details', async () => {
+  test('Verify user sees offline message on "Record"-tab', async () => {
     await page.getByRole('button', { name: 'Record', exact: true }).click()
+    await expect(page.getByTestId('record-offline-message')).toBeVisible()
+    await expect(page.getByText('No connection')).toBeVisible()
     await expect(page.getByTestId('row-value-child.name')).not.toBeVisible()
   })
 })

--- a/e2e/testcases/offline/offline-event-overview.spec.ts
+++ b/e2e/testcases/offline/offline-event-overview.spec.ts
@@ -90,7 +90,6 @@ test.describe.serial('Can partially view non-downloaded event offline', () => {
   test('Verify user sees offline message on "Record"-tab', async () => {
     await page.getByRole('button', { name: 'Record', exact: true }).click()
     await expect(page.getByTestId('record-offline-message')).toBeVisible()
-    await expect(page.getByText('No connection')).toBeVisible()
     await expect(page.getByTestId('row-value-child.name')).not.toBeVisible()
   })
 })


### PR DESCRIPTION
## Description

https://github.com/opencrvs/opencrvs-core/pull/12927

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
