### PR TITLE
Fix flaky test 15

### DIFF
--- a/e2e/testcases/advanced-search/9-search-birth-event-declaration-child-nid.spec.ts
+++ b/e2e/testcases/advanced-search/9-search-birth-event-declaration-child-nid.spec.ts
@@ -11,6 +11,7 @@ import {
 import { CREDENTIALS, GATEWAY_HOST } from '../../constants'
 import { assertTexts, ensureAssignedToUser, type } from '../../utils'
 import { formatV2ChildName } from '../birth/helpers'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 /*
  * Female identity from mock-identities.json (Sahara Wendy Moyo, NID: 1234567899).
@@ -179,7 +180,7 @@ test.describe
 
   test('Open record from search results and verify NID is visible in summary', async () => {
     const childName = formatV2ChildName(declaration)
-    await page.getByRole('button', { name: childName }).click()
+    await openRecordByTitle(page, childName)
 
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
 

--- a/e2e/testcases/application/4a-validate-pending-updates-FA.spec.ts
+++ b/e2e/testcases/application/4a-validate-pending-updates-FA.spec.ts
@@ -16,7 +16,10 @@ import {
   navigateToWorkqueue,
   selectAction
 } from '../../utils'
-import { getRowByTitle } from '../print-certificate/birth/helpers'
+import {
+  getRowByTitle,
+  openRecordByTitle
+} from '../print-certificate/birth/helpers'
 import { faker } from '@faker-js/faker'
 
 test.describe.serial('4(a) Validate "Pending updates"-workqueue for HO', () => {
@@ -50,7 +53,7 @@ test.describe.serial('4(a) Validate "Pending updates"-workqueue for HO', () => {
   test('4.0.2 Navigate to record audit', async () => {
     await page.getByText('Pending validation').click()
 
-    await page.getByRole('button', { name: formattedChildName }).click()
+    await openRecordByTitle(page, formattedChildName)
   })
 
   test('4.0.3 Reject a declaration', async () => {

--- a/e2e/testcases/application/4b-validate-pending-updates-RA.spec.ts
+++ b/e2e/testcases/application/4b-validate-pending-updates-RA.spec.ts
@@ -12,7 +12,10 @@ import {
   navigateToWorkqueue,
   selectAction
 } from '../../utils'
-import { getRowByTitle } from '../print-certificate/birth/helpers'
+import {
+  getRowByTitle,
+  openRecordByTitle
+} from '../print-certificate/birth/helpers'
 import { faker } from '@faker-js/faker'
 
 test.describe.serial('4(b) Validate "Pending updates"-workqueue for RO', () => {
@@ -39,10 +42,7 @@ test.describe.serial('4(b) Validate "Pending updates"-workqueue for RO', () => {
 
   test('4.0.2 Navigate to record audit', async () => {
     await page.getByText('Pending registration').click()
-
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
   })
 
   test('4.0.3 Reject a declaration', async () => {

--- a/e2e/testcases/application/5a-validate-pending-validation-RA.spec.ts
+++ b/e2e/testcases/application/5a-validate-pending-validation-RA.spec.ts
@@ -11,7 +11,10 @@ import {
   expectInUrl,
   selectAction
 } from '../../utils'
-import { getRowByTitle } from '../print-certificate/birth/helpers'
+import {
+  getRowByTitle,
+  openRecordByTitle
+} from '../print-certificate/birth/helpers'
 
 test.describe
   .serial('5(a) Validate "Pending validation"-workqueue for RO', () => {
@@ -69,9 +72,7 @@ test.describe
   })
 
   test('5.3 Click a name', async () => {
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
 
     await expectInUrl(
       page,

--- a/e2e/testcases/application/5b-validate-pending-registration-for-registrar.spec.ts
+++ b/e2e/testcases/application/5b-validate-pending-registration-for-registrar.spec.ts
@@ -6,7 +6,10 @@ import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { ActionType } from '@opencrvs/toolkit/events'
 import { formatV2ChildName } from '../birth/helpers'
 import { ensureAssignedToUser, expectInUrl } from '../../utils'
-import { getRowByTitle } from '../print-certificate/birth/helpers'
+import {
+  getRowByTitle,
+  openRecordByTitle
+} from '../print-certificate/birth/helpers'
 
 test.describe
   .serial('5(b) Validate "Pending registration"-workqueue for Registrar', () => {
@@ -64,9 +67,7 @@ test.describe
   })
 
   test('5.4 Click a name', async () => {
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
 
     await expectInUrl(
       page,

--- a/e2e/testcases/application/6-validate-pending-certification.spec.ts
+++ b/e2e/testcases/application/6-validate-pending-certification.spec.ts
@@ -5,6 +5,7 @@ import { CREDENTIALS, SAFE_WORKQUEUE_TIMEOUT_MS } from '../../constants'
 import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { formatV2ChildName } from '../birth/helpers'
 import { ensureAssignedToUser, expectInUrl, selectAction } from '../../utils'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test.describe.serial('6 Validate "Pending certification"-workqueue', () => {
   let page: Page
@@ -65,9 +66,7 @@ test.describe.serial('6 Validate "Pending certification"-workqueue', () => {
   })
 
   test('6.4 Click a name', async () => {
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
 
     await expectInUrl(
       page,

--- a/e2e/testcases/application/workqueue-flow-3.spec.ts
+++ b/e2e/testcases/application/workqueue-flow-3.spec.ts
@@ -16,7 +16,6 @@ import {
   selectAction
 } from '../../utils'
 import { assertRecordInWorkqueue, fillDate } from '../birth/helpers'
-import { getRowByTitle } from '../print-certificate/birth/helpers'
 
 // HO Notifies => RO Rejects => RO Re-declares and validates => Registrar rejects
 // => RO Re-declares again => Registrar registers

--- a/e2e/testcases/birth/helpers.ts
+++ b/e2e/testcases/birth/helpers.ts
@@ -3,7 +3,6 @@ import { omit } from 'lodash'
 import { formatName, joinValuesWith } from '../../helpers'
 import { faker } from '@faker-js/faker'
 import { ensureOutboxIsEmpty } from '../../utils'
-import { getRowByTitle } from '../print-certificate/birth/helpers'
 import { SAFE_OUTBOX_TIMEOUT_MS } from '../../constants'
 import { GATEWAY_HOST } from '../../constants'
 import { createClient } from '@opencrvs/toolkit/api'
@@ -62,6 +61,10 @@ export const formatV2ChildName = (obj: {
   ])
 }
 
+/**
+ * @deprecated - causes flakiness on tests that use it, and forcing us to keep retrying.
+ *
+ */
 export const assertRecordInWorkqueue = async ({
   page,
   name,

--- a/e2e/testcases/correction-birth/request-and-accept-correction-offline.spec.ts
+++ b/e2e/testcases/correction-birth/request-and-accept-correction-offline.spec.ts
@@ -14,6 +14,7 @@ import {
   selectAction,
   type
 } from '../../utils'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test.describe.serial('Request and accept correction (offline)', () => {
   let declaration: DeclarationV2
@@ -182,9 +183,8 @@ test.describe.serial('Request and accept correction (offline)', () => {
     test('Navigate to correction review', async () => {
       await type(page, '#searchText', trackingId)
       await page.locator('#searchIconButton').click()
-      await page
-        .getByRole('button', { name: formatV2ChildName(declaration) })
-        .click()
+
+      await openRecordByTitle(page, formatV2ChildName(declaration))
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
       await selectAction(page, 'Review correction request')

--- a/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-1.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-1.spec.ts
@@ -18,6 +18,7 @@ import {
 } from '../../utils'
 import { selectDeclarationAction } from '../../helpers'
 import { format, subDays } from 'date-fns'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 const recentDate = subDays(new Date(), 2)
 const recentDay = format(recentDate, 'dd')
@@ -153,8 +154,8 @@ test.describe.serial('Approval of late birth registration', () => {
     test('Navigate to the declaration review page', async () => {
       await login(page, CREDENTIALS.REGISTRATION_OFFICER)
       await page.getByText('Pending approval').click()
-      await page.getByRole('button', { name: childNameFormatted }).click()
 
+      await openRecordByTitle(page, childNameFormatted)
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
     })
 
@@ -197,7 +198,7 @@ test.describe.serial('Approval of late birth registration', () => {
     test('Navigate to the declaration review page', async () => {
       await login(page, CREDENTIALS.PROVINCIAL_REGISTRAR)
       await page.getByText('Pending approval').first().click()
-      await page.getByRole('button', { name: childNameFormatted }).click()
+      await openRecordByTitle(page, childNameFormatted)
     })
 
     test('Approve action should be disabled before assignment', async () => {

--- a/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-2.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-2.spec.ts
@@ -18,6 +18,7 @@ import {
 } from '../../utils'
 import { selectDeclarationAction } from '../../helpers'
 import { format, subDays } from 'date-fns'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 const recentDate = subDays(new Date(), 2)
 const recentDay = format(recentDate, 'dd')
@@ -145,7 +146,7 @@ test.describe
     test('Navigate to the declaration review page', async () => {
       await login(page, CREDENTIALS.REGISTRATION_OFFICER)
       await page.getByText('Pending approval').click()
-      await page.getByRole('button', { name: childNameFormatted }).click()
+      await openRecordByTitle(page, childNameFormatted)
     })
 
     test('Assign', async () => {
@@ -321,7 +322,7 @@ test.describe
     test('Navigate to the declaration review page', async () => {
       await login(page, CREDENTIALS.REGISTRAR)
       await page.getByText('Pending registration').click()
-      await page.getByRole('button', { name: childNameFormatted }).click()
+      await openRecordByTitle(page, childNameFormatted)
     })
 
     test('Assign', async () => {
@@ -362,7 +363,8 @@ test.describe
 
     test('Go to record', async () => {
       await page.getByText('Recent').click()
-      await page.getByRole('button', { name: childNameFormatted }).click()
+
+      await openRecordByTitle(page, childNameFormatted)
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     })
 

--- a/e2e/testcases/custom-actions-and-flags/escalate-keeps-rejected-flag.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/escalate-keeps-rejected-flag.spec.ts
@@ -19,6 +19,7 @@ import {
   type Declaration
 } from '../test-data/birth-declaration'
 import { formatV2ChildName } from '../birth/helpers'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test('Escalating a rejected record preserves the Rejected flag', async ({
   page
@@ -75,9 +76,7 @@ test('Escalating a rejected record preserves the Rejected flag', async ({
   await test.step('Find the rejected record by tracking ID', async () => {
     await type(page, '#searchText', trackingId)
     await page.locator('#searchIconButton').click()
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
 
     await expectInUrl(page, `events/${eventId}`)
 

--- a/e2e/testcases/custom-actions-and-flags/escalate-to-registrars.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/escalate-to-registrars.spec.ts
@@ -14,6 +14,7 @@ import {
   selectAction
 } from '../../utils'
 import { createDeclaration } from '../test-data/birth-declaration-with-father-brother'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test.describe.serial('Escalation of birth registration by Registrar', () => {
   let page: Page
@@ -65,9 +66,7 @@ test.describe.serial('Escalation of birth registration by Registrar', () => {
   test.describe('Escalate to Provincial Registrar', async () => {
     test('Registrar assigns birth registration', async () => {
       await page.getByText('Pending certification').click()
-      await page
-        .getByRole('button', { name: childNameForProvincialFormatted })
-        .click()
+      await openRecordByTitle(page, childNameForProvincialFormatted)
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     })
 
@@ -104,9 +103,7 @@ test.describe.serial('Escalation of birth registration by Registrar', () => {
 
   test.describe('Escalate to Registrar General', () => {
     test('Registrar assigns birth registration', async () => {
-      await page
-        .getByRole('button', { name: childNameForRegGeneralFormatted })
-        .click()
+      await openRecordByTitle(page, childNameForRegGeneralFormatted)
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     })
 
@@ -142,9 +139,8 @@ test.describe.serial('Escalation of birth registration by Registrar', () => {
     test('Verify Registrar General Escalated Status', async () => {
       await login(page, CREDENTIALS.REGISTRAR_GENERAL)
       await page.getByText('Pending feedback').click()
-      await page
-        .getByRole('button', { name: childNameForRegGeneralFormatted })
-        .click()
+
+      await openRecordByTitle(page, childNameForRegGeneralFormatted)
     })
 
     test('Assign', async () => {
@@ -179,9 +175,7 @@ test.describe.serial('Escalation of birth registration by Registrar', () => {
     test('Verify Provincial Registrar Escalated Status', async () => {
       await login(page, CREDENTIALS.PROVINCIAL_REGISTRAR)
       await page.getByText('Pending feedback').click()
-      await page
-        .getByRole('button', { name: childNameForProvincialFormatted })
-        .click()
+      await openRecordByTitle(page, childNameForProvincialFormatted)
     })
 
     test('Assign', async () => {

--- a/e2e/testcases/custom-actions-and-flags/issue-certified-copy.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/issue-certified-copy.spec.ts
@@ -9,7 +9,10 @@ import {
 import { Declaration, createDeclaration } from '../test-data/birth-declaration'
 import { REQUIRED_VALIDATION_ERROR } from '../birth/helpers'
 import { formatV2ChildName } from '../birth/helpers'
-import { printAndExpectPopup } from '../print-certificate/birth/helpers'
+import {
+  openRecordByTitle,
+  printAndExpectPopup
+} from '../print-certificate/birth/helpers'
 
 test.describe.serial('Issue Certified Copy', () => {
   let page: Page
@@ -98,7 +101,7 @@ test.describe.serial('Issue Certified Copy', () => {
   test.describe('Print issuance', async () => {
     test('Navigate to the declaration review page', async () => {
       await navigateToWorkqueue(page, 'Pending issuance')
-      await page.getByRole('button', { name: childName }).click()
+      await openRecordByTitle(page, childName)
       await expect(page.getByText('Registered')).toBeVisible()
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
 

--- a/e2e/testcases/death/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/death/8-validate-declaration-review-page.spec.ts
@@ -20,6 +20,7 @@ import {
   expectInUrl,
   selectAction
 } from '../../utils'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test.describe.serial('8. Validate declaration review page', () => {
   let page: Page
@@ -717,14 +718,12 @@ test.describe.serial('8. Validate declaration review page', () => {
       await ensureOutboxIsEmpty(page)
       await page.getByText('Notifications').click()
 
-      await page
-        .getByRole('button', {
-          name:
-            declaration.deceased.name.firstname +
-            ' ' +
-            declaration.deceased.name.surname
-        })
-        .click()
+      await openRecordByTitle(
+        page,
+        declaration.deceased.name.firstname +
+          ' ' +
+          declaration.deceased.name.surname
+      )
     })
 
     test('8.2.1.1 Verify information added on previous pages', async () => {
@@ -1173,14 +1172,12 @@ test.describe.serial('8. Validate declaration review page', () => {
       await ensureOutboxIsEmpty(page)
       await page.getByText('Pending registration').click()
 
-      await page
-        .getByRole('button', {
-          name:
-            declaration.deceased.name.firstname +
-            ' ' +
-            declaration.deceased.name.surname
-        })
-        .click()
+      await openRecordByTitle(
+        page,
+        declaration.deceased.name.firstname +
+          ' ' +
+          declaration.deceased.name.surname
+      )
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
       await switchEventTab(page, 'Record')

--- a/e2e/testcases/death/declaration/death-declaration-1.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-1.spec.ts
@@ -18,6 +18,7 @@ import {
   ensureOutboxIsEmpty,
   expectInUrl
 } from '../../../utils'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('1. Death declaration case - 1', () => {
   let page: Page
@@ -593,16 +594,14 @@ test.describe.serial('1. Death declaration case - 1', () => {
       await ensureOutboxIsEmpty(page)
       await page.getByText('Pending validation').click()
 
-      await page
-        .getByRole('button', {
-          name:
-            declaration.deceased.name.firstname +
-            ' ' +
-            declaration.deceased.name.surname
-        })
-        .click()
+      await openRecordByTitle(
+        page,
+        declaration.deceased.name.firstname +
+          ' ' +
+          declaration.deceased.name.surname
+      )
 
-      await ensureAssignedToUser
+      await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
       await switchEventTab(page, 'Record')
     })
 

--- a/e2e/testcases/death/declaration/death-declaration-11.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-11.spec.ts
@@ -18,6 +18,7 @@ import {
   ensureOutboxIsEmpty,
   expectInUrl
 } from '../../../utils'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('11. Death declaration case - 11', () => {
   let page: Page
@@ -694,17 +695,14 @@ test.describe.serial('11. Death declaration case - 11', () => {
     test('11.2.1 Navigate to the declaration "Record" -tab', async () => {
       await login(page, CREDENTIALS.REGISTRATION_OFFICER)
 
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Pending validation').click()
 
-      await page
-        .getByRole('button', {
-          name:
-            declaration.deceased.name.firstname +
-            ' ' +
-            declaration.deceased.name.surname
-        })
-        .click()
+      await openRecordByTitle(
+        page,
+        declaration.deceased.name.firstname +
+          ' ' +
+          declaration.deceased.name.surname
+      )
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
       await switchEventTab(page, 'Record')

--- a/e2e/testcases/death/declaration/death-declaration-2.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-2.spec.ts
@@ -18,6 +18,7 @@ import {
   ensureOutboxIsEmpty,
   expectInUrl
 } from '../../../utils'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('2. Death declaration case - 2', () => {
   let page: Page
@@ -738,14 +739,12 @@ test.describe.serial('2. Death declaration case - 2', () => {
       await ensureOutboxIsEmpty(page)
       await page.getByText('Pending validation').click()
 
-      await page
-        .getByRole('button', {
-          name:
-            declaration.deceased.name.firstname +
-            ' ' +
-            declaration.deceased.name.surname
-        })
-        .click()
+      await openRecordByTitle(
+        page,
+        declaration.deceased.name.firstname +
+          ' ' +
+          declaration.deceased.name.surname
+      )
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
       await switchEventTab(page, 'Record')

--- a/e2e/testcases/death/declaration/death-declaration-3.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-3.spec.ts
@@ -18,6 +18,7 @@ import {
   ensureOutboxIsEmpty,
   expectInUrl
 } from '../../../utils'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('3. Death declaration case - 3', () => {
   let page: Page
@@ -700,14 +701,12 @@ test.describe.serial('3. Death declaration case - 3', () => {
       await ensureOutboxIsEmpty(page)
       await page.getByText('Pending validation').click()
 
-      await page
-        .getByRole('button', {
-          name:
-            declaration.deceased.name.firstname +
-            ' ' +
-            declaration.deceased.name.surname
-        })
-        .click()
+      await openRecordByTitle(
+        page,
+        declaration.deceased.name.firstname +
+          ' ' +
+          declaration.deceased.name.surname
+      )
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
       await switchEventTab(page, 'Record')

--- a/e2e/testcases/death/declaration/death-declaration-4.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-4.spec.ts
@@ -19,6 +19,7 @@ import {
   expectInUrl,
   selectAction
 } from '../../../utils'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('4. Death declaration case - 4', () => {
   let page: Page
@@ -829,14 +830,12 @@ test.describe.serial('4. Death declaration case - 4', () => {
       await ensureOutboxIsEmpty(page)
       await page.getByText('Pending registration').click()
 
-      await page
-        .getByRole('button', {
-          name:
-            declaration.deceased.name.firstname +
-            ' ' +
-            declaration.deceased.name.surname
-        })
-        .click()
+      await openRecordByTitle(
+        page,
+        declaration.deceased.name.firstname +
+          ' ' +
+          declaration.deceased.name.surname
+      )
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
       await switchEventTab(page, 'Record')

--- a/e2e/testcases/death/declaration/death-declaration-5.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-5.spec.ts
@@ -18,6 +18,7 @@ import {
   ensureOutboxIsEmpty,
   expectInUrl
 } from '../../../utils'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('5. Death declaration case - 5', () => {
   let page: Page
@@ -559,14 +560,12 @@ test.describe.serial('5. Death declaration case - 5', () => {
       await ensureOutboxIsEmpty(page)
       await page.getByText('Pending registration').click()
 
-      await page
-        .getByRole('button', {
-          name:
-            declaration.deceased.name.firstname +
-            ' ' +
-            declaration.deceased.name.surname
-        })
-        .click()
+      await openRecordByTitle(
+        page,
+        declaration.deceased.name.firstname +
+          ' ' +
+          declaration.deceased.name.surname
+      )
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
       await switchEventTab(page, 'Record')

--- a/e2e/testcases/death/declaration/death-declaration-6.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-6.spec.ts
@@ -17,6 +17,7 @@ import {
   ensureOutboxIsEmpty,
   expectInUrl
 } from '../../../utils'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('6. Death declaration case - 6', () => {
   let page: Page
@@ -560,14 +561,12 @@ test.describe.serial('6. Death declaration case - 6', () => {
       await ensureOutboxIsEmpty(page)
       await page.getByText('Pending certification').click()
 
-      await page
-        .getByRole('button', {
-          name:
-            declaration.deceased.name.firstname +
-            ' ' +
-            declaration.deceased.name.surname
-        })
-        .click()
+      await openRecordByTitle(
+        page,
+        declaration.deceased.name.firstname +
+          ' ' +
+          declaration.deceased.name.surname
+      )
     })
 
     test('6.2.2 Verify information on "Record" tab', async () => {

--- a/e2e/testcases/death/declaration/death-declaration-7.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-7.spec.ts
@@ -17,6 +17,7 @@ import {
   ensureOutboxIsEmpty,
   expectInUrl
 } from '../../../utils'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('7. Death declaration case - 7', () => {
   let page: Page
@@ -558,14 +559,12 @@ test.describe.serial('7. Death declaration case - 7', () => {
       ).toBeVisible()
     })
     test('7.1.8 Verify information on "Record" tab', async () => {
-      await page
-        .getByRole('button', {
-          name:
-            declaration.deceased.name.firstname +
-            ' ' +
-            declaration.deceased.name.surname
-        })
-        .click()
+      await openRecordByTitle(
+        page,
+        declaration.deceased.name.firstname +
+          ' ' +
+          declaration.deceased.name.surname
+      )
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
       await switchEventTab(page, 'Record')

--- a/e2e/testcases/death/declaration/death-declaration-8.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-8.spec.ts
@@ -16,6 +16,7 @@ import {
   selectAction
 } from '../../../utils'
 import { REQUIRED_VALIDATION_ERROR } from '../../birth/helpers'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('8. Death declaration case - 8', () => {
   let page: Page
@@ -291,14 +292,12 @@ test.describe.serial('8. Death declaration case - 8', () => {
       await ensureOutboxIsEmpty(page)
       await page.getByText('Notifications').click()
 
-      await page
-        .getByRole('button', {
-          name:
-            declaration.deceased.name.firstname +
-            ' ' +
-            declaration.deceased.name.surname
-        })
-        .click()
+      await openRecordByTitle(
+        page,
+        declaration.deceased.name.firstname +
+          ' ' +
+          declaration.deceased.name.surname
+      )
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
       await selectAction(page, 'Edit')

--- a/e2e/testcases/death/declaration/death-declaration-9.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-9.spec.ts
@@ -16,6 +16,7 @@ import {
   selectAction
 } from '../../../utils'
 import { REQUIRED_VALIDATION_ERROR } from '../../birth/helpers'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('9. Death declaration case - 9', () => {
   let page: Page
@@ -291,14 +292,12 @@ test.describe.serial('9. Death declaration case - 9', () => {
       await ensureOutboxIsEmpty(page)
       await page.getByText('Notifications').click()
 
-      await page
-        .getByRole('button', {
-          name:
-            declaration.deceased.name.firstname +
-            ' ' +
-            declaration.deceased.name.surname
-        })
-        .click()
+      await openRecordByTitle(
+        page,
+        declaration.deceased.name.firstname +
+          ' ' +
+          declaration.deceased.name.surname
+      )
     })
 
     test('9.2.2 Verify information on review page', async () => {

--- a/e2e/testcases/duplicate/corrected-record-comparison.spec.ts
+++ b/e2e/testcases/duplicate/corrected-record-comparison.spec.ts
@@ -9,6 +9,7 @@ import { createDeclaration } from '../test-data/birth-declaration-with-mother-fa
 import { formatV2ChildName } from '../birth/helpers'
 import { getLocations, getIdByName } from '../birth/helpers'
 import { ensureAssignedToUser, selectAction } from '../../utils'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 /**
  * Regression test for opencrvs-core#12848.
@@ -104,9 +105,7 @@ test('Corrected place of birth (PRIVATE_HOME → HEALTH_FACILITY) is not shown s
   await test.step('Open the duplicate record in the comparison view', async () => {
     await login(page, CREDENTIALS.REGISTRAR)
     await page.getByRole('button', { name: 'Potential duplicate' }).click()
-    await page
-      .getByRole('button', { name: formatV2ChildName(sharedDetails) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(sharedDetails))
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     await selectAction(page, 'Review potential duplicates')
   })

--- a/e2e/testcases/duplicate/overview.spec.ts
+++ b/e2e/testcases/duplicate/overview.spec.ts
@@ -11,6 +11,7 @@ import { createDeclaration } from '../test-data/birth-declaration-with-mother-fa
 import { formatV2ChildName } from '../birth/helpers'
 import { ActionType } from '@opencrvs/toolkit/events'
 import { ensureAssignedToUser, selectAction } from '../../utils'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test('Duplicate overview', async ({ page }) => {
   const details = {
@@ -92,7 +93,7 @@ test('Duplicate overview', async ({ page }) => {
 
   await test.step("Navigate back to duplicate's overview and validate audit", async () => {
     await searchFromSearchBar(page, duplicateTrackingId, false)
-    await page.getByRole('button', { name }).click()
+    await openRecordByTitle(page, name)
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     await expect(page.getByTestId('status-value')).toHaveText('Archived')
 

--- a/e2e/testcases/event-overview/history-for-registrar.spec.ts
+++ b/e2e/testcases/event-overview/history-for-registrar.spec.ts
@@ -3,6 +3,8 @@ import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { getToken, login, switchEventTab } from '../../helpers'
 import { CREDENTIALS, SAFE_WORKQUEUE_TIMEOUT_MS } from '../../constants'
 import { ensureAssignedToUser } from '../../utils'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
+import { formatV2ChildName } from '../birth/helpers'
 
 test.describe
   .serial('History rows when Registrar registers a birth from scratch', () => {
@@ -27,8 +29,8 @@ test.describe
     await page.waitForTimeout(SAFE_WORKQUEUE_TIMEOUT_MS) // wait for the event to be in the workqueue.
     await page.getByText('Pending certification').click()
 
-    const childName = `${declaration['child.name'].firstname} ${declaration['child.name'].surname}`
-    await page.getByRole('button', { name: childName }).click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
+
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     await expect(page.getByTestId('assignedTo-value')).toHaveText(
       'Kennedy Mweene'

--- a/e2e/testcases/events-rest-api/events-notify.spec.ts
+++ b/e2e/testcases/events-rest-api/events-notify.spec.ts
@@ -17,6 +17,7 @@ import { getAdministrativeAreas, getIdByName } from '../birth/helpers'
 import { formatV2ChildName, REQUIRED_VALIDATION_ERROR } from '../birth/helpers'
 import { getDeclaration } from '../test-data/birth-declaration'
 import {
+  openRecordByTitle,
   printAndExpectPopup,
   selectRequesterType
 } from '../print-certificate/birth/helpers'
@@ -687,11 +688,10 @@ test.describe('POST /api/events/events/{eventId}/notify', () => {
 
     test("Navigate to event via 'Pending certification' -workqueue", async () => {
       await page.getByRole('button', { name: 'Pending certification' }).click()
-      await page
-        .getByRole('button', {
-          name: await formatV2ChildName({ 'child.name': newChildName })
-        })
-        .click()
+      await openRecordByTitle(
+        page,
+        formatV2ChildName({ 'child.name': newChildName })
+      )
     })
 
     test('Print certificate', async () => {
@@ -797,11 +797,10 @@ test.describe('POST /api/events/events/{eventId}/notify', () => {
 
     test("Navigate to event via 'Notifications' -workqueue", async () => {
       await page.getByRole('button', { name: 'Notifications' }).click()
-      await page
-        .getByRole('button', {
-          name: await formatV2ChildName({ 'child.name': childName })
-        })
-        .click()
+      await openRecordByTitle(
+        page,
+        formatV2ChildName({ 'child.name': childName })
+      )
     })
 
     test('Reject event', async () => {
@@ -816,11 +815,10 @@ test.describe('POST /api/events/events/{eventId}/notify', () => {
       await page.getByPlaceholder('Search').fill(trackingId)
       await page.getByRole('button', { name: 'Search' }).click()
 
-      await page
-        .getByRole('button', {
-          name: await formatV2ChildName({ 'child.name': childName })
-        })
-        .click()
+      await openRecordByTitle(
+        page,
+        formatV2ChildName({ 'child.name': childName })
+      )
     })
 
     test('Audit event', async () => {

--- a/e2e/testcases/events-rest-api/events-notify.spec.ts
+++ b/e2e/testcases/events-rest-api/events-notify.spec.ts
@@ -28,7 +28,7 @@ import {
   NON_EXISTING_UUID
 } from './helpers'
 
-import { CREDENTIALS, SAFE_IN_EXTERNAL_VALIDATION_MS } from '../../constants'
+import { CREDENTIALS } from '../../constants'
 
 test.describe('POST /api/events/events/{eventId}/notify', () => {
   let clientToken: string
@@ -471,7 +471,7 @@ test.describe('POST /api/events/events/{eventId}/notify', () => {
 
     await page.getByRole('button', { name: 'Notifications' }).click()
 
-    await page.getByText(await formatName(childName)).click()
+    await openRecordByTitle(page, formatName(childName))
 
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
 
@@ -624,11 +624,10 @@ test.describe('POST /api/events/events/{eventId}/notify', () => {
 
     test("Navigate to event via 'Notifications' -workqueue", async () => {
       await page.getByRole('button', { name: 'Notifications' }).click()
-      await page
-        .getByRole('button', {
-          name: await formatV2ChildName({ 'child.name': childName })
-        })
-        .click()
+      await openRecordByTitle(
+        page,
+        formatV2ChildName({ 'child.name': childName })
+      )
     })
 
     test('Edit event', async () => {

--- a/e2e/testcases/messages/roles-in-record-audit.spec.ts
+++ b/e2e/testcases/messages/roles-in-record-audit.spec.ts
@@ -5,6 +5,7 @@ import { createDeclaration } from '../test-data/birth-declaration'
 import { ActionType } from '@opencrvs/toolkit/events'
 import { ensureAssignedToUser } from '../../utils'
 import { formatV2ChildName } from '../birth/helpers'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 const testCases = [
   {
@@ -45,23 +46,14 @@ test.describe('Roles in Record Audit', () => {
           .getByRole('textbox', { name: 'Search for a record' })
           .fill(formatV2ChildName(res.declaration))
         await page.getByRole('button', { name: 'Search' }).click()
-        await expect(
-          page.getByRole('button', {
-            name: formatV2ChildName(res.declaration),
-            exact: true
-          })
-        ).toBeVisible({ timeout: 5_000 })
+
+        await openRecordByTitle(page, formatV2ChildName(res.declaration))
       }).toPass({
         timeout: 60_000,
         intervals: [...Array(5).fill(1_000), ...Array(5).fill(2_000), 5_000]
       })
 
-      await page
-        .getByRole('button', {
-          name: formatV2ChildName(res.declaration),
-          exact: true
-        })
-        .click()
+      await openRecordByTitle(page, formatV2ChildName(res.declaration))
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
       await switchEventTab(page, 'Audit')

--- a/e2e/testcases/messages/roles-in-record-audit.spec.ts
+++ b/e2e/testcases/messages/roles-in-record-audit.spec.ts
@@ -40,11 +40,22 @@ test.describe('Roles in Record Audit', () => {
         }
       )
 
-      await page
-        .getByRole('textbox', { name: 'Search for a record' })
-        .fill(formatV2ChildName(res.declaration))
+      await expect(async () => {
+        await page
+          .getByRole('textbox', { name: 'Search for a record' })
+          .fill(formatV2ChildName(res.declaration))
+        await page.getByRole('button', { name: 'Search' }).click()
+        await expect(
+          page.getByRole('button', {
+            name: formatV2ChildName(res.declaration),
+            exact: true
+          })
+        ).toBeVisible({ timeout: 5_000 })
+      }).toPass({
+        timeout: 60_000,
+        intervals: [...Array(5).fill(1_000), ...Array(5).fill(2_000), 5_000]
+      })
 
-      await page.getByRole('button', { name: 'Search' }).click()
       await page
         .getByRole('button', {
           name: formatV2ChildName(res.declaration),

--- a/e2e/testcases/messages/roles-in-record-audit.spec.ts
+++ b/e2e/testcases/messages/roles-in-record-audit.spec.ts
@@ -47,7 +47,12 @@ test.describe('Roles in Record Audit', () => {
           .fill(formatV2ChildName(res.declaration))
         await page.getByRole('button', { name: 'Search' }).click()
 
-        await openRecordByTitle(page, formatV2ChildName(res.declaration))
+        await expect(
+          page.getByRole('button', {
+            name: formatV2ChildName(res.declaration),
+            exact: true
+          })
+        ).toBeVisible({ timeout: 5_000 })
       }).toPass({
         timeout: 60_000,
         intervals: [...Array(5).fill(1_000), ...Array(5).fill(2_000), 5_000]

--- a/e2e/testcases/offline/offline-mark-as-duplicate.spec.ts
+++ b/e2e/testcases/offline/offline-mark-as-duplicate.spec.ts
@@ -8,6 +8,7 @@ import { ActionType } from '@opencrvs/toolkit/events'
 import { ensureAssignedToUser, selectAction } from '../../utils'
 import { createClient } from '@opencrvs/toolkit/api'
 import { v4 as uuidv4 } from 'uuid'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test('Mark as duplicate while offline', async ({ page }) => {
   const details = {
@@ -55,7 +56,7 @@ test('Mark as duplicate while offline', async ({ page }) => {
   await test.step("Navigate to potential duplicate's overview", async () => {
     await login(page, CREDENTIALS.REGISTRAR)
     await page.getByRole('button', { name: 'Potential duplicate' }).click()
-    await page.getByRole('button', { name }).click()
+    await openRecordByTitle(page, name)
   })
 
   await test.step('Go to duplicate review', async () => {

--- a/e2e/testcases/print-certificate/birth/36.03-validate-certify-record-page.spec.ts
+++ b/e2e/testcases/print-certificate/birth/36.03-validate-certify-record-page.spec.ts
@@ -9,7 +9,8 @@ import {
   printAndExpectPopup,
   navigateToCertificatePrintAction,
   selectCertificationType,
-  selectRequesterType
+  selectRequesterType,
+  openRecordByTitle
 } from './helpers'
 import { ensureAssignedToUser, expectInUrl, type } from '../../../utils'
 import { formatV2ChildName } from '../../birth/helpers'
@@ -144,9 +145,7 @@ test.describe.serial('3.0 Validate "Certify record" page', () => {
     }
     await type(page, '#searchText', trackingId)
     await page.locator('#searchIconButton').click()
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
 
     await page.getByRole('button', { name: 'Audit' }).click()

--- a/e2e/testcases/print-certificate/birth/36.05.06-validate-certify-record-page.spec.ts
+++ b/e2e/testcases/print-certificate/birth/36.05.06-validate-certify-record-page.spec.ts
@@ -10,7 +10,8 @@ import {
   selectRequesterType,
   selectCertificationType,
   navigateToCertificatePrintAction,
-  printAndExpectPopup
+  printAndExpectPopup,
+  openRecordByTitle
 } from './helpers'
 import { ensureAssignedToUser, type, expectInUrl } from '../../../utils'
 import { REQUIRED_VALIDATION_ERROR } from '../../birth/helpers'
@@ -152,9 +153,8 @@ test.describe.serial('Validate collect payment page', () => {
     }
     await type(page, '#searchText', trackingId)
     await page.locator('#searchIconButton').click()
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
+
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     await page.getByRole('button', { name: 'Audit' }).click()
     await page.getByRole('button', { name: 'Certified', exact: true }).click()

--- a/e2e/testcases/print-certificate/birth/44.14-certified-copy.spec.ts
+++ b/e2e/testcases/print-certificate/birth/44.14-certified-copy.spec.ts
@@ -7,6 +7,7 @@ import { CREDENTIALS } from '../../../constants'
 import { login } from '../../../helpers'
 import {
   navigateToCertificatePrintAction,
+  openRecordByTitle,
   selectRequesterType
 } from './helpers'
 import { ensureAssignedToUser, selectAction } from '../../../utils'
@@ -68,13 +69,7 @@ test.describe.serial('44.14.0 Validate "Certified copy" option', () => {
       .fill(formatV2ChildName(declaration))
 
     await page.getByRole('button', { name: 'Search' }).click()
-    await page
-      .getByRole('button', {
-        name: formatV2ChildName(declaration),
-        exact: true
-      })
-      .click()
-
+    await openRecordByTitle(page, formatV2ChildName(declaration))
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     await selectAction(page, 'Print')
     await page.locator('#certificateTemplateId svg').click()

--- a/e2e/testcases/print-certificate/birth/helpers.ts
+++ b/e2e/testcases/print-certificate/birth/helpers.ts
@@ -42,6 +42,35 @@ export function getRowByTitle(page: Page, title: string) {
     .filter({ has: page.getByRole('button', { name: title }) })
 }
 
+/**
+ * Opens a record from a workqueue list by its title (e.g. formatted child name) and **verifies it**
+ *
+ * NOTE:
+ * Application polls continuously for updates. E2E tests are run in parallel.
+ * It is likely that the same workqueue will get updated, and **during** the time we select a row, and click it, it actually has diffrent user and the test fails down the line.
+ *
+ */
+export async function openRecordByTitle(page: Page, title: string) {
+  await expect(async () => {
+    await getRowByTitle(page, title)
+      .getByRole('button', { name: title })
+      .click()
+    try {
+      // target the event overview title.
+      await expect(
+        page.getByTestId('record-header').getByText(title)
+      ).toBeVisible({ timeout: 3_000 })
+    } catch (error) {
+      await page.goBack()
+      // This triggers toPass retry loop if the updated happened and we picked wrong one.
+      throw error
+    }
+  }).toPass({
+    timeout: 60_000,
+    intervals: [...Array(5).fill(1_000), ...Array(5).fill(2_000), 5_000]
+  })
+}
+
 export async function printAndExpectPopup(page: Page) {
   await page.getByRole('button', { name: 'Yes, print certificate' }).click()
   const popupPromise = page.waitForEvent('popup')

--- a/e2e/testcases/print-certificate/birth/helpers.ts
+++ b/e2e/testcases/print-certificate/birth/helpers.ts
@@ -56,9 +56,9 @@ export async function openRecordByTitle(page: Page, title: string) {
       .getByRole('button', { name: title })
       .click()
     try {
-      // target the event overview title.
+      // target the event overview title to make sure this is the right one.
       await expect(
-        page.getByTestId('record-header').getByText(title)
+        page.getByRole('heading', { name: title, level: 1 })
       ).toBeVisible({ timeout: 3_000 })
     } catch (error) {
       await page.goBack()

--- a/e2e/testcases/print-certificate/birth/print-to-someone-else-using-alien-number.spec.ts
+++ b/e2e/testcases/print-certificate/birth/print-to-someone-else-using-alien-number.spec.ts
@@ -10,7 +10,8 @@ import {
   selectRequesterType,
   selectCertificationType,
   navigateToCertificatePrintAction,
-  printAndExpectPopup
+  printAndExpectPopup,
+  openRecordByTitle
 } from './helpers'
 import { ensureAssignedToUser, type } from '../../../utils'
 import { formatV2ChildName } from '../../birth/helpers'
@@ -76,9 +77,7 @@ test.describe
     }
     await type(page, '#searchText', trackingId)
     await page.locator('#searchIconButton').click()
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     await page.getByRole('button', { name: 'Audit' }).click()
     await page.getByRole('button', { name: 'Certified', exact: true }).click()

--- a/e2e/testcases/print-certificate/birth/validate-pdf-details.spec.ts
+++ b/e2e/testcases/print-certificate/birth/validate-pdf-details.spec.ts
@@ -6,6 +6,7 @@ import { CREDENTIALS } from '../../../constants'
 import { getToken } from '../../../helpers'
 import {
   navigateToCertificatePrintAction,
+  openRecordByTitle,
   selectRequesterType
 } from './helpers'
 import { selectCertificationType } from './helpers'
@@ -62,14 +63,9 @@ test.describe
       .fill(formatV2ChildName(declaration))
 
     await page.getByRole('button', { name: 'Search' }).click()
-    await page
-      .getByRole('button', {
-        name: formatV2ChildName(declaration),
-        exact: true
-      })
-      .click()
-
+    await openRecordByTitle(page, formatV2ChildName(declaration))
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
+
     await selectAction(page, 'Print')
     await selectCertificationType(page, 'Birth Certificate Certified Copy')
     await selectRequesterType(page, 'Print and issue to Informant (Mother)')

--- a/e2e/testcases/print-certificate/death/helpers.ts
+++ b/e2e/testcases/print-certificate/death/helpers.ts
@@ -2,6 +2,7 @@ import { Page } from '@playwright/test'
 import { Declaration } from '../../test-data/death-declaration'
 import { ensureAssignedToUser, selectAction } from '../../../utils'
 import { CREDENTIALS } from '../../../constants'
+import { openRecordByTitle } from '../birth/helpers'
 
 export async function selectCertificationType(page: Page, type: string) {
   await page.locator('#certificateTemplateId svg').click()
@@ -22,7 +23,7 @@ export async function navigateToCertificatePrintAction(
   username: (typeof CREDENTIALS)[keyof typeof CREDENTIALS]
 ) {
   const deceasedName = `${declaration['deceased.name'].firstname} ${declaration['deceased.name'].surname}`
-  await page.getByRole('button', { name: deceasedName }).click()
+  await openRecordByTitle(page, deceasedName)
 
   await ensureAssignedToUser(page, username)
   await selectAction(page, 'Print')

--- a/e2e/testcases/quick-search/1-quick-search-birth-event-declaration.spec.ts
+++ b/e2e/testcases/quick-search/1-quick-search-birth-event-declaration.spec.ts
@@ -7,6 +7,8 @@ import {
 import { CREDENTIALS } from '../../constants'
 import { faker } from '@faker-js/faker'
 import { ensureAssignedToUser } from '../../utils'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
+import { formatV2ChildName } from '../birth/helpers'
 
 test.describe
   .serial("Quick Search - Birth Event Declaration - Child's details", () => {
@@ -55,11 +57,10 @@ test.describe
   })
 
   test('1.2 Should display informant email correctly in record details', async () => {
-    await page
-      .getByRole('button', {
-        name: getChildNameFromRecord(recordWithDefaultEmail)
-      })
-      .click()
+    await openRecordByTitle(
+      page,
+      getChildNameFromRecord(recordWithDefaultEmail)
+    )
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     await expect(page.getByTestId('assignedTo-value')).toHaveText(
       'Kennedy Mweene'
@@ -113,11 +114,8 @@ test.describe
     const searchResult = await page.locator('#content-name').textContent()
     await expect(searchResult).toMatch(searchResultRegex)
     await expect(page.getByText(getChildNameFromRecord(record))).toBeVisible()
-    await page
-      .getByRole('button', {
-        name: getChildNameFromRecord(record)
-      })
-      .click()
+
+    await openRecordByTitle(page, getChildNameFromRecord(record))
 
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     await expect(page.getByTestId('assignedTo-value')).toHaveText(

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -103,6 +103,9 @@ export async function ensureAssignedToUser(
 
   const assignedTo = page.getByTestId('assignedTo-value').locator('span')
 
+  // Wait for the value to actually render before deciding
+  await assignedTo.first().waitFor({ state: 'visible' })
+
   if (await assignedTo.filter({ hasText: userFullName }).isVisible()) {
     return
   }
@@ -115,17 +118,19 @@ export async function ensureAssignedToUser(
     .first()
 
   await assignAction.waitFor({ state: 'visible' })
-
   await assignAction.click()
-  // Wait for the assign modal to appear
-  await page.getByRole('button', { name: 'Assign', exact: true }).click()
 
-  // Wait for the assignment API call to complete and the UI to update.
-  await page.waitForResponse(
+  // Setup the listener before clicking.
+  const assignResponse = page.waitForResponse(
     (res) =>
       res.url().includes('event.actions.assignment.assign') &&
       res.status() === 200
   )
+  // Wait for the assign modal to appear
+  await page.getByRole('button', { name: 'Assign', exact: true }).click()
+
+  // Wait for the assignment API call to complete and the UI to update.
+  await assignResponse
 
   await expect(
     page.getByTestId('assignedTo-value').locator('span')


### PR DESCRIPTION
## Description
Many of the tests were flaky when selecting event on workqueue.
Because the tests are run in parallel and we are polling constantly, 

```
    await page
      .getByRole('button', { name: formatV2ChildName(declaration) })
      .click()
 ```
 
Will actually pick the correct one, but seemingly keeps the reference based on the position in the workqueue list.  Having no checks for that will cost us 90s of wait time.

Changes:
- Introduce `openRecordByTitle` which will retry instantly if the worst-case happened.
- Make `ensureAssignedToUser` more robust.
## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
