### PR TITLE
Fix flaky test 17

### DIFF
--- a/.github/workflows/deploy-and-e2e.yml
+++ b/.github/workflows/deploy-and-e2e.yml
@@ -136,28 +136,29 @@ jobs:
       max-parallel: 15
       fail-fast: false
       matrix:
+        # Since we are not yet in a place where we can reliably run all tests in parallel, we will run the slowest ones first
         shard:
           [
-            1,
-            2,
+            20,
             3,
-            4,
+            2,
+            1,
+            15,
             5,
-            6,
+            4,
+            16,
+            19,
             7,
+            17,
             8,
             9,
+            12,
+            14,
+            18,
+            6,
             10,
             11,
-            12,
-            13,
-            14,
-            15,
-            16,
-            17,
-            18,
-            19,
-            20
+            13
           ]
     name: shard-${{ matrix.shard }}
     steps:

--- a/e2e/constants.ts
+++ b/e2e/constants.ts
@@ -27,13 +27,6 @@ export const GATEWAY_HOST =
  */
 export const SAFE_INPUT_CHANGE_TIMEOUT_MS = 500
 
-/*
- * This timeout ensures that
- * the declaration in outbox is sent to backend
- * and outbox is now empty
- */
-export const SAFE_OUTBOX_TIMEOUT_MS = 30 * 1000
-
 export const TEST_USER_PASSWORD = 'test'
 
 export const CREDENTIALS = {

--- a/e2e/constants.ts
+++ b/e2e/constants.ts
@@ -33,8 +33,7 @@ export const SAFE_INPUT_CHANGE_TIMEOUT_MS = 500
  * and outbox is now empty
  */
 export const SAFE_OUTBOX_TIMEOUT_MS = 30 * 1000
-export const SAFE_IN_EXTERNAL_VALIDATION_MS = 30 * 1000
-export const SAFE_WORKQUEUE_TIMEOUT_MS = 5 * 1000
+
 export const TEST_USER_PASSWORD = 'test'
 
 export const CREDENTIALS = {

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -413,6 +413,7 @@ const actionTitleToApiCallMap = {
   Notify: ['event.actions.notify'],
   Declare: ['event.actions.declare'],
   Register: ['event.actions.register'],
+  Validate: ['event.actions.custom'],
   'Delete declaration': ['event.delete'],
   'Save & Exit': ['event.draft.create'],
   'Declare with edits': ['event.actions.edit', 'event.actions.declare'],
@@ -429,6 +430,7 @@ export async function selectDeclarationAction(
     | 'Notify'
     | 'Declare'
     | 'Register'
+    | 'Validate'
     | 'Delete declaration'
     | 'Save & Exit'
     | 'Declare with edits'

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -6,7 +6,6 @@ import {
   GATEWAY_HOST,
   LOGIN_URL,
   SAFE_INPUT_CHANGE_TIMEOUT_MS,
-  SAFE_OUTBOX_TIMEOUT_MS,
   TEST_USER_PASSWORD
 } from './constants'
 import { format, parseISO } from 'date-fns'
@@ -364,7 +363,7 @@ export async function expectRowValue(
 ) {
   await expect(page.getByTestId(`row-value-${fieldName}`)).toContainText(
     assertionText,
-    { timeout: SAFE_OUTBOX_TIMEOUT_MS }
+    { timeout: 30_000 }
   )
 }
 

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -15,6 +15,7 @@ import { isMobile } from './mobile-helpers'
 import { createClient } from '@opencrvs/toolkit/api'
 import { UUID } from 'crypto'
 import { faker } from '@faker-js/faker'
+import { openRecordByTitle } from './testcases/print-certificate/birth/helpers'
 
 export async function createPIN(page: Page) {
   await page.click('#pin-input')
@@ -467,8 +468,9 @@ export async function searchFromSearchBar(
   await page.locator('#searchIconButton').click()
   const searchResult = await page.locator('#content-name').textContent()
   expect(searchResult).toMatch(searchResultRegex)
+
   if (expectToBeFound) {
-    await page.getByRole('button', { name: searchText, exact: true }).click()
+    await openRecordByTitle(page, searchText)
   } else {
     await expect(
       page.getByRole('button', { name: searchText, exact: true })

--- a/e2e/testcases/action-menu/action-menu-options.spec.ts
+++ b/e2e/testcases/action-menu/action-menu-options.spec.ts
@@ -143,7 +143,13 @@ test.describe('Action menu options', () => {
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
       await selectAction(page, 'Archive')
-      await page.getByRole('button', { name: 'Archive', exact: true }).click()
+
+      const archiveResponse = page.waitForResponse(
+        (res) => res.url().includes('event.actions.archive') && res.ok()
+      )
+
+      await page.getByRole('button', { name: 'Archive' }).click()
+      await archiveResponse
     })
 
     test('Registrar', async () => {

--- a/e2e/testcases/advanced-search/7-search-birth-event-declaration-stauts.spec.ts
+++ b/e2e/testcases/advanced-search/7-search-birth-event-declaration-stauts.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from '@playwright/test'
 import { joinValuesWith, login } from '../../helpers'
 import { faker } from '@faker-js/faker'
-import { ensureOutboxIsEmpty, expectInUrl, type } from '../../utils'
+import { expectInUrl, type } from '../../utils'
 
 test.describe
   .serial("Advanced Search - Birth Event Declaration - Informant's details", () => {
@@ -35,8 +35,9 @@ test.describe
     ).toBeVisible()
     await page.getByRole('button', { name: 'Save & Exit' }).click()
     await page.getByRole('button', { name: 'Confirm' }).click()
-
-    await ensureOutboxIsEmpty(page)
+    await page.waitForResponse(
+      (res) => res.url().includes('event.draft.create') && res.ok()
+    )
 
     //@todo: The user should be navigated to "my-drafts" tab by default
     await page.getByText('Drafts').click()

--- a/e2e/testcases/advanced-search/7-search-birth-event-declaration-stauts.spec.ts
+++ b/e2e/testcases/advanced-search/7-search-birth-event-declaration-stauts.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, type Page } from '@playwright/test'
-import { joinValuesWith, login } from '../../helpers'
+import { joinValuesWith, login, selectDeclarationAction } from '../../helpers'
 import { faker } from '@faker-js/faker'
 import { expectInUrl, type } from '../../utils'
 
@@ -33,11 +33,13 @@ test.describe
     await expect(
       page.getByRole('button', { name: 'Save & Exit' })
     ).toBeVisible()
-    await page.getByRole('button', { name: 'Save & Exit' }).click()
-    await page.getByRole('button', { name: 'Confirm' }).click()
-    await page.waitForResponse(
+
+    const draftResponse = page.waitForResponse(
       (res) => res.url().includes('event.draft.create') && res.ok()
     )
+    await page.getByRole('button', { name: 'Save & Exit' }).click()
+    await page.getByRole('button', { name: 'Confirm' }).click()
+    await draftResponse
 
     //@todo: The user should be navigated to "my-drafts" tab by default
     await page.getByText('Drafts').click()

--- a/e2e/testcases/application/4a-validate-pending-updates-FA.spec.ts
+++ b/e2e/testcases/application/4a-validate-pending-updates-FA.spec.ts
@@ -6,7 +6,7 @@ import {
   selectDeclarationAction,
   formatName
 } from '../../helpers'
-import { CREDENTIALS, SAFE_WORKQUEUE_TIMEOUT_MS } from '../../constants'
+import { CREDENTIALS } from '../../constants'
 import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { ActionType } from '@opencrvs/toolkit/events'
 import { formatV2ChildName } from '../birth/helpers'
@@ -67,7 +67,7 @@ test.describe.serial('4(a) Validate "Pending updates"-workqueue for HO', () => {
 
   test('4.1 Go to "Pending updates"-workqueue', async () => {
     await login(page, CREDENTIALS.HOSPITAL_OFFICIAL)
-    await page.waitForTimeout(SAFE_WORKQUEUE_TIMEOUT_MS) // wait for the event to be in the workqueue.
+
     await page.getByText('Pending updates').click()
     await expect(
       page.getByRole('button', { name: formattedChildName })

--- a/e2e/testcases/application/4a-validate-pending-updates-FA.spec.ts
+++ b/e2e/testcases/application/4a-validate-pending-updates-FA.spec.ts
@@ -100,7 +100,7 @@ test.describe.serial('4(a) Validate "Pending updates"-workqueue for HO', () => {
   })
 
   test('4.4 Click a name', async () => {
-    await page.getByRole('button', { name: formattedChildName }).click()
+    await openRecordByTitle(page, formattedChildName)
 
     // User should navigate to record audit page
     await expectInUrl(
@@ -138,7 +138,7 @@ test.describe.serial('4(a) Validate "Pending updates"-workqueue for HO', () => {
 
   test('4.6 Assert record does not have "Edit in progress" flag', async () => {
     await navigateToWorkqueue(page, 'Recent')
-    await page.getByRole('button', { name: formattedChildName }).click()
+    await openRecordByTitle(page, formattedChildName)
     await expect(page.getByText('Edit in progress')).not.toBeVisible()
   })
 })

--- a/e2e/testcases/application/4a-validate-pending-updates-FA.spec.ts
+++ b/e2e/testcases/application/4a-validate-pending-updates-FA.spec.ts
@@ -62,7 +62,12 @@ test.describe.serial('4(a) Validate "Pending updates"-workqueue for HO', () => {
 
     await page.getByTestId('reject-reason').fill(faker.lorem.sentence())
 
+    const rejectResponse = page.waitForResponse(
+      (res) => res.url().includes('event.actions.reject.request') && res.ok()
+    )
+
     await page.getByRole('button', { name: 'Send For Update' }).click()
+    await rejectResponse
   })
 
   test('4.1 Go to "Pending updates"-workqueue', async () => {

--- a/e2e/testcases/application/4b-validate-pending-updates-RA.spec.ts
+++ b/e2e/testcases/application/4b-validate-pending-updates-RA.spec.ts
@@ -88,9 +88,7 @@ test.describe.serial('4(b) Validate "Pending updates"-workqueue for RO', () => {
   })
 
   test('4.3 Click a name', async () => {
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
 
     // User should navigate to record audit page
     await expectInUrl(
@@ -121,9 +119,7 @@ test.describe.serial('4(b) Validate "Pending updates"-workqueue for RO', () => {
 
   test('4.6 Assert record has correct flags', async () => {
     await navigateToWorkqueue(page, 'Recent')
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
     await expect(page.getByTestId('flags-value')).toHaveText('Validated')
     await expect(page.getByTestId('flags-value')).not.toHaveText(
       'Edit in progress'

--- a/e2e/testcases/application/4b-validate-pending-updates-RA.spec.ts
+++ b/e2e/testcases/application/4b-validate-pending-updates-RA.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from '@playwright/test'
 
 import { login, getToken, selectDeclarationAction } from '../../helpers'
-import { CREDENTIALS, SAFE_WORKQUEUE_TIMEOUT_MS } from '../../constants'
+import { CREDENTIALS } from '../../constants'
 import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { ActionType } from '@opencrvs/toolkit/events'
 import { formatV2ChildName } from '../birth/helpers'
@@ -55,7 +55,7 @@ test.describe.serial('4(b) Validate "Pending updates"-workqueue for RO', () => {
 
   test('4.1 Go to "Pending updates"-workqueue', async () => {
     await login(page, CREDENTIALS.REGISTRATION_OFFICER)
-    await page.waitForTimeout(SAFE_WORKQUEUE_TIMEOUT_MS) // wait for the event to be in the workqueue.
+
     await page.getByText('Pending updates').click()
     await expect(
       page.getByRole('button', { name: formatV2ChildName(declaration) })

--- a/e2e/testcases/application/5a-validate-pending-validation-RA.spec.ts
+++ b/e2e/testcases/application/5a-validate-pending-validation-RA.spec.ts
@@ -96,12 +96,17 @@ test.describe
   })
 
   test('5.5 Complete validate action', async () => {
+    const validateResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('event.actions.custom') && res.status() === 200
+    )
+
     await page.getByRole('button', { name: 'Confirm' }).click()
+
+    await validateResponse
 
     // Should redirect back to "Pending validation"-workqueue
     await expect(page.locator('#content-name')).toHaveText('Pending validation')
-
-    await ensureOutboxIsEmpty(page)
 
     await expect(
       page.getByRole('button', { name: formatV2ChildName(declaration) })

--- a/e2e/testcases/application/5a-validate-pending-validation-RA.spec.ts
+++ b/e2e/testcases/application/5a-validate-pending-validation-RA.spec.ts
@@ -5,12 +5,7 @@ import { CREDENTIALS, SAFE_WORKQUEUE_TIMEOUT_MS } from '../../constants'
 import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { ActionType } from '@opencrvs/toolkit/events'
 import { formatV2ChildName } from '../birth/helpers'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  expectInUrl,
-  selectAction
-} from '../../utils'
+import { ensureAssignedToUser, expectInUrl, selectAction } from '../../utils'
 import {
   getRowByTitle,
   openRecordByTitle

--- a/e2e/testcases/application/5a-validate-pending-validation-RA.spec.ts
+++ b/e2e/testcases/application/5a-validate-pending-validation-RA.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from '@playwright/test'
 
 import { login, getToken } from '../../helpers'
-import { CREDENTIALS, SAFE_WORKQUEUE_TIMEOUT_MS } from '../../constants'
+import { CREDENTIALS } from '../../constants'
 import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { ActionType } from '@opencrvs/toolkit/events'
 import { formatV2ChildName } from '../birth/helpers'
@@ -35,7 +35,6 @@ test.describe
   })
 
   test('5.1 Go to "Pending validation"-workqueue', async () => {
-    await page.waitForTimeout(SAFE_WORKQUEUE_TIMEOUT_MS) // wait for the event to be in the workqueue.
     await page.getByText('Pending validation').click()
     await expect(
       page.getByRole('button', { name: formatV2ChildName(declaration) })

--- a/e2e/testcases/application/5b-validate-pending-registration-for-registrar.spec.ts
+++ b/e2e/testcases/application/5b-validate-pending-registration-for-registrar.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from '@playwright/test'
 
 import { login, getToken, validateActionMenuButton } from '../../helpers'
-import { CREDENTIALS, SAFE_WORKQUEUE_TIMEOUT_MS } from '../../constants'
+import { CREDENTIALS } from '../../constants'
 import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { ActionType } from '@opencrvs/toolkit/events'
 import { formatV2ChildName } from '../birth/helpers'
@@ -35,7 +35,6 @@ test.describe
   })
 
   test('5.1 Go to "Pending registration"-workqueue', async () => {
-    await page.waitForTimeout(SAFE_WORKQUEUE_TIMEOUT_MS) // wait for the event to be in the workqueue.
     await page.getByText('Pending registration').click()
     await expect(
       page.getByRole('button', { name: formatV2ChildName(declaration) })

--- a/e2e/testcases/application/6-validate-pending-certification.spec.ts
+++ b/e2e/testcases/application/6-validate-pending-certification.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from '@playwright/test'
 
 import { login, getToken } from '../../helpers'
-import { CREDENTIALS, SAFE_WORKQUEUE_TIMEOUT_MS } from '../../constants'
+import { CREDENTIALS } from '../../constants'
 import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { formatV2ChildName } from '../birth/helpers'
 import { ensureAssignedToUser, expectInUrl, selectAction } from '../../utils'
@@ -30,7 +30,6 @@ test.describe.serial('6 Validate "Pending certification"-workqueue', () => {
   })
 
   test('6.1 Go to "Pending certification"-workqueue', async () => {
-    await page.waitForTimeout(SAFE_WORKQUEUE_TIMEOUT_MS) // wait for the event to be in the workqueue.
     await page.getByText('Pending certification').click()
     await expect(
       page.getByRole('button', { name: formatV2ChildName(declaration) })

--- a/e2e/testcases/application/draft-with-partial-name.spec.ts
+++ b/e2e/testcases/application/draft-with-partial-name.spec.ts
@@ -1,9 +1,8 @@
 import { expect, test, type Page } from '@playwright/test'
 
-import { formatName, login } from '../../helpers'
+import { formatName, login, selectDeclarationAction } from '../../helpers'
 import { CREDENTIALS } from '../../constants'
 import { faker } from '@faker-js/faker'
-import { ensureOutboxIsEmpty } from '../../utils'
 
 test.describe.serial('Validate draft with partial name', () => {
   let page: Page
@@ -42,9 +41,7 @@ test.describe.serial('Validate draft with partial name', () => {
 
     await page.locator('#firstname').fill(name1.firstNames)
 
-    await page.getByRole('button', { name: 'Save & Exit' }).click()
-    await page.getByRole('button', { name: 'Confirm' }).click()
-    await ensureOutboxIsEmpty(page)
+    await selectDeclarationAction(page, 'Save & Exit')
   })
 
   test('Create a draft with only lastname', async () => {
@@ -55,9 +52,7 @@ test.describe.serial('Validate draft with partial name', () => {
 
     await page.locator('#surname').fill(name2.familyName)
 
-    await page.getByRole('button', { name: 'Save & Exit' }).click()
-    await page.getByRole('button', { name: 'Confirm' }).click()
-    await ensureOutboxIsEmpty(page)
+    await selectDeclarationAction(page, 'Save & Exit')
   })
 
   test('Records appear in draft', async () => {

--- a/e2e/testcases/application/draft-with-partial-name.spec.ts
+++ b/e2e/testcases/application/draft-with-partial-name.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, type Page } from '@playwright/test'
 
-import { formatName, login, selectDeclarationAction } from '../../helpers'
+import { formatName, login } from '../../helpers'
 import { CREDENTIALS } from '../../constants'
 import { faker } from '@faker-js/faker'
 
@@ -41,7 +41,13 @@ test.describe.serial('Validate draft with partial name', () => {
 
     await page.locator('#firstname').fill(name1.firstNames)
 
-    await selectDeclarationAction(page, 'Save & Exit')
+    const draftResponse = page.waitForResponse(
+      (res) => res.url().includes('event.draft.create') && res.ok()
+    )
+    await page.getByRole('button', { name: 'Save & Exit' }).click()
+    await page.getByRole('button', { name: 'Confirm' }).click()
+
+    await draftResponse
   })
 
   test('Create a draft with only lastname', async () => {
@@ -52,7 +58,13 @@ test.describe.serial('Validate draft with partial name', () => {
 
     await page.locator('#surname').fill(name2.familyName)
 
-    await selectDeclarationAction(page, 'Save & Exit')
+    const draftResponse = page.waitForResponse(
+      (res) => res.url().includes('event.draft.create') && res.ok()
+    )
+    await page.getByRole('button', { name: 'Save & Exit' }).click()
+    await page.getByRole('button', { name: 'Confirm' }).click()
+
+    await draftResponse
   })
 
   test('Records appear in draft', async () => {

--- a/e2e/testcases/application/drafts-workqueue.spec.ts
+++ b/e2e/testcases/application/drafts-workqueue.spec.ts
@@ -4,7 +4,6 @@ import { formatName, login, selectDeclarationAction } from '../../helpers'
 import { CREDENTIALS } from '../../constants'
 import { faker } from '@faker-js/faker'
 import { getRowByTitle } from '../print-certificate/birth/helpers'
-import { ensureOutboxIsEmpty } from '../../utils'
 
 test.describe.serial('1: Validate my draft tab', () => {
   let page: Page
@@ -40,13 +39,10 @@ test.describe.serial('1: Validate my draft tab', () => {
     await page.locator('#firstname').fill(name.firstNames)
     await page.locator('#surname').fill(name.familyName)
 
-    await page.getByRole('button', { name: 'Save & Exit' }).click()
-    await page.getByRole('button', { name: 'Confirm' }).click()
+    await selectDeclarationAction(page, 'Save & Exit')
   })
 
   test('1.3 Record appears in draft', async () => {
-    await ensureOutboxIsEmpty(page)
-
     await page.getByRole('button', { name: 'Drafts' }).click()
 
     await expect(page.getByTestId('search-result')).toContainText(formattedName)

--- a/e2e/testcases/application/drafts-workqueue.spec.ts
+++ b/e2e/testcases/application/drafts-workqueue.spec.ts
@@ -39,7 +39,13 @@ test.describe.serial('1: Validate my draft tab', () => {
     await page.locator('#firstname').fill(name.firstNames)
     await page.locator('#surname').fill(name.familyName)
 
-    await selectDeclarationAction(page, 'Save & Exit')
+    const draftResponse = page.waitForResponse(
+      (res) => res.url().includes('event.draft.create') && res.ok()
+    )
+    await page.getByRole('button', { name: 'Save & Exit' }).click()
+    await page.getByRole('button', { name: 'Confirm' }).click()
+
+    await draftResponse
   })
 
   test('1.3 Record appears in draft', async () => {

--- a/e2e/testcases/application/workqueue-flow-1.spec.ts
+++ b/e2e/testcases/application/workqueue-flow-1.spec.ts
@@ -12,7 +12,10 @@ import {
 import { CREDENTIALS } from '../../constants'
 import { ensureAssignedToUser, selectAction } from '../../utils'
 import { assertRecordInWorkqueue, fillDate } from '../birth/helpers'
-import { getRowByTitle } from '../print-certificate/birth/helpers'
+import {
+  getRowByTitle,
+  openRecordByTitle
+} from '../print-certificate/birth/helpers'
 
 // HO Notifies => RO Validates => Registrar Registers => Registrar Prints
 test.describe.serial('1. Workqueue flow - 1', () => {
@@ -159,11 +162,7 @@ test.describe.serial('1. Workqueue flow - 1', () => {
 
     test('1.2.2 Go to Edit', async () => {
       await page.getByText('Notifications').click()
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-        .click()
+      await openRecordByTitle(page, formatName(declaration.child.name))
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
       await selectAction(page, 'Edit')
@@ -317,11 +316,7 @@ test.describe.serial('1. Workqueue flow - 1', () => {
 
     test('1.4.2 Register', async () => {
       await page.getByText('Pending registration').click()
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-        .click()
+      await openRecordByTitle(page, formatName(declaration.child.name))
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
       await selectAction(page, 'Register')

--- a/e2e/testcases/application/workqueue-flow-2.spec.ts
+++ b/e2e/testcases/application/workqueue-flow-2.spec.ts
@@ -12,6 +12,7 @@ import { CREDENTIALS } from '../../constants'
 import { ensureAssignedToUser, selectAction } from '../../utils'
 import { selectDeclarationAction } from '../../helpers'
 import { assertRecordInWorkqueue, fillDate } from '../birth/helpers'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 // HO Notifies => Registrar Registers
 
@@ -163,11 +164,7 @@ test.describe.serial('2. Workqueue flow - 2', () => {
 
     test('2.2.2 Go to Edit', async () => {
       await page.getByText('Notifications').click()
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-        .click()
+      await openRecordByTitle(page, formatName(declaration.child.name))
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
       await selectAction(page, 'Edit')

--- a/e2e/testcases/application/workqueue-flow-3.spec.ts
+++ b/e2e/testcases/application/workqueue-flow-3.spec.ts
@@ -12,6 +12,7 @@ import {
 import { CREDENTIALS } from '../../constants'
 import { ensureAssignedToUser, selectAction } from '../../utils'
 import { assertRecordInWorkqueue, fillDate } from '../birth/helpers'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 // HO Notifies => RO Rejects => RO Re-declares and validates => Registrar rejects
 // => RO Re-declares again => Registrar registers
@@ -164,11 +165,8 @@ test.describe.serial('3. Workqueue flow - 3', () => {
 
     test('3.2.2 Reject', async () => {
       await page.getByText('Notifications').click()
-      await page
-        .getByRole('button', {
-          name: childName
-        })
-        .click()
+
+      await openRecordByTitle(page, childName)
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
 
@@ -196,11 +194,7 @@ test.describe.serial('3. Workqueue flow - 3', () => {
 
     test('3.2.3 Ensure rejection is no longer available', async () => {
       await page.getByRole('button', { name: 'Recent' }).click()
-      await page
-        .getByRole('button', {
-          name: childName
-        })
-        .click()
+      await openRecordByTitle(page, childName)
 
       await expect(page.getByText('Rejected')).toBeVisible()
 
@@ -224,11 +218,7 @@ test.describe.serial('3. Workqueue flow - 3', () => {
 
   test.describe('3.3 Re-declare and validate by RO', async () => {
     test('3.3.1 Go to edit', async () => {
-      await page
-        .getByRole('button', {
-          name: childName
-        })
-        .click()
+      await openRecordByTitle(page, childName)
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
 
@@ -365,11 +355,7 @@ test.describe.serial('3. Workqueue flow - 3', () => {
     test('3.4.2 Reject', async () => {
       await page.getByText('Pending registration').click()
 
-      await page
-        .getByRole('button', {
-          name: childName
-        })
-        .click()
+      await openRecordByTitle(page, childName)
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
 
@@ -423,12 +409,7 @@ test.describe.serial('3. Workqueue flow - 3', () => {
 
     test('3.5.2 Go to edit', async () => {
       await page.getByText('Pending updates').click()
-      await page
-        .getByRole('button', {
-          name: childName
-        })
-        .click()
-
+      await openRecordByTitle(page, childName)
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
 
       await selectAction(page, 'Edit')
@@ -496,12 +477,7 @@ test.describe.serial('3. Workqueue flow - 3', () => {
     test('3.6.2 Register', async () => {
       await page.getByText('Pending registration').click()
 
-      await page
-        .getByRole('button', {
-          name: childName
-        })
-        .click()
-
+      await openRecordByTitle(page, childName)
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
 
       await selectAction(page, 'Register')

--- a/e2e/testcases/application/workqueue-flow-4.spec.ts
+++ b/e2e/testcases/application/workqueue-flow-4.spec.ts
@@ -12,11 +12,11 @@ import {
 import { CREDENTIALS } from '../../constants'
 import {
   ensureAssignedToUser,
-  ensureInExternalValidationIsEmpty,
   ensureOutboxIsEmpty,
   selectAction
 } from '../../utils'
 import { assertRecordInWorkqueue, fillDate } from '../birth/helpers'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 // HO Declares => RO Validates => Registrar Registers
 test.describe.serial('4. Workqueue flow - 4', () => {
@@ -270,18 +270,15 @@ test.describe.serial('4. Workqueue flow - 4', () => {
 
     test('4.3.2 Validate', async () => {
       await page.getByText('Pending validation').click()
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-        .click()
+
+      await openRecordByTitle(page, formatName(declaration.child.name))
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
+      // @†odo
+      // await selectDeclarationAction(page, 'Validate')
       await selectAction(page, 'Validate')
 
       await page.getByRole('button', { name: 'Confirm' }).click()
-
-      await ensureOutboxIsEmpty(page)
 
       await assertRecordInWorkqueue({
         page,
@@ -343,18 +340,11 @@ test.describe.serial('4. Workqueue flow - 4', () => {
 
     test('4.5.2 Register', async () => {
       await page.getByText('Pending registration').click()
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-        .click()
 
+      await openRecordByTitle(page, formatName(declaration.child.name))
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
-      await selectAction(page, 'Register')
-      await page.getByRole('button', { name: 'Confirm' }).click()
 
-      await ensureOutboxIsEmpty(page)
-      await ensureInExternalValidationIsEmpty(page)
+      await selectDeclarationAction(page, 'Register')
 
       await assertRecordInWorkqueue({
         page,

--- a/e2e/testcases/application/workqueue-flow-4.spec.ts
+++ b/e2e/testcases/application/workqueue-flow-4.spec.ts
@@ -274,11 +274,8 @@ test.describe.serial('4. Workqueue flow - 4', () => {
       await openRecordByTitle(page, formatName(declaration.child.name))
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
-      // @†odo
-      // await selectDeclarationAction(page, 'Validate')
-      await selectAction(page, 'Validate')
 
-      await page.getByRole('button', { name: 'Confirm' }).click()
+      await selectDeclarationAction(page, 'Validate')
 
       await assertRecordInWorkqueue({
         page,

--- a/e2e/testcases/application/workqueue-flow-4.spec.ts
+++ b/e2e/testcases/application/workqueue-flow-4.spec.ts
@@ -10,11 +10,7 @@ import {
   selectDeclarationAction
 } from '../../helpers'
 import { CREDENTIALS } from '../../constants'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  selectAction
-} from '../../utils'
+import { ensureAssignedToUser } from '../../utils'
 import { assertRecordInWorkqueue, fillDate } from '../birth/helpers'
 import { openRecordByTitle } from '../print-certificate/birth/helpers'
 

--- a/e2e/testcases/application/workqueue-flow-5.spec.ts
+++ b/e2e/testcases/application/workqueue-flow-5.spec.ts
@@ -141,8 +141,13 @@ test.describe.serial('5. Workqueue flow - 5', () => {
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
       await selectAction(page, 'Reject')
       await page.getByTestId('reject-reason').fill(faker.lorem.sentence())
+
+      const rejectResponse = page.waitForResponse(
+        (res) => res.url().includes('event.actions.reject') && res.ok()
+      )
       await page.getByRole('button', { name: 'Send For Update' }).click()
-      // @todo
+
+      await rejectResponse
     })
 
     test('5.2.3 Ensure rejection is no longer available', async () => {
@@ -315,11 +320,7 @@ test.describe.serial('5. Workqueue flow - 5', () => {
     test('5.4.2 Reject', async () => {
       await page.getByText('Pending registration').click()
 
-      await page
-        .getByRole('button', {
-          name: childName
-        })
-        .click()
+      await openRecordByTitle(page, childName)
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
 
@@ -327,8 +328,12 @@ test.describe.serial('5. Workqueue flow - 5', () => {
 
       await page.getByTestId('reject-reason').fill(faker.lorem.sentence())
 
+      const rejectResponse = page.waitForResponse(
+        (res) => res.url().includes('event.actions.reject') && res.ok()
+      )
       await page.getByRole('button', { name: 'Send For Update' }).click()
-      // @todo:
+
+      await rejectResponse
 
       await assertRecordInWorkqueue({
         page,

--- a/e2e/testcases/application/workqueue-flow-5.spec.ts
+++ b/e2e/testcases/application/workqueue-flow-5.spec.ts
@@ -12,6 +12,7 @@ import {
 import { CREDENTIALS } from '../../constants'
 import { ensureAssignedToUser, selectAction } from '../../utils'
 import { assertRecordInWorkqueue, fillDate } from '../birth/helpers'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 // HO Notifies => RO Rejects => RO Declares and validates => Registrar rejects
 // => RO Re-declares again => Registrar registers
@@ -134,25 +135,19 @@ test.describe.serial('5. Workqueue flow - 5', () => {
 
     test('5.2.2 Reject', async () => {
       await page.getByText('Notifications').click()
-      await page
-        .getByRole('button', {
-          name: childName
-        })
-        .click()
+
+      await openRecordByTitle(page, childName)
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
       await selectAction(page, 'Reject')
       await page.getByTestId('reject-reason').fill(faker.lorem.sentence())
       await page.getByRole('button', { name: 'Send For Update' }).click()
+      // @todo
     })
 
     test('5.2.3 Ensure rejection is no longer available', async () => {
       await page.getByRole('button', { name: 'Recent' }).click()
-      await page
-        .getByRole('button', {
-          name: childName
-        })
-        .click()
+      await openRecordByTitle(page, childName)
 
       await expect(page.getByText('Rejected')).toBeVisible()
 
@@ -197,12 +192,6 @@ test.describe.serial('5. Workqueue flow - 5', () => {
 
     test('5.3.2 Go to edit', async () => {
       await page.getByText('Pending updates').click()
-
-      await page
-        .getByRole('button', {
-          name: childName
-        })
-        .click()
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
 
@@ -338,6 +327,7 @@ test.describe.serial('5. Workqueue flow - 5', () => {
       await page.getByTestId('reject-reason').fill(faker.lorem.sentence())
 
       await page.getByRole('button', { name: 'Send For Update' }).click()
+      // @todo:
 
       await assertRecordInWorkqueue({
         page,
@@ -384,11 +374,7 @@ test.describe.serial('5. Workqueue flow - 5', () => {
 
     test('5.5.2 Go to edit', async () => {
       await page.getByText('Pending updates').click()
-      await page
-        .getByRole('button', {
-          name: childName
-        })
-        .click()
+      await openRecordByTitle(page, childName)
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
       await selectAction(page, 'Edit')
@@ -456,16 +442,11 @@ test.describe.serial('5. Workqueue flow - 5', () => {
     test('5.6.2 Register', async () => {
       await page.getByText('Pending registration').click()
 
-      await page
-        .getByRole('button', {
-          name: childName
-        })
-        .click()
+      await openRecordByTitle(page, childName)
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
 
-      await selectAction(page, 'Register')
-      await page.getByRole('button', { name: 'Confirm' }).click()
+      await selectDeclarationAction(page, 'Register')
 
       await assertRecordInWorkqueue({
         page,

--- a/e2e/testcases/application/workqueue-flow-5.spec.ts
+++ b/e2e/testcases/application/workqueue-flow-5.spec.ts
@@ -193,6 +193,7 @@ test.describe.serial('5. Workqueue flow - 5', () => {
     test('5.3.2 Go to edit', async () => {
       await page.getByText('Pending updates').click()
 
+      await openRecordByTitle(page, childName)
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
 
       await selectAction(page, 'Edit')

--- a/e2e/testcases/application/workqueue-flow-5.spec.ts
+++ b/e2e/testcases/application/workqueue-flow-5.spec.ts
@@ -145,6 +145,7 @@ test.describe.serial('5. Workqueue flow - 5', () => {
       const rejectResponse = page.waitForResponse(
         (res) => res.url().includes('event.actions.reject') && res.ok()
       )
+
       await page.getByRole('button', { name: 'Send For Update' }).click()
 
       await rejectResponse
@@ -381,6 +382,10 @@ test.describe.serial('5. Workqueue flow - 5', () => {
     test('5.5.2 Go to edit', async () => {
       await page.getByText('Pending updates').click()
       await openRecordByTitle(page, childName)
+
+      await expect(
+        page.getByTestId('status-value').locator('span')
+      ).toContainText('Declared')
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
       await selectAction(page, 'Edit')

--- a/e2e/testcases/archival/basic-archival.spec.ts
+++ b/e2e/testcases/archival/basic-archival.spec.ts
@@ -350,18 +350,15 @@ test.describe.serial('Archival of declaration pending validation', () => {
 
   test('Validate the declaration', async () => {
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
-    // @TODO
-    await selectAction(page, 'Validate')
-    await page.getByRole('button', { name: 'Confirm', exact: true }).click()
+
+    await selectDeclarationAction(page, 'Validate')
   })
 
   test('Confirm the declaration is in "Pending registration" -workqueue', async () => {
     await login(page, CREDENTIALS.REGISTRAR)
 
     await page.getByText('Pending registration').click()
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
 
     await expect(page.getByTestId('status-value')).toHaveText('Declared')
     await expect(page.getByTestId('flags-value')).toHaveText('Validated')

--- a/e2e/testcases/archival/basic-archival.spec.ts
+++ b/e2e/testcases/archival/basic-archival.spec.ts
@@ -20,6 +20,7 @@ import {
 } from '../../utils'
 import { ActionType } from '@opencrvs/toolkit/events'
 import { createDeclaration, Declaration } from '../test-data/birth-declaration'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test.describe.serial('Basic Archival flow', () => {
   let page: Page
@@ -269,11 +270,7 @@ test.describe.serial('Basic Archival flow', () => {
 
   test('Archival is not available for HO', async () => {
     await page.getByText('Recent').click()
-    await page
-      .getByRole('button', {
-        name: formatName(declaration.child.name)
-      })
-      .click()
+    await openRecordByTitle(page, formatName(declaration.child.name))
 
     await page.getByRole('button', { name: 'Action', exact: true }).click()
     await expect(
@@ -300,11 +297,7 @@ test.describe.serial('Basic Archival flow', () => {
       page.getByRole('button', { name: 'Archive', exact: true })
     ).not.toBeVisible()
 
-    await page
-      .getByRole('button', {
-        name: formatName(declaration.child.name)
-      })
-      .click()
+    await openRecordByTitle(page, formatName(declaration.child.name))
   })
 
   test('Archive the declaration', async () => {
@@ -325,11 +318,8 @@ test.describe.serial('Basic Archival flow', () => {
   test('Archived declaration can be found via search', async () => {
     await page.locator('#searchText').fill(formatName(declaration.child.name))
     await page.locator('#searchIconButton').click()
-    await page
-      .getByRole('button', {
-        name: formatName(declaration.child.name)
-      })
-      .click()
+
+    await openRecordByTitle(page, formatName(declaration.child.name))
 
     await expect(page.getByTestId('status-value')).toHaveText('Archived')
   })
@@ -354,18 +344,15 @@ test.describe.serial('Archival of declaration pending validation', () => {
 
   test('Navigate to the event overview page', async () => {
     await page.getByText('Pending validation').click()
-    await page
-      .getByRole('button', {
-        name: formatV2ChildName(declaration)
-      })
-      .click()
+
+    await openRecordByTitle(page, formatV2ChildName(declaration))
   })
 
   test('Validate the declaration', async () => {
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
+    // @TODO
     await selectAction(page, 'Validate')
     await page.getByRole('button', { name: 'Confirm', exact: true }).click()
-    await ensureOutboxIsEmpty(page)
   })
 
   test('Confirm the declaration is in "Pending registration" -workqueue', async () => {
@@ -382,6 +369,8 @@ test.describe.serial('Archival of declaration pending validation', () => {
 
   test('Archive the declaration', async () => {
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
+
+    // @TODO
     await selectAction(page, 'Archive')
     await page.getByRole('button', { name: 'Archive', exact: true }).click()
   })

--- a/e2e/testcases/archival/basic-archival.spec.ts
+++ b/e2e/testcases/archival/basic-archival.spec.ts
@@ -13,11 +13,7 @@ import {
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../constants'
 import { fillDate, formatV2ChildName } from '../birth/helpers'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  selectAction
-} from '../../utils'
+import { ensureAssignedToUser, selectAction } from '../../utils'
 import { ActionType } from '@opencrvs/toolkit/events'
 import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { openRecordByTitle } from '../print-certificate/birth/helpers'

--- a/e2e/testcases/birth/1-birth-event-declaration.spec.ts
+++ b/e2e/testcases/birth/1-birth-event-declaration.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test, type Page } from '@playwright/test'
-import { login } from '../../helpers'
+import { login, selectDeclarationAction } from '../../helpers'
 import path from 'path'
 import { faker } from '@faker-js/faker'
-import { ensureOutboxIsEmpty, expectInUrl, selectAction } from '../../utils'
+import { expectInUrl, selectAction } from '../../utils'
 import { trackAndDeleteCreatedEvents } from '../test-data/eventDeletion'
 
 const child = {
@@ -431,10 +431,7 @@ test.describe.serial('1. Birth event declaration', () => {
       })
 
       test('1.9.3 Click Confirm', async () => {
-        await page.getByRole('button', { name: 'Action' }).click()
-        await page.getByText('Save & Exit', { exact: true }).click()
-
-        await page.getByRole('button', { name: 'Confirm' }).click()
+        await selectDeclarationAction(page, 'Save & Exit')
 
         /*
          * Expected result: should
@@ -445,8 +442,6 @@ test.describe.serial('1. Birth event declaration', () => {
         await page.getByText('Drafts').click()
 
         await expect(page.locator('#content-name')).toHaveText('Drafts')
-
-        await ensureOutboxIsEmpty(page)
 
         await expect(page.getByText(child.name.firstNames)).toBeVisible()
       })

--- a/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
@@ -14,11 +14,7 @@ import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../constants'
 import { fillDate } from './helpers'
 import { selectDeclarationAction } from '../../helpers'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  selectAction
-} from '../../utils'
+import { ensureAssignedToUser, selectAction } from '../../utils'
 import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test.describe.serial('8. Validate declaration review page', () => {
@@ -1123,12 +1119,10 @@ test.describe.serial('8. Validate declaration review page', () => {
     })
 
     test('8.3.1.3 Register', async () => {
-      await selectAction(page, 'Register')
-      await page.getByRole('button', { name: 'Confirm' }).click()
+      await selectDeclarationAction(page, 'Register')
     })
 
     test('8.3.8 Confirm the declaration is in "Pending certification" -workqueue', async () => {
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Pending certification').click()
       await expect(
         page.getByRole('button', {

--- a/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
@@ -870,6 +870,7 @@ test.describe.serial('8. Validate declaration review page', () => {
     })
     test('8.2.2 Validate', async () => {
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
+      // @todo:
       await selectAction(page, 'Validate')
       await page.getByRole('button', { name: 'Confirm' }).click()
     })

--- a/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/birth/8-validate-declaration-review-page.spec.ts
@@ -19,6 +19,7 @@ import {
   ensureOutboxIsEmpty,
   selectAction
 } from '../../utils'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test.describe.serial('8. Validate declaration review page', () => {
   let page: Page
@@ -862,21 +863,15 @@ test.describe.serial('8. Validate declaration review page', () => {
 
       await page.getByText('Pending validation').click()
 
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-        .click()
+      await openRecordByTitle(page, formatName(declaration.child.name))
     })
     test('8.2.2 Validate', async () => {
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
-      // @todo:
-      await selectAction(page, 'Validate')
-      await page.getByRole('button', { name: 'Confirm' }).click()
+
+      await selectDeclarationAction(page, 'Validate')
     })
 
     test('8.2.3 Confirm the declaration is in Recent-workqueue', async () => {
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Recent').click()
 
       await expect(
@@ -893,11 +888,7 @@ test.describe.serial('8. Validate declaration review page', () => {
 
       await page.getByText('Pending registration').click()
 
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-        .click()
+      await openRecordByTitle(page, formatName(declaration.child.name))
     })
 
     test('8.3.1.1 Assert values', async () => {

--- a/e2e/testcases/birth/assign-and-unassign.spec.ts
+++ b/e2e/testcases/birth/assign-and-unassign.spec.ts
@@ -1,9 +1,10 @@
 import { expect, test, type Page } from '@playwright/test'
 
 import { login, getToken } from '../../helpers'
-import { CREDENTIALS, SAFE_WORKQUEUE_TIMEOUT_MS } from '../../constants'
+import { CREDENTIALS } from '../../constants'
 import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { ensureAssignedToUser, selectAction } from '../../utils'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test.describe.serial('Assign & Unassign', () => {
   let page: Page
@@ -17,7 +18,7 @@ test.describe.serial('Assign & Unassign', () => {
   })
 
   test.afterAll(async () => {
-    await page.close()
+    await page?.close()
   })
 
   test('Login', async () => {
@@ -25,11 +26,10 @@ test.describe.serial('Assign & Unassign', () => {
   })
 
   test('Click on "Assign" from action menu', async () => {
-    await page.waitForTimeout(SAFE_WORKQUEUE_TIMEOUT_MS) // wait for the event to be in the workqueue.
     await page.getByText('Pending certification').click()
 
     const childName = `${declaration['child.name'].firstname} ${declaration['child.name'].surname}`
-    await page.getByRole('button', { name: childName }).click()
+    await openRecordByTitle(page, childName)
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
   })
 

--- a/e2e/testcases/birth/declarations/add-mother-details-on-review.spec.ts
+++ b/e2e/testcases/birth/declarations/add-mother-details-on-review.spec.ts
@@ -12,11 +12,7 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  selectAction
-} from '../../../utils'
+import { ensureAssignedToUser, selectAction } from '../../../utils'
 import { REQUIRED_VALIDATION_ERROR } from '../helpers'
 import { selectDeclarationAction } from '../../../helpers'
 import { openRecordByTitle } from '../../print-certificate/birth/helpers'
@@ -308,11 +304,8 @@ test.describe.serial('Add mother details on review', () => {
     })
 
     test('Assert event is registered', async () => {
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Pending certification').click()
-      await page
-        .getByRole('button', { name: formatName(declaration.child.name) })
-        .click()
+      await openRecordByTitle(page, formatName(declaration.child.name))
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR_VILLAGE)
 

--- a/e2e/testcases/birth/declarations/add-mother-details-on-review.spec.ts
+++ b/e2e/testcases/birth/declarations/add-mother-details-on-review.spec.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../utils'
 import { REQUIRED_VALIDATION_ERROR } from '../helpers'
 import { selectDeclarationAction } from '../../../helpers'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('Add mother details on review', () => {
   let page: Page
@@ -225,11 +226,7 @@ test.describe.serial('Add mother details on review', () => {
 
       await page.getByText('Recent').click()
 
-      await expect(
-        page.getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-      ).toBeVisible()
+      await openRecordByTitle(page, formatName(declaration.child.name))
     })
   })
 
@@ -240,11 +237,7 @@ test.describe.serial('Add mother details on review', () => {
 
       await page.getByText('Pending registration').click()
 
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-        .click()
+      await openRecordByTitle(page, formatName(declaration.child.name))
 
       await expect(page.getByTestId('status-value')).toHaveText('Declared')
 

--- a/e2e/testcases/birth/declarations/birth-declaration-1.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-1.spec.ts
@@ -15,6 +15,7 @@ import { CREDENTIALS } from '../../../constants'
 import { fillDate, validateAddress } from '../helpers'
 import { selectDeclarationAction } from '../../../helpers'
 import { ensureAssignedToUser } from '../../../utils'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('1. Birth declaration case - 1', () => {
   let page: Page
@@ -479,6 +480,7 @@ test.describe.serial('1. Birth declaration case - 1', () => {
       await selectDeclarationAction(page, 'Declare')
 
       await page.getByText('Recent').click()
+
       await expect(
         page.getByRole('button', {
           name: formatName(declaration.child.name)
@@ -491,11 +493,8 @@ test.describe.serial('1. Birth declaration case - 1', () => {
     test('1.2.1 Navigate to the declaration review page', async () => {
       await login(page, CREDENTIALS.REGISTRATION_OFFICER)
       await page.getByText('Pending validation').click()
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-        .click()
+
+      await openRecordByTitle(page, formatName(declaration.child.name))
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
 

--- a/e2e/testcases/birth/declarations/birth-declaration-10.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-10.spec.ts
@@ -11,6 +11,7 @@ import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
 import { REQUIRED_VALIDATION_ERROR } from '../helpers'
 import { selectDeclarationAction } from '../../../helpers'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('10. Birth declaration case - 10', () => {
   let page: Page
@@ -195,13 +196,8 @@ test.describe.serial('10. Birth declaration case - 10', () => {
 
       await page.getByText('Notifications').click()
 
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name),
-          exact: true
-        })
-        .click()
-      await page.getByRole('button', { name: 'Action', exact: true }).click()
+      await openRecordByTitle(page, formatName(declaration.child.name))
+
       await switchEventTab(page, 'Record')
     })
 

--- a/e2e/testcases/birth/declarations/birth-declaration-2.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-2.spec.ts
@@ -15,6 +15,7 @@ import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
 import { validateAddress } from '../helpers'
 import { selectDeclarationAction } from '../../../helpers'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('2. Birth declaration case - 2', () => {
   let page: Page
@@ -533,11 +534,8 @@ test.describe.serial('2. Birth declaration case - 2', () => {
     test('2.2.1 Navigate to the declaration "Record" -tab', async () => {
       await login(page, CREDENTIALS.REGISTRATION_OFFICER)
       await page.getByText('Pending validation').click()
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-        .click()
+
+      await openRecordByTitle(page, formatName(declaration.child.name))
 
       await switchEventTab(page, 'Record')
     })

--- a/e2e/testcases/birth/declarations/birth-declaration-3.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-3.spec.ts
@@ -16,6 +16,7 @@ import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
 import { fillDate, validateAddress } from '../helpers'
 import { selectDeclarationAction } from '../../../helpers'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('3. Birth declaration case - 3', () => {
   let page: Page
@@ -748,11 +749,7 @@ test.describe.serial('3. Birth declaration case - 3', () => {
     test('3.2.1 Navigate to the declaration "Record" -tab', async () => {
       await page.getByText('Pending registration').click()
 
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-        .click()
+      await openRecordByTitle(page, formatName(declaration.child.name))
 
       await switchEventTab(page, 'Record')
 

--- a/e2e/testcases/birth/declarations/birth-declaration-4.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-4.spec.ts
@@ -14,6 +14,7 @@ import {
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
 import { fillDate, validateAddress } from '../helpers'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('4. Birth declaration case - 4', () => {
   let page: Page
@@ -652,11 +653,7 @@ test.describe.serial('4. Birth declaration case - 4', () => {
 
       await page.getByText('Pending registration').click()
 
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-        .click()
+      await openRecordByTitle(page, formatName(declaration.child.name))
 
       await switchEventTab(page, 'Record')
     })

--- a/e2e/testcases/birth/declarations/birth-declaration-7.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-7.spec.ts
@@ -15,6 +15,7 @@ import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
 import { REQUIRED_VALIDATION_ERROR } from '../helpers'
 import { ensureAssignedToUser } from '../../../utils'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('7. Birth declaration case - 7', () => {
   let page: Page
@@ -248,11 +249,8 @@ test.describe.serial('7. Birth declaration case - 7', () => {
 
       await page.getByText('Notifications').click()
 
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-        .click()
+      await openRecordByTitle(page, formatName(declaration.child.name))
+
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
       await switchEventTab(page, 'Record')
     })

--- a/e2e/testcases/birth/declarations/birth-declaration-8.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-8.spec.ts
@@ -13,6 +13,7 @@ import { CREDENTIALS } from '../../../constants'
 import { faker } from '@faker-js/faker'
 import { REQUIRED_VALIDATION_ERROR } from '../helpers'
 import { ensureAssignedToUser } from '../../../utils'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('8. Birth declaration case - 8', () => {
   let page: Page
@@ -278,11 +279,7 @@ test.describe.serial('8. Birth declaration case - 8', () => {
 
       await page.getByText('Notifications').click()
 
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-        .click()
+      await openRecordByTitle(page, formatName(declaration.child.name))
 
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
       await switchEventTab(page, 'Record')

--- a/e2e/testcases/birth/declarations/birth-declaration-9.spec.ts
+++ b/e2e/testcases/birth/declarations/birth-declaration-9.spec.ts
@@ -12,6 +12,7 @@ import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
 import { REQUIRED_VALIDATION_ERROR } from '../helpers'
 import { ensureAssignedToUser } from '../../../utils'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('9. Birth declaration case - 9', () => {
   let page: Page
@@ -197,11 +198,7 @@ test.describe.serial('9. Birth declaration case - 9', () => {
 
       await page.getByText('Notifications').click()
 
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-        .click()
+      await openRecordByTitle(page, formatName(declaration.child.name))
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
       await switchEventTab(page, 'Record')
     })

--- a/e2e/testcases/birth/declarations/change-informant-on-review.spec.ts
+++ b/e2e/testcases/birth/declarations/change-informant-on-review.spec.ts
@@ -15,6 +15,7 @@ import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
 import { ensureAssignedToUser, selectAction } from '../../../utils'
 import { REQUIRED_VALIDATION_ERROR } from '../helpers'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('Change informant on review', () => {
   let page: Page
@@ -260,11 +261,7 @@ test.describe.serial('Change informant on review', () => {
 
       await page.getByText('Pending registration').click()
 
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name)
-        })
-        .click()
+      await openRecordByTitle(page, formatName(declaration.child.name))
 
       await expect(page.getByTestId('status-value')).toHaveText('Declared')
 
@@ -333,9 +330,7 @@ test.describe.serial('Change informant on review', () => {
 
     test('Assert event is registered', async () => {
       await page.getByText('Pending certification').click()
-      await page
-        .getByRole('button', { name: formatName(declaration.child.name) })
-        .click()
+      await openRecordByTitle(page, formatName(declaration.child.name))
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR_VILLAGE)
       await expect(page.getByTestId('status-value')).toHaveText('Registered')
     })

--- a/e2e/testcases/birth/declarations/community-leader-notifies-birth.spec.ts
+++ b/e2e/testcases/birth/declarations/community-leader-notifies-birth.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test('Community leader notifies birth', async ({ page }) => {
   const childName = {
@@ -59,11 +60,7 @@ test('Community leader notifies birth', async ({ page }) => {
   await test.step('Open record', async () => {
     await page.getByText('Recent').click()
 
-    await page
-      .getByRole('button', {
-        name: formatName(childName)
-      })
-      .click()
+    await openRecordByTitle(page, formatName(childName))
   })
 
   await test.step('Assert that record is notified', async () => {

--- a/e2e/testcases/birth/declarations/notify-after-deleting-signature-from-draft.spec.ts
+++ b/e2e/testcases/birth/declarations/notify-after-deleting-signature-from-draft.spec.ts
@@ -115,7 +115,7 @@ test('Community leader notifies a birth after deleting a previously persisted si
 
   await test.step('Open the notification and start the Declare flow', async () => {
     await page.getByText('Notifications').click()
-    await page.getByRole('button', { name: formattedChildName }).click()
+    await openRecordByTitle(page, formattedChildName)
 
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
     await selectAction(page, 'Edit')

--- a/e2e/testcases/birth/declarations/notify-after-deleting-signature-from-draft.spec.ts
+++ b/e2e/testcases/birth/declarations/notify-after-deleting-signature-from-draft.spec.ts
@@ -10,7 +10,10 @@ import {
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
 import { ensureAssignedToUser, selectAction } from '../../../utils'
-import { getRowByTitle } from '../../print-certificate/birth/helpers'
+import {
+  getRowByTitle,
+  openRecordByTitle
+} from '../../print-certificate/birth/helpers'
 
 /**
  * Regression test for https://github.com/opencrvs/opencrvs-core/issues/12803
@@ -95,11 +98,7 @@ test('Community leader notifies a birth after deleting a previously persisted si
   await test.step('Open record', async () => {
     await page.getByText('Recent').click()
 
-    await page
-      .getByRole('button', {
-        name: formattedChildName
-      })
-      .click()
+    await openRecordByTitle(page, formattedChildName)
   })
 
   await test.step('Assert that record is notified', async () => {

--- a/e2e/testcases/birth/declarations/submit-incomplete.spec.ts
+++ b/e2e/testcases/birth/declarations/submit-incomplete.spec.ts
@@ -8,6 +8,7 @@ import {
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
 import { ensureOutboxIsEmpty } from '../../../utils'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('Submit and verify incomplete birth declaration', () => {
   let page: Page
@@ -56,15 +57,9 @@ test.describe.serial('Submit and verify incomplete birth declaration', () => {
     })
 
     test('Verify summary page', async () => {
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Recent').click()
 
-      await page
-        .getByRole('button', {
-          name: formatName(declaration.child.name),
-          exact: true
-        })
-        .click()
+      await openRecordByTitle(page, formatName(declaration.child.name))
 
       await expect(page.getByText('Notified', { exact: true })).toBeVisible()
       await expect(page.locator('#content-name')).toContainText(

--- a/e2e/testcases/birth/declarations/submit-incomplete.spec.ts
+++ b/e2e/testcases/birth/declarations/submit-incomplete.spec.ts
@@ -7,7 +7,6 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import { ensureOutboxIsEmpty } from '../../../utils'
 import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('Submit and verify incomplete birth declaration', () => {

--- a/e2e/testcases/birth/helpers.ts
+++ b/e2e/testcases/birth/helpers.ts
@@ -2,8 +2,6 @@ import { expect, type Page } from '@playwright/test'
 import { omit } from 'lodash'
 import { formatName, joinValuesWith } from '../../helpers'
 import { faker } from '@faker-js/faker'
-
-import { SAFE_OUTBOX_TIMEOUT_MS } from '../../constants'
 import { GATEWAY_HOST } from '../../constants'
 import { createClient } from '@opencrvs/toolkit/api'
 
@@ -91,7 +89,7 @@ export async function assertRecordInWorkqueue({
       await expect(async () => {
         await openWorkqueue(title)
         await expect(record).toBeVisible({ timeout: 1_500 })
-      }).toPass({ timeout: SAFE_OUTBOX_TIMEOUT_MS })
+      }).toPass({ timeout: 30_000 })
       settled = true
       continue
     }

--- a/e2e/testcases/birth/save-and-delete-drafts.spec.ts
+++ b/e2e/testcases/birth/save-and-delete-drafts.spec.ts
@@ -3,7 +3,7 @@ import { goToSection, login, logout } from '../../helpers'
 import { CREDENTIALS } from '../../constants'
 import { fillChildDetails, openBirthDeclaration } from './helpers'
 import { selectDeclarationAction } from '../../helpers'
-import { ensureOutboxIsEmpty, selectAction } from '../../utils'
+import { selectAction } from '../../utils'
 import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 /**
@@ -82,7 +82,10 @@ test.describe('Save and delete drafts', () => {
       const childName = await fillChildDetails(page)
       await goToSection(page, 'review')
       await page.getByTestId('exit-button').click()
-      // @todo:
+
+      const draftResponse = page.waitForResponse(
+        (res) => res.url().includes('event.draft.create') && res.ok()
+      )
 
       await expect(
         page.getByText(
@@ -92,7 +95,8 @@ test.describe('Save and delete drafts', () => {
 
       await page.getByRole('button', { name: 'Confirm', exact: true }).click()
 
-      await ensureOutboxIsEmpty(page)
+      await draftResponse
+
       await page.getByRole('button', { name: 'Assigned to you' }).click()
 
       await expect(

--- a/e2e/testcases/birth/save-and-delete-drafts.spec.ts
+++ b/e2e/testcases/birth/save-and-delete-drafts.spec.ts
@@ -21,7 +21,6 @@ test.describe('Save and delete drafts', () => {
     })
 
     test('Save draft via Save & Exit', async () => {
-      // @todo:
       childName = await fillChildDetails(page)
       await page.getByRole('button', { name: 'Save & Exit' }).click()
       await expect(
@@ -83,10 +82,6 @@ test.describe('Save and delete drafts', () => {
       await goToSection(page, 'review')
       await page.getByTestId('exit-button').click()
 
-      const draftResponse = page.waitForResponse(
-        (res) => res.url().includes('event.draft.create') && res.ok()
-      )
-
       await expect(
         page.getByText(
           'You have unsaved changes on your declaration form. Are you sure you want to exit without saving?'
@@ -94,8 +89,6 @@ test.describe('Save and delete drafts', () => {
       ).toBeVisible()
 
       await page.getByRole('button', { name: 'Confirm', exact: true }).click()
-
-      await draftResponse
 
       await page.getByRole('button', { name: 'Assigned to you' }).click()
 

--- a/e2e/testcases/birth/save-and-delete-drafts.spec.ts
+++ b/e2e/testcases/birth/save-and-delete-drafts.spec.ts
@@ -20,6 +20,7 @@ test.describe('Save and delete drafts', () => {
     })
 
     test('Save draft via Save & Exit', async () => {
+      // @todo:
       childName = await fillChildDetails(page)
       await page.getByRole('button', { name: 'Save & Exit' }).click()
       await expect(
@@ -76,6 +77,7 @@ test.describe('Save and delete drafts', () => {
       const childName = await fillChildDetails(page)
       await goToSection(page, 'review')
       await page.getByTestId('exit-button').click()
+      // @todo:
 
       await expect(
         page.getByText(

--- a/e2e/testcases/birth/save-and-delete-drafts.spec.ts
+++ b/e2e/testcases/birth/save-and-delete-drafts.spec.ts
@@ -4,6 +4,7 @@ import { CREDENTIALS } from '../../constants'
 import { fillChildDetails, openBirthDeclaration } from './helpers'
 import { selectDeclarationAction } from '../../helpers'
 import { ensureOutboxIsEmpty, selectAction } from '../../utils'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 /**
  * Skipping tests until the outbox workqueue is implemented.
@@ -29,12 +30,15 @@ test.describe('Save and delete drafts', () => {
         )
       ).toBeVisible()
 
+      const draftResponse = page.waitForResponse(
+        (res) => res.url().includes('event.draft.create') && res.ok()
+      )
       await page.getByRole('button', { name: 'Confirm' }).click()
+      await draftResponse
 
-      await ensureOutboxIsEmpty(page)
       await page.getByRole('button', { name: 'Drafts' }).click()
+      await openRecordByTitle(page, childName)
 
-      await page.getByRole('button', { name: childName, exact: true }).click()
       await expect(page.locator('#content-name')).toHaveText(childName)
     })
 
@@ -56,7 +60,8 @@ test.describe('Save and delete drafts', () => {
 
     test('Delete saved draft', async () => {
       await page.getByRole('button', { name: 'Drafts' }).click()
-      await page.getByRole('button', { name: childName, exact: true }).click()
+      await openRecordByTitle(page, childName)
+
       await selectAction(page, 'Update')
       await selectDeclarationAction(page, 'Delete declaration', true)
 

--- a/e2e/testcases/correction-birth/birth-correction-flow.mobile.spec.ts
+++ b/e2e/testcases/correction-birth/birth-correction-flow.mobile.spec.ts
@@ -8,7 +8,6 @@ import {
 } from '../test-data/birth-declaration-with-mother-father'
 import {
   ensureAssignedToUser,
-  ensureOutboxIsEmpty,
   expectInUrl,
   navigateToWorkqueue,
   selectAction,
@@ -130,10 +129,16 @@ test.describe.serial('Birth correction flow - Mobile', () => {
       .getByRole('button', { name: 'Submit correction request' })
       .click()
 
+    const correctionResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('event.actions.correction.request') && res.ok()
+    )
+
     await expect(page.getByText('Request record correction?')).toBeVisible()
     await page.getByRole('button', { name: 'Confirm', exact: true }).click()
+
+    await correctionResponse
     await expectInUrl(page, `/workqueue/pending-certification`)
-    await ensureOutboxIsEmpty(page)
   })
 
   test('Logout', async () => {
@@ -148,9 +153,7 @@ test.describe.serial('Birth correction flow - Mobile', () => {
     test("Find the event in the 'Pending corrections' workflow", async () => {
       await navigateToWorkqueue(page, 'Pending corrections')
 
-      await page
-        .getByRole('button', { name: formatV2ChildName(declaration) })
-        .click()
+      await openRecordByTitle(page, formatV2ChildName(declaration))
     })
 
     test('Navigate to correction review', async () => {
@@ -204,35 +207,20 @@ test.describe.serial('Birth correction flow - Mobile', () => {
     })
 
     test('Approve correction request', async () => {
+      const correctionResponse = page.waitForResponse(
+        (res) =>
+          res.url().includes('event.actions.correction.approve') && res.ok()
+      )
+
       await page.getByRole('button', { name: 'Approve', exact: true }).click()
       await page.getByRole('button', { name: 'Confirm', exact: true }).click()
+      await correctionResponse
 
       await expectInUrl(page, `/workqueue/correction-requested`)
-      await ensureOutboxIsEmpty(page)
-      await navigateToWorkqueue(page, 'Pending certification')
-      await page
-        .getByRole('button', {
-          name: formatV2ChildName({
-            'child.name': {
-              firstname: newFirstName,
-              surname: declaration['child.name'].surname
-            }
-          })
-        })
-        .click()
 
-      await expect(
-        page.getByRole('heading', {
-          name: formatV2ChildName({
-            'child.name': {
-              firstname: newFirstName,
-              surname: declaration['child.name'].surname
-            }
-          })
-        })
-      ).toBeVisible({
-        timeout: 60_000
-      })
+      await navigateToWorkqueue(page, 'Pending certification')
+
+      await openRecordByTitle(page, formatV2ChildName(declaration))
     })
   })
 })

--- a/e2e/testcases/correction-birth/birth-correction-flow.mobile.spec.ts
+++ b/e2e/testcases/correction-birth/birth-correction-flow.mobile.spec.ts
@@ -16,6 +16,7 @@ import {
 } from '../../utils'
 import { formatV2ChildName } from '../birth/helpers'
 import { setMobileViewport } from '../../mobile-helpers'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test.describe.serial('Birth correction flow - Mobile', () => {
   let declaration: Declaration
@@ -43,9 +44,7 @@ test.describe.serial('Birth correction flow - Mobile', () => {
 
   test('Navigate to the correction form', async () => {
     await navigateToWorkqueue(page, 'Pending certification')
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
 
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
     await selectAction(page, 'Correct')

--- a/e2e/testcases/correction-birth/birth-correction-flow.mobile.spec.ts
+++ b/e2e/testcases/correction-birth/birth-correction-flow.mobile.spec.ts
@@ -220,7 +220,15 @@ test.describe.serial('Birth correction flow - Mobile', () => {
 
       await navigateToWorkqueue(page, 'Pending certification')
 
-      await openRecordByTitle(page, formatV2ChildName(declaration))
+      await openRecordByTitle(
+        page,
+        formatV2ChildName({
+          'child.name': {
+            firstname: newFirstName,
+            surname: declaration['child.name'].surname
+          }
+        })
+      )
     })
   })
 })

--- a/e2e/testcases/correction-birth/birth-correction-flow.spec.ts
+++ b/e2e/testcases/correction-birth/birth-correction-flow.spec.ts
@@ -8,7 +8,6 @@ import {
 } from '../test-data/birth-declaration-with-mother-father'
 import {
   ensureAssignedToUser,
-  ensureOutboxIsEmpty,
   expectInUrl,
   selectAction,
   type
@@ -223,11 +222,17 @@ test.describe.serial('Birth correction flow', () => {
       .getByRole('button', { name: 'Submit correction request' })
       .click()
 
+    const correctionResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('event.actions.correction.request') && res.ok()
+    )
+
     await expect(page.getByText('Request record correction?')).toBeVisible()
 
     await page.getByRole('button', { name: 'Confirm', exact: true }).click()
+
+    await correctionResponse
     await expectInUrl(page, `/workqueue/pending-certification`)
-    await ensureOutboxIsEmpty(page)
   })
 
   test("Event appears in 'Recent' workqueue", async () => {
@@ -247,9 +252,7 @@ test.describe.serial('Birth correction flow', () => {
     test("Find the event in the 'Pending corrections' workflow", async () => {
       await page.getByRole('button', { name: 'Pending corrections' }).click()
 
-      await page
-        .getByRole('button', { name: formatV2ChildName(declaration) })
-        .click()
+      await openRecordByTitle(page, formatV2ChildName(declaration))
     })
 
     test('Correction request action appears in audit history', async () => {
@@ -298,32 +301,25 @@ test.describe.serial('Birth correction flow', () => {
     })
 
     test('Approve correction request', async () => {
+      const correctionResponse = page.waitForResponse(
+        (res) =>
+          res.url().includes('event.actions.correction.approve') && res.ok()
+      )
+
       await page.getByRole('button', { name: 'Approve', exact: true }).click()
       await page.getByRole('button', { name: 'Confirm', exact: true }).click()
 
+      await correctionResponse
       await expectInUrl(page, `/workqueue/correction-requested`)
-      await ensureOutboxIsEmpty(page)
-      await page.getByRole('button', { name: 'Pending certification' }).click()
-      await page
-        .getByRole('button', {
-          name: formatV2ChildName({
-            'child.name': {
-              firstname: newFirstName,
-              surname: declaration['child.name'].surname
-            }
-          })
-        })
-        .click()
 
-      await expect(page.locator('#content-name')).toHaveText(
-        formatV2ChildName({
-          'child.name': {
-            firstname: newFirstName,
-            surname: declaration['child.name'].surname
-          }
-        }),
-        { timeout: 60_000 }
-      )
+      await page.getByRole('button', { name: 'Pending certification' }).click()
+      const childName = formatV2ChildName({
+        'child.name': {
+          firstname: newFirstName,
+          surname: declaration['child.name'].surname
+        }
+      })
+      await openRecordByTitle(page, childName)
     })
 
     test('Correction approved action appears in audit history', async () => {

--- a/e2e/testcases/correction-birth/birth-correction-flow.spec.ts
+++ b/e2e/testcases/correction-birth/birth-correction-flow.spec.ts
@@ -14,6 +14,7 @@ import {
   type
 } from '../../utils'
 import { formatV2ChildName, REQUIRED_VALIDATION_ERROR } from '../birth/helpers'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test.describe.serial('Birth correction flow', () => {
   let declaration: Declaration
@@ -37,9 +38,7 @@ test.describe.serial('Birth correction flow', () => {
 
   test('Navigate to the correction form', async () => {
     await page.getByRole('button', { name: 'Pending certification' }).click()
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
     await selectAction(page, 'Correct')
   })

--- a/e2e/testcases/correction-birth/birth-make-correction-flow.spec.ts
+++ b/e2e/testcases/correction-birth/birth-make-correction-flow.spec.ts
@@ -8,6 +8,7 @@ import {
 } from '../test-data/birth-declaration-with-mother-father'
 import { ensureAssignedToUser, expectInUrl, selectAction } from '../../utils'
 import { formatV2ChildName, REQUIRED_VALIDATION_ERROR } from '../birth/helpers'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test.describe.serial('Birth Record correction flow', () => {
   let declaration: Declaration
@@ -31,9 +32,7 @@ test.describe.serial('Birth Record correction flow', () => {
 
   test('Navigate to the correction form', async () => {
     await page.getByRole('button', { name: 'Pending certification' }).click()
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     await selectAction(page, 'Correct')
   })
@@ -225,9 +224,7 @@ test.describe.serial('Birth Record correction flow', () => {
   })
 
   test('Assign', async () => {
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
 
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
   })

--- a/e2e/testcases/correction-birth/birth-make-correction-flow.spec.ts
+++ b/e2e/testcases/correction-birth/birth-make-correction-flow.spec.ts
@@ -212,15 +212,18 @@ test.describe.serial('Birth Record correction flow', () => {
 
     await expect(page.getByText('Correct record?')).toBeVisible()
 
+    const correctionResponse = page.waitForResponse(
+      (response) =>
+        response
+          .url()
+          .includes('/api/events/event.actions.correction.approve.request') &&
+        response.ok()
+    )
+
     await page.getByRole('button', { name: 'Confirm', exact: true }).click()
 
+    await correctionResponse
     await expectInUrl(page, `/workqueue/pending-certification`)
-
-    await page.waitForResponse((response) =>
-      response
-        .url()
-        .includes('/api/events/event.actions.correction.approve.request')
-    )
   })
 
   test('Assign', async () => {

--- a/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
@@ -24,6 +24,7 @@ import {
   type
 } from '../../utils'
 import { formatV2ChildName } from '../birth/helpers'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test('1. Correct record', async ({ page }) => {
   const updatedChildDetails = {
@@ -63,10 +64,7 @@ test('1. Correct record', async ({ page }) => {
   await test.step('Login as Registration Officer and open the record', async () => {
     await login(page, CREDENTIALS.REGISTRATION_OFFICER)
     await page.getByRole('button', { name: 'Pending certification' }).click()
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
-
+    await openRecordByTitle(page, formatV2ChildName(declaration))
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
   })
 
@@ -493,9 +491,7 @@ test('1. Correct record', async ({ page }) => {
 
     await type(page, '#searchText', trackingId)
     await page.locator('#searchIconButton').click()
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
   })
 
   await test.step('1.2.6.2 Correction review', async () => {

--- a/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
@@ -6,7 +6,6 @@ import {
   getToken,
   goBackToReview,
   login,
-  logout,
   searchFromSearchBar,
   uploadImage
 } from '../../helpers'
@@ -17,12 +16,7 @@ import {
   createDeclaration,
   Declaration
 } from '../test-data/birth-declaration-with-mother-father'
-import {
-  ensureAssignedToUser,
-  expectInUrl,
-  selectAction,
-  type
-} from '../../utils'
+import { ensureAssignedToUser, expectInUrl, selectAction } from '../../utils'
 import { formatV2ChildName } from '../birth/helpers'
 import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
@@ -525,17 +519,19 @@ test('1. Correct record', async ({ page }) => {
         res.url().includes('event.actions.correction.approve') && res.ok()
     )
 
+    const searchCacheRefetchResponse = page.waitForResponse(
+      (res) => res.url().includes(`event.search?batch=1`) && res.ok()
+    )
+
     await page.getByRole('button', { name: 'Confirm', exact: true }).click()
     await correctionResponse
+    await searchCacheRefetchResponse
 
     await expectInUrl(page, `/events/${eventId}`)
   })
 
-  // Skipped due to flakiness - needs investigation.
-  // Issue is with the overview not reflecting unassigned state after the approve action.
-
   // 1.2.6.4 Validate history in record audit.
-  test.skip('1.2.6.4.1 Validate correction requested modal', async () => {
+  await test.step('1.2.6.4.1 Validate correction requested modal', async () => {
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     await page.getByRole('button', { name: 'Audit' }).click()
 
@@ -571,7 +567,7 @@ test('1. Correct record', async ({ page }) => {
     await page.locator('#close-btn').click()
   })
 
-  test.skip('1.2.6.4.2 Validate correction approved modal', async () => {
+  await test.step('1.2.6.4.2 Validate correction approved modal', async () => {
     await page.getByRole('button', { name: 'Next page' }).click()
     await page
       .getByRole('button', { name: 'Correction approved', exact: true })

--- a/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
@@ -7,6 +7,7 @@ import {
   goBackToReview,
   login,
   logout,
+  searchFromSearchBar,
   uploadImage
 } from '../../helpers'
 import { faker } from '@faker-js/faker'
@@ -481,13 +482,11 @@ test('1. Correct record', async ({ page }) => {
       throw new Error('Tracking ID is required')
     }
 
-    await type(page, '#searchText', trackingId)
-    await page.locator('#searchIconButton').click()
-    await openRecordByTitle(page, formatV2ChildName(declaration))
+    await searchFromSearchBar(page, formatV2ChildName(declaration))
+    await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
   })
 
   await test.step('1.2.6.2 Correction review', async () => {
-    await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     await selectAction(page, 'Review correction request')
 
     await expect(
@@ -527,15 +526,16 @@ test('1. Correct record', async ({ page }) => {
     )
 
     await page.getByRole('button', { name: 'Confirm', exact: true }).click()
-
     await correctionResponse
 
     await expectInUrl(page, `/events/${eventId}`)
 
-    // Wait until the actions have finished, which unassigns user
-    await expect(
-      page.getByRole('button', { name: 'Assign record' })
-    ).toBeVisible()
+    // Wait for the correction approval to fully complete before checking
+    // assignment. The approval triggers an auto-unassign — if we call
+    // ensureAssignedToUser before that unassign lands, we may skip
+    // re-assigning (record appears still assigned), then the unassign
+    // fires late and leaves the record unassigned for the audit steps.
+    await page.waitForTimeout(3000)
   })
 
   // 1.2.6.4 Validate history in record audit.

--- a/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
@@ -18,7 +18,6 @@ import {
 } from '../test-data/birth-declaration-with-mother-father'
 import {
   ensureAssignedToUser,
-  ensureOutboxIsEmpty,
   expectInUrl,
   selectAction,
   type
@@ -464,15 +463,21 @@ test('1. Correct record', async ({ page }) => {
       page.locator('#listTable-corrections-table-child')
     ).toContainText(`Weight at birth-${updatedChildDetails.weightAtBirth}`)
 
+    const correctionResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('event.actions.correction.request') && res.ok()
+    )
+
     await page
       .getByRole('button', { name: 'Submit correction request' })
       .click()
     await page.getByRole('button', { name: 'Confirm' }).click()
+    await correctionResponse
 
     await expectInUrl(page, `/workqueue/pending-certification`)
 
     await page.getByText('Recent').click()
-    await ensureOutboxIsEmpty(page)
+
     await expect(
       page.getByRole('button', { name: formatV2ChildName(declaration) })
     ).toBeVisible()

--- a/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
@@ -530,12 +530,8 @@ test('1. Correct record', async ({ page }) => {
 
     await expectInUrl(page, `/events/${eventId}`)
 
-    // Wait for the correction approval to fully complete before checking
-    // assignment. The approval triggers an auto-unassign — if we call
-    // ensureAssignedToUser before that unassign lands, we may skip
-    // re-assigning (record appears still assigned), then the unassign
-    // fires late and leaves the record unassigned for the audit steps.
-    await page.waitForTimeout(3000)
+    // force reload to ensure we are seeing the latest data after approval.
+    await page.reload()
   })
 
   // 1.2.6.4 Validate history in record audit.

--- a/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
@@ -69,14 +69,6 @@ test('1. Correct record', async ({ page }) => {
 
   // 1.1 Validate verbiage on the request-correction onboarding pages.
   await test.step('1.1.1 Validate record audit page', async () => {
-    await expect(page.locator('#content-name')).toHaveText(
-      formatV2ChildName(declaration),
-      { timeout: 60_000 }
-    )
-    await expect(
-      page.getByRole('button', { name: 'Action' }).first()
-    ).toBeVisible()
-
     await expectInUrl(page, `/events/${eventId}`)
 
     await expect(page.getByText(`StatusRegistered`)).toBeVisible()
@@ -463,29 +455,24 @@ test('1. Correct record', async ({ page }) => {
       page.locator('#listTable-corrections-table-child')
     ).toContainText(`Weight at birth-${updatedChildDetails.weightAtBirth}`)
 
+    await page
+      .getByRole('button', { name: 'Submit correction request' })
+      .click()
+
     const correctionResponse = page.waitForResponse(
       (res) =>
         res.url().includes('event.actions.correction.request') && res.ok()
     )
 
-    await page
-      .getByRole('button', { name: 'Submit correction request' })
-      .click()
     await page.getByRole('button', { name: 'Confirm' }).click()
+
     await correctionResponse
 
     await expectInUrl(page, `/workqueue/pending-certification`)
-
-    await page.getByText('Recent').click()
-
-    await expect(
-      page.getByRole('button', { name: formatV2ChildName(declaration) })
-    ).toBeVisible()
   })
 
   // 1.2.6 Correction Approval — performed by a Registrar.
   await test.step('Log in as Registrar to review the correction request', async () => {
-    await logout(page)
     await login(page, CREDENTIALS.REGISTRAR)
   })
 
@@ -534,7 +521,14 @@ test('1. Correct record', async ({ page }) => {
 
   await test.step('1.2.6.3 Approve correction', async () => {
     await page.getByRole('button', { name: 'Approve', exact: true }).click()
+    const correctionResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('event.actions.correction.approve') && res.ok()
+    )
+
     await page.getByRole('button', { name: 'Confirm', exact: true }).click()
+
+    await correctionResponse
 
     await expectInUrl(page, `/events/${eventId}`)
 

--- a/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-1.spec.ts
@@ -529,13 +529,13 @@ test('1. Correct record', async ({ page }) => {
     await correctionResponse
 
     await expectInUrl(page, `/events/${eventId}`)
-
-    // force reload to ensure we are seeing the latest data after approval.
-    await page.reload()
   })
 
+  // Skipped due to flakiness - needs investigation.
+  // Issue is with the overview not reflecting unassigned state after the approve action.
+
   // 1.2.6.4 Validate history in record audit.
-  await test.step('1.2.6.4.1 Validate correction requested modal', async () => {
+  test.skip('1.2.6.4.1 Validate correction requested modal', async () => {
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     await page.getByRole('button', { name: 'Audit' }).click()
 
@@ -571,7 +571,7 @@ test('1. Correct record', async ({ page }) => {
     await page.locator('#close-btn').click()
   })
 
-  await test.step('1.2.6.4.2 Validate correction approved modal', async () => {
+  test.skip('1.2.6.4.2 Validate correction approved modal', async () => {
     await page.getByRole('button', { name: 'Next page' }).click()
     await page
       .getByRole('button', { name: 'Correction approved', exact: true })

--- a/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
@@ -20,6 +20,7 @@ import {
 } from '../../utils'
 import {
   navigateToCertificatePrintAction,
+  openRecordByTitle,
   selectCertificationType,
   selectRequesterType
 } from '../print-certificate/birth/helpers'
@@ -278,9 +279,8 @@ test.describe.serial('Correct record - 2', () => {
 
       await type(page, '#searchText', trackingId)
       await page.locator('#searchIconButton').click()
-      await page
-        .getByRole('button', { name: formatV2ChildName(declaration) })
-        .click()
+
+      await openRecordByTitle(page, formatV2ChildName(declaration))
     })
 
     test('2.8.2 Correction review page', async () => {

--- a/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
@@ -257,10 +257,16 @@ test.describe.serial('Correct record - 2', () => {
       page.getByText('Relationship to child' + 'Mother' + 'Brother')
     ).toBeVisible()
 
+    const correctionRequest = page.waitForResponse(
+      (res) =>
+        res.url().includes('event.actions.correction.request') && res.ok()
+    )
+
     await page
       .getByRole('button', { name: 'Submit correction request' })
       .click()
     await page.getByRole('button', { name: 'Confirm' }).click()
+    await correctionRequest
 
     await expectInUrl(page, `/workqueue/pending-certification`)
   })
@@ -351,7 +357,14 @@ test.describe.serial('Correct record - 2', () => {
       ).toBeDisabled()
 
       await page.locator('#reject-correction-reason').fill('No legal proof')
+
+      const correctionResponse = page.waitForResponse(
+        (res) =>
+          res.url().includes('event.actions.correction.reject') && res.ok()
+      )
       await page.getByRole('button', { name: 'Confirm', exact: true }).click()
+
+      await correctionResponse
 
       await expectInUrl(page, `/events/${eventId}`)
     })

--- a/e2e/testcases/correction-birth/correct-birth-record-3.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-3.spec.ts
@@ -8,11 +8,7 @@ import {
   uploadImage
 } from '../../helpers'
 import { faker } from '@faker-js/faker'
-import {
-  CREDENTIALS,
-  SAFE_INPUT_CHANGE_TIMEOUT_MS,
-  SAFE_OUTBOX_TIMEOUT_MS
-} from '../../constants'
+import { CREDENTIALS } from '../../constants'
 import { random } from 'lodash'
 import {
   createDeclaration as createDeclarationV2,
@@ -906,28 +902,23 @@ test.describe.serial(' Correct record - 3', () => {
     /*
      * Expected result: should enable the Submit correction request button
      */
+
+    const correctionResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('event.actions.correction.request') &&
+        response.ok()
+    )
+
     await page
       .getByRole('button', { name: 'Submit correction request' })
       .click()
     await page.getByRole('button', { name: 'Confirm' }).click()
 
+    await correctionResponse
+
     await expectInUrl(page, `events/${eventId}`)
 
     await page.getByTestId('exit-event').click()
-    await page.getByRole('button', { name: 'Outbox' }).click()
-
-    /*
-     * This is to ensure the following condition is asserted
-     * after the outbox has the declaration
-     */
-    await page.waitForTimeout(SAFE_INPUT_CHANGE_TIMEOUT_MS)
-
-    await expect(await page.locator('#no-record')).toContainText(
-      'No records require processing',
-      {
-        timeout: SAFE_OUTBOX_TIMEOUT_MS
-      }
-    )
 
     await page.getByRole('button', { name: 'Recent' }).click()
     await expect(

--- a/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
@@ -868,8 +868,14 @@ test.describe.serial('Correct record - 4', () => {
     )
 
     await page.getByRole('button', { name: 'Correct record' }).click()
-    await page.getByRole('button', { name: 'Confirm' }).click()
 
+    const searchCacheRefetchResponse = page.waitForResponse(
+      (res) => res.url().includes(`event.search?batch=1`) && res.ok()
+    )
+
+    await page.getByRole('button', { name: 'Confirm', exact: true }).click()
+
+    await searchCacheRefetchResponse
     await correctionResponse
 
     await expectInUrl(page, `events/${eventId}`)

--- a/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
@@ -873,6 +873,8 @@ test.describe.serial('Correct record - 4', () => {
     await correctionResponse
 
     await expectInUrl(page, `events/${eventId}`)
+
+    await page.getByTestId('exit-event').click()
   })
 
   test('4.8 Validate history in record audit', async () => {

--- a/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-4.spec.ts
@@ -13,11 +13,7 @@ import {
   Declaration as DeclarationV2
 } from '../test-data/birth-declaration-with-mother-father'
 import { format, subDays, subYears } from 'date-fns'
-import {
-  CREDENTIALS,
-  SAFE_INPUT_CHANGE_TIMEOUT_MS,
-  SAFE_OUTBOX_TIMEOUT_MS
-} from '../../constants'
+import { CREDENTIALS } from '../../constants'
 import { IdType } from '@countryconfig/events/utils'
 import { random } from 'lodash'
 import { formatV2ChildName, REQUIRED_VALIDATION_ERROR } from '../birth/helpers'
@@ -865,25 +861,18 @@ test.describe.serial('Correct record - 4', () => {
     /*
      * Expected result: should enable the Correct record button
      */
+
+    const correctionResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('event.actions.correction.approve') && res.ok()
+    )
+
     await page.getByRole('button', { name: 'Correct record' }).click()
     await page.getByRole('button', { name: 'Confirm' }).click()
 
+    await correctionResponse
+
     await expectInUrl(page, `events/${eventId}`)
-    await page.getByTestId('exit-event').click()
-    await page.getByRole('button', { name: 'Outbox' }).click()
-
-    /*
-     * This is to ensure the following condition is asserted
-     * after the outbox has the declaration
-     */
-    await page.waitForTimeout(SAFE_INPUT_CHANGE_TIMEOUT_MS)
-
-    await expect(await page.locator('#no-record')).toContainText(
-      'No records require processing',
-      {
-        timeout: SAFE_OUTBOX_TIMEOUT_MS
-      }
-    )
   })
 
   test('4.8 Validate history in record audit', async () => {

--- a/e2e/testcases/correction-birth/correct-birth-record-change-ages-address.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-change-ages-address.spec.ts
@@ -17,6 +17,7 @@ import { formatV2ChildName, getAdministrativeAreas } from '../birth/helpers'
 import { ensureAssignedToUser, expectInUrl, selectAction } from '../../utils'
 import { getIdByName } from '../birth/helpers'
 import { AddressType } from '@opencrvs/toolkit/events'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test.describe.serial('Correct record - Change ages', () => {
   let declaration: Declaration
@@ -297,9 +298,7 @@ test.describe.serial('Correct record - Change ages', () => {
   test('Find the event in the "Pending corrections" workqueue', async () => {
     await page.getByRole('button', { name: 'Pending corrections' }).click()
 
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
   })
 
   test('Approve correction request', async () => {

--- a/e2e/testcases/correction-birth/correct-birth-record-change-father-id-number.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-change-father-id-number.spec.ts
@@ -15,6 +15,7 @@ import { format, subDays, subYears } from 'date-fns'
 import { CREDENTIALS } from '../../constants'
 import { formatV2ChildName } from '../birth/helpers'
 import { ensureAssignedToUser, expectInUrl, selectAction } from '../../utils'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test.describe.serial("Correct record - Change father's ID number", () => {
   let declaration: DeclarationV2
@@ -201,9 +202,7 @@ test.describe.serial("Correct record - Change father's ID number", () => {
   test('Find the event in the "Pending corrections" workqueue', async () => {
     await page.getByRole('button', { name: 'Pending corrections' }).click()
 
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
   })
 
   test('Approve correction request', async () => {

--- a/e2e/testcases/correction-birth/correct-birth-record-change-informant.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-change-informant.spec.ts
@@ -322,6 +322,7 @@ test.describe.serial('Correct record - change informant type', () => {
     await correctionResponse
 
     await expectInUrl(page, `events/${eventId}`)
+    await page.getByTestId('exit-event').click()
   })
 
   test('Validate history in record audit', async () => {

--- a/e2e/testcases/correction-birth/correct-birth-record-change-informant.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-change-informant.spec.ts
@@ -11,11 +11,7 @@ import {
   Declaration as DeclarationV2
 } from '../test-data/birth-declaration-with-mother-father'
 import { format, subDays, subYears } from 'date-fns'
-import {
-  CREDENTIALS,
-  SAFE_INPUT_CHANGE_TIMEOUT_MS,
-  SAFE_OUTBOX_TIMEOUT_MS
-} from '../../constants'
+import { CREDENTIALS } from '../../constants'
 import { IdType } from '@countryconfig/events/utils'
 import { random } from 'lodash'
 import { formatV2ChildName, REQUIRED_VALIDATION_ERROR } from '../birth/helpers'
@@ -315,21 +311,17 @@ test.describe.serial('Correct record - change informant type', () => {
       )
     )
 
+    const correctionResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('event.actions.correction.approve') && res.ok()
+    )
+
     await page.getByRole('button', { name: 'Correct record' }).click()
     await page.getByRole('button', { name: 'Confirm' }).click()
 
+    await correctionResponse
+
     await expectInUrl(page, `events/${eventId}`)
-    await page.getByTestId('exit-event').click()
-    await page.getByRole('button', { name: 'Outbox' }).click()
-
-    await page.waitForTimeout(SAFE_INPUT_CHANGE_TIMEOUT_MS)
-
-    await expect(await page.locator('#no-record')).toContainText(
-      'No records require processing',
-      {
-        timeout: SAFE_OUTBOX_TIMEOUT_MS
-      }
-    )
   })
 
   test('Validate history in record audit', async () => {

--- a/e2e/testcases/correction-birth/correct-birth-record-change-informant.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-change-informant.spec.ts
@@ -312,17 +312,23 @@ test.describe.serial('Correct record - change informant type', () => {
       )
     )
 
+    await page.getByRole('button', { name: 'Correct record' }).click()
     const correctionResponse = page.waitForResponse(
       (res) =>
         res.url().includes('event.actions.correction.approve') && res.ok()
     )
 
-    await page.getByRole('button', { name: 'Correct record' }).click()
-    await page.getByRole('button', { name: 'Confirm' }).click()
+    const searchCacheRefetchResponse = page.waitForResponse(
+      (res) => res.url().includes(`event.search?batch=1`) && res.ok()
+    )
+
+    await page.getByRole('button', { name: 'Confirm', exact: true }).click()
 
     await correctionResponse
+    await searchCacheRefetchResponse
 
-    await expectInUrl(page, `events/${eventId}`)
+    await expectInUrl(page, `/events/${eventId}`)
+
     await page.getByTestId('exit-event').click()
   })
 

--- a/e2e/testcases/correction-birth/correct-birth-record-change-informant.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-change-informant.spec.ts
@@ -20,6 +20,7 @@ import { ensureAssignedToUser, expectInUrl, selectAction } from '../../utils'
 test.describe.serial('Correct record - change informant type', () => {
   let declaration: DeclarationV2
   let trackingId = ''
+
   let eventId: string
   let page: Page
 

--- a/e2e/testcases/correction-birth/direct-correction-offline.spec.ts
+++ b/e2e/testcases/correction-birth/direct-correction-offline.spec.ts
@@ -6,7 +6,7 @@ import {
   Declaration as DeclarationV2
 } from '../test-data/birth-declaration-with-mother-father'
 import { format, subDays, subYears } from 'date-fns'
-import { CREDENTIALS, SAFE_OUTBOX_TIMEOUT_MS } from '../../constants'
+import { CREDENTIALS } from '../../constants'
 import { formatV2ChildName } from '../birth/helpers'
 import { ensureAssignedToUser, expectInUrl, selectAction } from '../../utils'
 
@@ -160,16 +160,16 @@ test.describe.serial('Direct correction offline', () => {
   })
 
   test('Go back online', async () => {
+    const correctionResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('event.actions.correction.approve') && res.ok()
+    )
+
     // Go back online
     await page.context().setOffline(false)
 
-    await expect(page.getByText('Offline')).not.toBeVisible()
+    await correctionResponse
 
-    await expect(await page.locator('#no-record')).toContainText(
-      'No records require processing',
-      {
-        timeout: SAFE_OUTBOX_TIMEOUT_MS
-      }
-    )
+    await expect(page.getByText('Offline')).not.toBeVisible()
   })
 })

--- a/e2e/testcases/correction-birth/request-and-accept-correction-offline.spec.ts
+++ b/e2e/testcases/correction-birth/request-and-accept-correction-offline.spec.ts
@@ -6,7 +6,7 @@ import {
   Declaration as DeclarationV2
 } from '../test-data/birth-declaration-with-mother-father'
 import { format, subDays, subYears } from 'date-fns'
-import { CREDENTIALS, SAFE_OUTBOX_TIMEOUT_MS } from '../../constants'
+import { CREDENTIALS } from '../../constants'
 import { formatV2ChildName } from '../birth/helpers'
 import {
   ensureAssignedToUser,
@@ -150,10 +150,17 @@ test.describe.serial('Request and accept correction (offline)', () => {
     })
 
     test('Request correction', async () => {
+      const correctionResponse = page.waitForResponse(
+        (res) =>
+          res.url().includes('event.actions.correction.request') && res.ok()
+      )
+
       await page
         .getByRole('button', { name: 'Submit correction request' })
         .click()
       await page.getByRole('button', { name: 'Confirm' }).click()
+
+      await correctionResponse
 
       await expectInUrl(page, `events/${eventId}`)
 
@@ -162,16 +169,6 @@ test.describe.serial('Request and accept correction (offline)', () => {
           hasText: formatV2ChildName(declaration)
         })
       ).toBeVisible()
-
-      await page.getByTestId('exit-event').click()
-
-      await page.getByRole('button', { name: 'Outbox' }).click()
-      await expect(await page.locator('#no-record')).toContainText(
-        'No records require processing',
-        {
-          timeout: SAFE_OUTBOX_TIMEOUT_MS
-        }
-      )
     })
   })
 
@@ -214,16 +211,18 @@ test.describe.serial('Request and accept correction (offline)', () => {
 
     test('Go back online', async () => {
       // Go back online
+
+      const acceptResponse = page.waitForResponse(
+        (response) =>
+          response.url().includes('event.actions.correction.accept') &&
+          response.ok()
+      )
+
       await page.context().setOffline(false)
 
       await expect(page.getByText('Offline')).not.toBeVisible()
 
-      await expect(await page.locator('#no-record')).toContainText(
-        'No records require processing',
-        {
-          timeout: SAFE_OUTBOX_TIMEOUT_MS
-        }
-      )
+      await acceptResponse
     })
   })
 })

--- a/e2e/testcases/correction-birth/request-and-accept-correction-offline.spec.ts
+++ b/e2e/testcases/correction-birth/request-and-accept-correction-offline.spec.ts
@@ -214,15 +214,14 @@ test.describe.serial('Request and accept correction (offline)', () => {
 
       const acceptResponse = page.waitForResponse(
         (response) =>
-          response.url().includes('event.actions.correction.accept') &&
+          response.url().includes('event.actions.correction.approve') &&
           response.ok()
       )
 
       await page.context().setOffline(false)
+      await acceptResponse
 
       await expect(page.getByText('Offline')).not.toBeVisible()
-
-      await acceptResponse
     })
   })
 })

--- a/e2e/testcases/correction-birth/request-escalate-approve-correction.spec.ts
+++ b/e2e/testcases/correction-birth/request-escalate-approve-correction.spec.ts
@@ -272,17 +272,23 @@ test.describe
   })
 
   test('Approve the correction', async () => {
+    await page.getByRole('button', { name: 'Approve', exact: true }).click()
+
     const correctionApprovalResponse = page.waitForResponse(
       (res) =>
         res.url().includes('event.actions.correction.approve') && res.ok()
     )
 
-    await page.getByRole('button', { name: 'Approve', exact: true }).click()
+    const searchCacheRefetchResponse = page.waitForResponse(
+      (res) => res.url().includes(`event.search?batch=1`) && res.ok()
+    )
+
     await page.getByRole('button', { name: 'Confirm', exact: true }).click()
 
     await correctionApprovalResponse
+    await searchCacheRefetchResponse
 
-    await expectInUrl(page, `events/${eventId}`)
+    await expectInUrl(page, `/events/${eventId}`)
 
     await expect(
       page.locator('#content-name', {

--- a/e2e/testcases/correction-birth/request-escalate-approve-correction.spec.ts
+++ b/e2e/testcases/correction-birth/request-escalate-approve-correction.spec.ts
@@ -272,8 +272,15 @@ test.describe
   })
 
   test('Approve the correction', async () => {
+    const correctionApprovalResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('event.actions.correction.approve') && res.ok()
+    )
+
     await page.getByRole('button', { name: 'Approve', exact: true }).click()
     await page.getByRole('button', { name: 'Confirm', exact: true }).click()
+
+    await correctionApprovalResponse
 
     await expectInUrl(page, `events/${eventId}`)
 

--- a/e2e/testcases/correction-birth/request-escalate-approve-correction.spec.ts
+++ b/e2e/testcases/correction-birth/request-escalate-approve-correction.spec.ts
@@ -6,7 +6,7 @@ import {
   Declaration as DeclarationV2
 } from '../test-data/birth-declaration-with-mother-father'
 import { format, subDays, subYears } from 'date-fns'
-import { CREDENTIALS, SAFE_OUTBOX_TIMEOUT_MS } from '../../constants'
+import { CREDENTIALS } from '../../constants'
 import { formatV2ChildName } from '../birth/helpers'
 import {
   ensureAssignedToUser,
@@ -152,11 +152,16 @@ test.describe
   })
 
   test('Submit correction request', async () => {
+    const correctionResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('event.actions.correction.request') && res.ok()
+    )
     await page
       .getByRole('button', { name: 'Submit correction request' })
       .click()
     await page.getByRole('button', { name: 'Confirm' }).click()
 
+    await correctionResponse
     await expectInUrl(page, `events/${eventId}`)
 
     await expect(
@@ -166,12 +171,6 @@ test.describe
     ).toBeVisible()
 
     await page.getByTestId('exit-event').click()
-
-    await page.getByRole('button', { name: 'Outbox' }).click()
-    await expect(page.locator('#no-record')).toContainText(
-      'No records require processing',
-      { timeout: SAFE_OUTBOX_TIMEOUT_MS }
-    )
   })
 
   test('Navigate back to the record', async () => {
@@ -204,14 +203,15 @@ test.describe
 
     await page.locator('#reason').fill(escalationReason)
 
+    const escalateResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('event.actions.custom') && response.ok()
+    )
+
     await expect(confirmButton).toBeEnabled()
     await confirmButton.click()
 
-    await page.getByRole('button', { name: 'Outbox' }).click()
-    await expect(page.locator('#no-record')).toContainText(
-      'No records require processing',
-      { timeout: SAFE_OUTBOX_TIMEOUT_MS }
-    )
+    await escalateResponse
   })
 
   test('Login as Local Registrar', async () => {

--- a/e2e/testcases/correction-birth/request-escalate-approve-correction.spec.ts
+++ b/e2e/testcases/correction-birth/request-escalate-approve-correction.spec.ts
@@ -14,6 +14,7 @@ import {
   selectAction,
   type
 } from '../../utils'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test.describe
   .serial('Request correction, escalate, then approve as Local Registrar', () => {
@@ -220,9 +221,7 @@ test.describe
   test('Navigate to the record by tracking ID', async () => {
     await type(page, '#searchText', trackingId)
     await page.locator('#searchIconButton').click()
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
 
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
   })

--- a/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-1.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-1.spec.ts
@@ -387,7 +387,8 @@ test.describe('Birth with non-late registration will not have flag or Approve-ac
 
     test('Navigate to the record', async () => {
       await page.getByText('Recent').click()
-      await page.getByRole('button', { name: childNameFormatted }).click()
+
+      await openRecordByTitle(page, childNameFormatted)
     })
 
     test("Record should not have the 'Approval required for late registration' -flag", async () => {

--- a/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-1.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-1.spec.ts
@@ -175,7 +175,8 @@ test.describe.serial('Approval of late birth registration', () => {
     test('Navigate to the declaration review page', async () => {
       await login(page, CREDENTIALS.REGISTRAR)
       await page.getByText('Pending approval').click()
-      await page.getByRole('button', { name: childNameFormatted }).click()
+
+      await openRecordByTitle(page, childNameFormatted)
     })
 
     test('Unassign', async () => {

--- a/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-1.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-1.spec.ts
@@ -10,7 +10,7 @@ import {
   validateActionMenuButton
 } from '../../helpers'
 import { faker } from '@faker-js/faker'
-import { CREDENTIALS, SAFE_OUTBOX_TIMEOUT_MS } from '../../constants'
+import { CREDENTIALS } from '../../constants'
 import { ensureAssignedToUser, selectAction } from '../../utils'
 import { selectDeclarationAction } from '../../helpers'
 import { format, subDays } from 'date-fns'
@@ -178,11 +178,19 @@ test.describe.serial('Approval of late birth registration', () => {
     test('Unassign', async () => {
       await page.getByRole('button', { name: 'Action', exact: true }).click()
       await page.getByText('Unassign', { exact: true }).click()
+
+      const unassignResponse = page.waitForResponse(
+        (response) =>
+          response.url().includes('event.actions.unassign') && response.ok()
+      )
+
       await page.getByRole('button', { name: 'Unassign', exact: true }).click()
+
+      await unassignResponse
 
       await expect(
         page.getByTestId('assignedTo-value').locator('span')
-      ).toContainText('Not assigned', { timeout: SAFE_OUTBOX_TIMEOUT_MS })
+      ).toContainText('Not assigned')
     })
 
     test('LR should not have the option to Approve', async () => {

--- a/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-1.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-1.spec.ts
@@ -181,7 +181,8 @@ test.describe.serial('Approval of late birth registration', () => {
 
       const unassignResponse = page.waitForResponse(
         (response) =>
-          response.url().includes('event.actions.unassign') && response.ok()
+          response.url().includes('event.actions.assignment.unassign') &&
+          response.ok()
       )
 
       await page.getByRole('button', { name: 'Unassign', exact: true }).click()

--- a/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-1.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-1.spec.ts
@@ -11,11 +11,7 @@ import {
 } from '../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS, SAFE_OUTBOX_TIMEOUT_MS } from '../../constants'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  selectAction
-} from '../../utils'
+import { ensureAssignedToUser, selectAction } from '../../utils'
 import { selectDeclarationAction } from '../../helpers'
 import { format, subDays } from 'date-fns'
 import { openRecordByTitle } from '../print-certificate/birth/helpers'
@@ -232,12 +228,17 @@ test.describe.serial('Approval of late birth registration', () => {
         'Approving after verifying all late submission details.'
       )
 
+      const approveResponse = page.waitForResponse(
+        (response) =>
+          response.url().includes('event.actions.custom') && response.ok()
+      )
+
       await expect(confirmButton).toBeEnabled()
       await confirmButton.click()
+      await approveResponse
     })
 
     test("Validate that the 'Approval required for late registration' -flag is removed after approval", async () => {
-      await ensureOutboxIsEmpty(page)
       await searchFromSearchBar(page, childNameFormatted)
 
       await expect(

--- a/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-2.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-2.spec.ts
@@ -176,7 +176,7 @@ test.describe
 
     test('Go to record', async () => {
       await page.getByText('Recent').click()
-      await page.getByRole('button', { name: childNameFormatted }).click()
+      await openRecordByTitle(page, childNameFormatted)
     })
 
     test("Event should not have the 'Approval required for late registration' -flag", async () => {

--- a/e2e/testcases/custom-actions-and-flags/escalate-keeps-rejected-flag.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/escalate-keeps-rejected-flag.spec.ts
@@ -114,9 +114,7 @@ test('Escalating a rejected record preserves the Rejected flag', async ({
   await test.step('Rejected flag is still present after escalation', async () => {
     await type(page, '#searchText', trackingId)
     await page.locator('#searchIconButton').click()
-    await page
-      .getByRole('button', { name: formatV2ChildName(declaration) })
-      .click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
 
     await expect(page.getByTestId('flags-value')).toContainText('Rejected')
     await expect(page.getByTestId('flags-value')).toContainText(

--- a/e2e/testcases/custom-actions-and-flags/escalate-keeps-rejected-flag.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/escalate-keeps-rejected-flag.spec.ts
@@ -2,11 +2,7 @@ import { expect, test } from '@playwright/test'
 import { v4 as uuidv4 } from 'uuid'
 import { createClient } from '@opencrvs/toolkit/api'
 import { ActionType } from '@opencrvs/toolkit/events'
-import {
-  CREDENTIALS,
-  GATEWAY_HOST,
-  SAFE_OUTBOX_TIMEOUT_MS
-} from '../../constants'
+import { CREDENTIALS, GATEWAY_HOST } from '../../constants'
 import { getToken, login } from '../../helpers'
 import {
   ensureAssignedToUser,
@@ -101,14 +97,15 @@ test('Escalating a rejected record preserves the Rejected flag', async ({
 
     await page.locator('#reason').fill(escalationReason)
 
+    const escalateResponse = await page.waitForResponse(
+      (response) =>
+        response.url().includes('event.actions.custom') && response.ok()
+    )
+
     await expect(confirmButton).toBeEnabled()
     await confirmButton.click()
 
-    await page.getByRole('button', { name: 'Outbox' }).click()
-    await expect(page.locator('#no-record')).toContainText(
-      'No records require processing',
-      { timeout: SAFE_OUTBOX_TIMEOUT_MS }
-    )
+    await escalateResponse
   })
 
   await test.step('Rejected flag is still present after escalation', async () => {

--- a/e2e/testcases/custom-actions-and-flags/escalate-keeps-rejected-flag.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/escalate-keeps-rejected-flag.spec.ts
@@ -97,7 +97,7 @@ test('Escalating a rejected record preserves the Rejected flag', async ({
 
     await page.locator('#reason').fill(escalationReason)
 
-    const escalateResponse = await page.waitForResponse(
+    const escalateResponse = page.waitForResponse(
       (response) =>
         response.url().includes('event.actions.custom') && response.ok()
     )

--- a/e2e/testcases/custom-actions-and-flags/escalate-to-registrars.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/escalate-to-registrars.spec.ts
@@ -8,11 +8,7 @@ import {
 } from '../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../constants'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  selectAction
-} from '../../utils'
+import { ensureAssignedToUser, selectAction } from '../../utils'
 import { createDeclaration } from '../test-data/birth-declaration-with-father-brother'
 import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
@@ -95,9 +91,15 @@ test.describe.serial('Escalation of birth registration by Registrar', () => {
         'Escalating this case to Provincial Registrar for further review.'
       )
 
+      const escalateResponse = page.waitForResponse(
+        (response) =>
+          response.url().includes('event.actions.custom') &&
+          response.status() === 200
+      )
+
       await expect(confirmButton).toBeEnabled()
       await confirmButton.click()
-      await ensureOutboxIsEmpty(page)
+      await escalateResponse
     })
   })
 
@@ -129,9 +131,15 @@ test.describe.serial('Escalation of birth registration by Registrar', () => {
         'Escalating this case to Registrar General for further review.'
       )
 
+      const escalateResponse = page.waitForResponse(
+        (response) =>
+          response.url().includes('event.actions.custom') && response.ok()
+      )
+
       await expect(confirmButton).toBeEnabled()
       await confirmButton.click()
-      await ensureOutboxIsEmpty(page)
+
+      await escalateResponse
     })
   })
 
@@ -159,6 +167,10 @@ test.describe.serial('Escalation of birth registration by Registrar', () => {
     test('Registrar general should have the action Registrar General feedback', async () => {
       await selectAction(page, 'Registrar general feedback')
 
+      const feedbackResponse = page.waitForResponse(
+        (response) =>
+          response.url().includes('event.actions.custom') && response.ok()
+      )
       const confirmButton = page.getByRole('button', { name: 'Confirm' })
       await expect(confirmButton).toBeDisabled()
 
@@ -167,7 +179,8 @@ test.describe.serial('Escalation of birth registration by Registrar', () => {
 
       await expect(confirmButton).toBeEnabled()
       await confirmButton.click()
-      await ensureOutboxIsEmpty(page)
+
+      await feedbackResponse
     })
   })
 
@@ -201,8 +214,15 @@ test.describe.serial('Escalation of birth registration by Registrar', () => {
       await notesField.fill('Approving after verifying record - by PR.')
 
       await expect(confirmButton).toBeEnabled()
+
+      const feedbackResponse = page.waitForResponse(
+        (response) =>
+          response.url().includes('event.actions.custom') && response.ok()
+      )
+
       await confirmButton.click()
-      await ensureOutboxIsEmpty(page)
+
+      await feedbackResponse
     })
   })
 

--- a/e2e/testcases/custom-actions-and-flags/issue-certified-copy.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/issue-certified-copy.spec.ts
@@ -33,7 +33,8 @@ test.describe.serial('Issue Certified Copy', () => {
     test('Navigate to the declaration review page', async () => {
       await login(page, CREDENTIALS.REGISTRATION_OFFICER)
       await navigateToWorkqueue(page, 'Pending certification')
-      await page.getByRole('button', { name: childName }).click()
+      await openRecordByTitle(page, childName)
+
       await expect(page.getByText('Registered')).toBeVisible()
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
 

--- a/e2e/testcases/custom-actions-and-flags/issue-verifiable-credential.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/issue-verifiable-credential.spec.ts
@@ -3,7 +3,6 @@ import { CREDENTIALS } from '../../constants'
 import { getToken, login, searchFromSearchBar } from '../../helpers'
 import {
   ensureAssignedToUser,
-  ensureOutboxIsEmpty,
   navigateToWorkqueue,
   selectAction
 } from '../../utils'
@@ -97,8 +96,13 @@ test.describe.serial('Issue verifiable credential', () => {
     await acceptedOfferCheckbox.check()
     await expect(confirmButton).toBeEnabled()
 
+    const verifiableCredentialResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('event.actions.custom') && response.ok()
+    )
+
     await confirmButton.click()
-    await ensureOutboxIsEmpty(page)
+    await verifiableCredentialResponse
   })
 
   test('Requester dropdown spec: non-parent informant shows available parent(s) plus informant relation', async () => {
@@ -130,8 +134,13 @@ test.describe.serial('Issue verifiable credential', () => {
     await expect(acceptedOfferCheckbox).toBeVisible()
     await acceptedOfferCheckbox.check()
 
+    const verifiableCredentialResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('event.actions.custom') && response.ok()
+    )
+
     await page.getByRole('button', { name: 'Confirm' }).click()
-    await ensureOutboxIsEmpty(page)
+    await verifiableCredentialResponse
   })
 
   test('Show verifiable credential QR code in Birth Certificate', async () => {

--- a/e2e/testcases/custom-actions-and-flags/revoke-and-reinstate.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/revoke-and-reinstate.spec.ts
@@ -1,11 +1,7 @@
 import { expect, test } from '@playwright/test'
 import { getToken, login, searchFromSearchBar } from '../../helpers'
 import { CREDENTIALS } from '../../constants'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  selectAction
-} from '../../utils'
+import { ensureAssignedToUser, selectAction } from '../../utils'
 import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { formatV2ChildName } from '../birth/helpers'
 
@@ -36,8 +32,13 @@ test('Revoke and reinstate record', async ({ browser }) => {
 
     await page.locator('#reason').fill('Revoking record for testing purposes.')
 
+    const revokeResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('event.actions.custom') && response.ok()
+    )
+
     await page.getByRole('button', { name: 'Confirm' }).click()
-    await ensureOutboxIsEmpty(page)
+    await revokeResponse
   })
 
   await test.step('Assert "Revoked" -flag is present', async () => {
@@ -54,8 +55,12 @@ test('Revoke and reinstate record', async ({ browser }) => {
       .locator('#reason')
       .fill('Reinstating record for testing purposes.')
 
-    await page.getByRole('button', { name: 'Confirm' }).click()
+    const reinstateResponse = page.waitForResponse(
+      (response) =>
+        response.url().includes('event.actions.custom') && response.ok()
+    )
 
-    await ensureOutboxIsEmpty(page)
+    await page.getByRole('button', { name: 'Confirm' }).click()
+    await reinstateResponse
   })
 })

--- a/e2e/testcases/death/1-death-event-declaration.spec.ts
+++ b/e2e/testcases/death/1-death-event-declaration.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test, type Page } from '@playwright/test'
 import { login, selectDeclarationAction } from '../../helpers'
 import { faker } from '@faker-js/faker'
-import { ensureOutboxIsEmpty, expectInUrl, type } from '../../utils'
+import { expectInUrl, type } from '../../utils'
 const deceased = {
   name: {
     firstname: faker.person.firstName('male')
@@ -475,8 +475,6 @@ test.describe('1. Death event declaration', () => {
 
       await expect(page.locator('#content-name')).toHaveText('Assigned to you')
 
-      await ensureOutboxIsEmpty(page)
-
       await expect(
         page.getByText(deceased.name.firstname, { exact: true })
       ).toBeHidden()
@@ -530,15 +528,17 @@ test.describe('1. Death event declaration', () => {
     })
 
     test('1.11.3 Click Confirm', async ({ page }) => {
+      const deleteResponse = page.waitForResponse(
+        (response) => response.url().includes('event.delete') && response.ok()
+      )
       await page.getByRole('button', { name: 'Confirm' }).click()
+      await deleteResponse
 
       /*
        * Expected result: should be navigated to "my-drafts" tab but no draft will be saved
        */
 
       await expect(page.locator('#content-name')).toHaveText('Assigned to you')
-
-      await ensureOutboxIsEmpty(page)
 
       await expect(
         page.getByText(deceased.name.firstname, { exact: true })

--- a/e2e/testcases/death/8-validate-declaration-review-page.spec.ts
+++ b/e2e/testcases/death/8-validate-declaration-review-page.spec.ts
@@ -14,12 +14,7 @@ import {
 } from '../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../constants'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  expectInUrl,
-  selectAction
-} from '../../utils'
+import { ensureAssignedToUser, expectInUrl, selectAction } from '../../utils'
 import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test.describe.serial('8. Validate declaration review page', () => {
@@ -688,7 +683,6 @@ test.describe.serial('8. Validate declaration review page', () => {
     })
 
     test('8.1.8 Validate that declaration is available on "Recent"', async () => {
-      await ensureOutboxIsEmpty(page)
       await expect(page.getByText('Farajaland CRS')).toBeVisible()
 
       /*
@@ -715,7 +709,6 @@ test.describe.serial('8. Validate declaration review page', () => {
     test('8.2.1 Navigate to the declaration preview page', async () => {
       await login(page, CREDENTIALS.REGISTRATION_OFFICER)
 
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Notifications').click()
 
       await openRecordByTitle(
@@ -1168,7 +1161,6 @@ test.describe.serial('8. Validate declaration review page', () => {
     test('8.3.1 Navigate to the declaration "Record" tab', async () => {
       await login(page, CREDENTIALS.REGISTRAR)
 
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Pending registration').click()
 
       await openRecordByTitle(
@@ -1610,7 +1602,6 @@ test.describe.serial('8. Validate declaration review page', () => {
     })
 
     test('8.3.7 Confirm the declaration to "Pending certification"-workqueue', async () => {
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Pending certification').click()
 
       await expect(

--- a/e2e/testcases/death/declaration/death-declaration-1.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-1.spec.ts
@@ -13,11 +13,7 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  expectInUrl
-} from '../../../utils'
+import { ensureAssignedToUser, expectInUrl } from '../../../utils'
 import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('1. Death declaration case - 1', () => {
@@ -591,7 +587,6 @@ test.describe.serial('1. Death declaration case - 1', () => {
     test('1.2.1 Navigate to the declaration "Record" -tab', async () => {
       await login(page, CREDENTIALS.REGISTRATION_OFFICER)
 
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Pending validation').click()
 
       await openRecordByTitle(

--- a/e2e/testcases/death/declaration/death-declaration-10.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-10.spec.ts
@@ -8,12 +8,7 @@ import {
   selectDeclarationAction
 } from '../../../helpers'
 import { CREDENTIALS } from '../../../constants'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  expectInUrl,
-  selectAction
-} from '../../../utils'
+import { ensureAssignedToUser, expectInUrl, selectAction } from '../../../utils'
 import { REQUIRED_VALIDATION_ERROR } from '../../birth/helpers'
 
 test.describe.serial('10. Death declaration case - 10', () => {
@@ -272,7 +267,6 @@ test.describe.serial('10. Death declaration case - 10', () => {
     test('10.2.1 Navigate to the declaration Edit-action', async () => {
       await login(page, CREDENTIALS.REGISTRATION_OFFICER)
 
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Notifications').click()
 
       await page

--- a/e2e/testcases/death/declaration/death-declaration-2.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-2.spec.ts
@@ -13,11 +13,7 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  expectInUrl
-} from '../../../utils'
+import { ensureAssignedToUser, expectInUrl } from '../../../utils'
 import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('2. Death declaration case - 2', () => {
@@ -736,7 +732,6 @@ test.describe.serial('2. Death declaration case - 2', () => {
     test('2.2.1 Navigate to the declaration "Record" -tab', async () => {
       await login(page, CREDENTIALS.REGISTRATION_OFFICER)
 
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Pending validation').click()
 
       await openRecordByTitle(

--- a/e2e/testcases/death/declaration/death-declaration-3.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-3.spec.ts
@@ -13,11 +13,7 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  expectInUrl
-} from '../../../utils'
+import { ensureAssignedToUser, expectInUrl } from '../../../utils'
 import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('3. Death declaration case - 3', () => {
@@ -698,7 +694,6 @@ test.describe.serial('3. Death declaration case - 3', () => {
     test('3.2.1 Navigate to the declaration "Record" -tab', async () => {
       await login(page, CREDENTIALS.REGISTRATION_OFFICER)
 
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Pending validation').click()
 
       await openRecordByTitle(

--- a/e2e/testcases/death/declaration/death-declaration-4.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-4.spec.ts
@@ -13,12 +13,7 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  expectInUrl,
-  selectAction
-} from '../../../utils'
+import { ensureAssignedToUser, expectInUrl } from '../../../utils'
 import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('4. Death declaration case - 4', () => {
@@ -827,7 +822,6 @@ test.describe.serial('4. Death declaration case - 4', () => {
     test('4.2.1 Navigate to the declaration "Record" -tab', async () => {
       await login(page, CREDENTIALS.REGISTRAR)
 
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Pending registration').click()
 
       await openRecordByTitle(
@@ -1121,10 +1115,7 @@ test.describe.serial('4. Death declaration case - 4', () => {
     })
 
     test('4.2.3 Register', async () => {
-      await selectAction(page, 'Register')
-      await page.getByRole('button', { name: 'Confirm' }).click()
-
-      await ensureOutboxIsEmpty(page)
+      await selectDeclarationAction(page, 'Register')
 
       await page.getByText('Pending certification').click()
       await expect(

--- a/e2e/testcases/death/declaration/death-declaration-5.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-5.spec.ts
@@ -13,11 +13,7 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  expectInUrl
-} from '../../../utils'
+import { ensureAssignedToUser, expectInUrl } from '../../../utils'
 import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('5. Death declaration case - 5', () => {
@@ -557,7 +553,6 @@ test.describe.serial('5. Death declaration case - 5', () => {
     test('5.2.1 Navigate to the declaration "Record" -tab', async () => {
       await login(page, CREDENTIALS.REGISTRAR)
 
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Pending registration').click()
 
       await openRecordByTitle(

--- a/e2e/testcases/death/declaration/death-declaration-6.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-6.spec.ts
@@ -12,11 +12,7 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  expectInUrl
-} from '../../../utils'
+import { ensureAssignedToUser, expectInUrl } from '../../../utils'
 import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('6. Death declaration case - 6', () => {
@@ -558,7 +554,6 @@ test.describe.serial('6. Death declaration case - 6', () => {
     test('6.2.1 Navigate to the declaration "Record" -tab', async () => {
       await login(page, CREDENTIALS.REGISTRATION_OFFICER)
 
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Pending certification').click()
 
       await openRecordByTitle(

--- a/e2e/testcases/death/declaration/death-declaration-7.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-7.spec.ts
@@ -12,11 +12,7 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  expectInUrl
-} from '../../../utils'
+import { ensureAssignedToUser, expectInUrl } from '../../../utils'
 import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
 test.describe.serial('7. Death declaration case - 7', () => {

--- a/e2e/testcases/death/declaration/death-declaration-8.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-8.spec.ts
@@ -9,12 +9,7 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  expectInUrl,
-  selectAction
-} from '../../../utils'
+import { ensureAssignedToUser, expectInUrl, selectAction } from '../../../utils'
 import { REQUIRED_VALIDATION_ERROR } from '../../birth/helpers'
 import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
@@ -289,7 +284,6 @@ test.describe.serial('8. Death declaration case - 8', () => {
     test('8.2.1 Navigate to the declaration Edit-action', async () => {
       await login(page, CREDENTIALS.REGISTRATION_OFFICER)
 
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Notifications').click()
 
       await openRecordByTitle(

--- a/e2e/testcases/death/declaration/death-declaration-9.spec.ts
+++ b/e2e/testcases/death/declaration/death-declaration-9.spec.ts
@@ -9,12 +9,7 @@ import {
 } from '../../../helpers'
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS } from '../../../constants'
-import {
-  ensureAssignedToUser,
-  ensureOutboxIsEmpty,
-  expectInUrl,
-  selectAction
-} from '../../../utils'
+import { ensureAssignedToUser, expectInUrl, selectAction } from '../../../utils'
 import { REQUIRED_VALIDATION_ERROR } from '../../birth/helpers'
 import { openRecordByTitle } from '../../print-certificate/birth/helpers'
 
@@ -289,7 +284,6 @@ test.describe.serial('9. Death declaration case - 9', () => {
     test('9.2.1 Navigate to the declaration Edit-action', async () => {
       await login(page, CREDENTIALS.REGISTRATION_OFFICER)
 
-      await ensureOutboxIsEmpty(page)
       await page.getByText('Notifications').click()
 
       await openRecordByTitle(

--- a/e2e/testcases/duplicate/overview.spec.ts
+++ b/e2e/testcases/duplicate/overview.spec.ts
@@ -53,7 +53,7 @@ test('Duplicate overview', async ({ page }) => {
   await test.step("Navigate to potential duplicate's overview", async () => {
     await login(page, CREDENTIALS.REGISTRAR)
     await page.getByRole('button', { name: 'Potential duplicate' }).click()
-    await page.getByRole('button', { name }).click()
+    await openRecordByTitle(page, name)
   })
 
   await test.step('Validate duplicate in overview page', async () => {

--- a/e2e/testcases/event-overview/history-for-registrar.spec.ts
+++ b/e2e/testcases/event-overview/history-for-registrar.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect, Page } from '@playwright/test'
 import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { getToken, login, switchEventTab } from '../../helpers'
-import { CREDENTIALS, SAFE_WORKQUEUE_TIMEOUT_MS } from '../../constants'
+import { CREDENTIALS } from '../../constants'
 import { ensureAssignedToUser } from '../../utils'
 import { openRecordByTitle } from '../print-certificate/birth/helpers'
 import { formatV2ChildName } from '../birth/helpers'
@@ -26,7 +26,6 @@ test.describe
     await login(page)
   })
   test('Assign', async () => {
-    await page.waitForTimeout(SAFE_WORKQUEUE_TIMEOUT_MS) // wait for the event to be in the workqueue.
     await page.getByText('Pending certification').click()
 
     await openRecordByTitle(page, formatV2ChildName(declaration))

--- a/e2e/testcases/form-state/form-state.spec.ts
+++ b/e2e/testcases/form-state/form-state.spec.ts
@@ -14,6 +14,7 @@ import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { selectAction, type } from '../../utils'
 import {
   navigateToCertificatePrintAction,
+  openRecordByTitle,
   selectRequesterType
 } from '../print-certificate/birth/helpers'
 import { REQUIRED_VALIDATION_ERROR } from '../birth/helpers'
@@ -121,9 +122,8 @@ test.describe('Form state', () => {
 
     test('Form states and annotations are not persisted', async () => {
       await page.getByRole('button', { name: 'Drafts' }).click()
-      await page
-        .getByRole('button', { name: actionableEventChildName, exact: true })
-        .click()
+
+      await openRecordByTitle(page, actionableEventChildName)
 
       await selectAction(page, 'Update')
 

--- a/e2e/testcases/form-state/informant-reset.spec.ts
+++ b/e2e/testcases/form-state/informant-reset.spec.ts
@@ -15,11 +15,8 @@ test.describe('Informant details resets when relation is changed', () => {
       await page.close()
     })
 
-    test('Login', async () => {
-      await login(page, CREDENTIALS.REGISTRAR_VILLAGE)
-    })
-
     test('Fill in informant details', async () => {
+      await login(page, CREDENTIALS.REGISTRAR_VILLAGE)
       await openBirthDeclaration(page)
 
       await goToSection(page, 'informant')
@@ -96,6 +93,7 @@ test.describe('Informant details resets when relation is changed', () => {
       await expect(page.locator('#informant____email')).toHaveValue('')
     })
   })
+
   test.describe.serial('Death', async () => {
     let page: Page
 
@@ -107,11 +105,8 @@ test.describe('Informant details resets when relation is changed', () => {
       await page.close()
     })
 
-    test('Login', async () => {
-      await login(page)
-    })
-
     test('Fill in informant details', async () => {
+      await login(page)
       await page.click('#header-new-event')
       await page.getByLabel('Death').click()
       await page.getByRole('button', { name: 'Continue' }).click()

--- a/e2e/testcases/offline/offline-draft-overview.spec.ts
+++ b/e2e/testcases/offline/offline-draft-overview.spec.ts
@@ -3,7 +3,6 @@ import { expect, Page, test } from '@playwright/test'
 import { formatName, login } from '../../helpers'
 import { mockNetworkConditions } from '../../mock-network-conditions'
 import { faker } from '@faker-js/faker'
-import { ensureOutboxIsEmpty } from '../../utils'
 
 test.describe.serial('Can Open Draft offline', () => {
   let page: Page
@@ -36,10 +35,13 @@ test.describe.serial('Can Open Draft offline', () => {
     await page.locator('#firstname').fill(name.firstNames)
     await page.locator('#surname').fill(name.familyName)
 
+    const draftResponse = page.waitForResponse(
+      (res) => res.url().includes('event.draft.create') && res.ok()
+    )
     await page.getByRole('button', { name: 'Save & Exit' }).click()
     await page.getByRole('button', { name: 'Confirm' }).click()
 
-    await ensureOutboxIsEmpty(page)
+    await draftResponse
   })
 
   test('Open the draft offline', async () => {

--- a/e2e/testcases/offline/offline-draft-overview.spec.ts
+++ b/e2e/testcases/offline/offline-draft-overview.spec.ts
@@ -3,6 +3,7 @@ import { expect, Page, test } from '@playwright/test'
 import { formatName, login } from '../../helpers'
 import { mockNetworkConditions } from '../../mock-network-conditions'
 import { faker } from '@faker-js/faker'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test.describe.serial('Can Open Draft offline', () => {
   let page: Page
@@ -48,7 +49,9 @@ test.describe.serial('Can Open Draft offline', () => {
     await mockNetworkConditions(page, 'offline')
     await page.getByRole('button', { name: 'Drafts' }).click()
     await expect(page.locator('#content-name')).toHaveText('Drafts')
-    await page.getByRole('button', { name: formatName(name) }).click()
+
+    await openRecordByTitle(page, formatName(name))
+
     await expect(page.locator('#content-name')).toHaveText(formatName(name))
   })
 })

--- a/e2e/testcases/offline/offline-event-overview.spec.ts
+++ b/e2e/testcases/offline/offline-event-overview.spec.ts
@@ -6,6 +6,7 @@ import { mockNetworkConditions } from '../../mock-network-conditions'
 import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { CREDENTIALS } from '../../constants'
 import { formatV2ChildName } from '../birth/helpers'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
 test.describe.serial('Can view non-downloaded event online', () => {
   let page: Page
@@ -32,7 +33,7 @@ test.describe.serial('Can view non-downloaded event online', () => {
   })
 
   test('Open the event overview page', async () => {
-    await page.getByRole('button', { name: childName, exact: true }).click()
+    await openRecordByTitle(page, childName)
   })
 
   test('Verify user can only see non-secured details', async () => {
@@ -77,7 +78,7 @@ test.describe.serial('Can partially view non-downloaded event offline', () => {
   })
 
   test('Open the event overview page', async () => {
-    await page.getByRole('button', { name: childName, exact: true }).click()
+    await openRecordByTitle(page, childName)
   })
 
   test('Verify user can only see non-secured details', async () => {
@@ -135,7 +136,7 @@ test.describe.serial('Can view downloaded event offline', () => {
   })
 
   test('Open the event overview page', async () => {
-    await page.getByRole('button', { name: childName, exact: true }).click()
+    await openRecordByTitle(page, childName)
   })
 
   test('Verify that user can see secured details', async () => {

--- a/e2e/testcases/print-certificate/birth/helpers.ts
+++ b/e2e/testcases/print-certificate/birth/helpers.ts
@@ -1,7 +1,5 @@
 import { Page, expect } from '@playwright/test'
-import { Declaration } from '../../test-data/birth-declaration'
 import { ensureAssignedToUser, selectAction } from '../../../utils'
-import { formatName } from '../../../helpers'
 import { formatV2ChildName } from '../../birth/helpers'
 import { CREDENTIALS } from '../../../constants'
 

--- a/e2e/testcases/print-certificate/birth/helpers.ts
+++ b/e2e/testcases/print-certificate/birth/helpers.ts
@@ -30,7 +30,8 @@ export async function navigateToCertificatePrintAction(
   username: (typeof CREDENTIALS)[keyof typeof CREDENTIALS]
 ) {
   const childName = formatV2ChildName(declaration)
-  await page.getByRole('button', { name: childName }).click()
+
+  await openRecordByTitle(page, childName)
 
   await ensureAssignedToUser(page, username)
   await selectAction(page, 'Print')

--- a/e2e/testcases/quick-search/searchbar-visility-by-scope.spec.ts
+++ b/e2e/testcases/quick-search/searchbar-visility-by-scope.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test'
-import { CREDENTIALS, SAFE_OUTBOX_TIMEOUT_MS } from '../../constants'
+import { CREDENTIALS } from '../../constants'
 import { login } from '../../helpers'
 
 const testCases = [
@@ -41,7 +41,7 @@ test.describe('Search bar should be visible only if the user has search scope', 
       await login(page, credential)
 
       await expect(page.getByText('Farajaland CRS')).toBeVisible({
-        timeout: SAFE_OUTBOX_TIMEOUT_MS
+        timeout: 30_000
       })
 
       if (hasSearch) {

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -1,5 +1,5 @@
 import { Locator, Page, expect } from '@playwright/test'
-import { CLIENT_URL, SAFE_OUTBOX_TIMEOUT_MS } from './constants'
+import { CLIENT_URL } from './constants'
 import { isMobile } from './mobile-helpers'
 
 type Workqueue =
@@ -129,7 +129,7 @@ export async function ensureAssignedToUser(
 
   await expect(
     page.getByTestId('assignedTo-value').locator('span')
-  ).toContainText(userFullName, { timeout: SAFE_OUTBOX_TIMEOUT_MS })
+  ).toContainText(userFullName)
 }
 
 export async function expectInUrl(page: Page, assertionString: string) {

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -1,10 +1,5 @@
 import { Locator, Page, expect } from '@playwright/test'
-import {
-  CLIENT_URL,
-  SAFE_IN_EXTERNAL_VALIDATION_MS,
-  SAFE_INPUT_CHANGE_TIMEOUT_MS,
-  SAFE_OUTBOX_TIMEOUT_MS
-} from './constants'
+import { CLIENT_URL, SAFE_OUTBOX_TIMEOUT_MS } from './constants'
 import { isMobile } from './mobile-helpers'
 
 type Workqueue =
@@ -141,39 +136,6 @@ export async function expectInUrl(page: Page, assertionString: string) {
   await expect(page).toHaveURL((url) =>
     decodeURIComponent(url.toString()).includes(assertionString)
   )
-}
-
-/**
- * Checks if user has pending item visible in outbox sidebar.
- * @deprecated This will make every test flaky. Outbox is user dependent. When running tests in parallel, there will be interference between tests and they will fail.
- *
- * Consider using `await page.waitForResponse((response) => response.url() === 'https://example.com' && response.status() === 200)` if you cannot find another UI element to wait for.
- */
-export async function ensureOutboxIsEmpty(page: Page) {
-  await page.waitForTimeout(SAFE_INPUT_CHANGE_TIMEOUT_MS)
-
-  await expect(page.locator('#navigation_workqueue_outbox')).toHaveText(
-    'Outbox',
-    {
-      timeout: SAFE_OUTBOX_TIMEOUT_MS
-    }
-  )
-}
-
-/**
- * Checks if user has pending item visible in external validation sidebar.
- * @deprecated This will make every test flaky. External validation is user dependent. When running tests in parallel, there will be interference between tests and they will fail.
- *
- * Consider using `await page.waitForResponse((response) => response.url() === 'https://example.com' && response.status() === 200)` if you cannot find another UI element to wait for.
- */
-export async function ensureInExternalValidationIsEmpty(page: Page) {
-  await page.waitForTimeout(SAFE_INPUT_CHANGE_TIMEOUT_MS)
-
-  await expect(
-    page.locator('#navigation_workqueue_in-external-validation')
-  ).toHaveText('Pending external validation', {
-    timeout: SAFE_IN_EXTERNAL_VALIDATION_MS
-  })
 }
 
 export async function selectLocationOption(page: Page, locationName: string) {


### PR DESCRIPTION
## Description
Deprecate flaky constructs. Outbox is shared globally, so relying on it did not work for us. Check for the specific action to complete instead.
- `SAFE_WORKQUEUE_TIMEOUT_MS`
- `ensureOutboxIsEmpty`
- use `openRecordByTitle` instead of clicking in workqueue. Parallel runs ensure that we select the right item and click the wrong one otherwise. workqueue updates so fast.

Order e2e tests based on the time they take on farajaland e2e runs, too 


Link this pull request to the GitHub issue (and optionally name the branch `ocrvs-<issue #>`)

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
