### PR TITLE
E2e test: reconnect during application loading

### DIFF
--- a/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-2.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/approval-of-late-birth-registration-2.spec.ts
@@ -356,9 +356,7 @@ test.describe
 
     test('Go to record', async () => {
       await page.getByText('Recent').click()
-
       await openRecordByTitle(page, childNameFormatted)
-      await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     })
 
     test("Event should have the 'Approval required for late registration' -flag", async () => {
@@ -369,6 +367,8 @@ test.describe
       await expect(page.getByTestId('flags-value')).not.toHaveText(
         'Edit in progress'
       )
+
+      await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     })
 
     test('Assert audit trail', async () => {

--- a/e2e/testcases/offline/reconnect-during-application-loading.spec.ts
+++ b/e2e/testcases/offline/reconnect-during-application-loading.spec.ts
@@ -5,7 +5,8 @@ import { createPIN, getToken } from '../../helpers'
 import { mockNetworkConditions } from '../../mock-network-conditions'
 
 test('Reconnect during application loading', async ({ browser }) => {
-  const page = await browser.newPage()
+  const context = await browser.newContext()
+  const page = await context.newPage()
 
   await test.step('Prepare login', async () => {
     const token = await getToken(CREDENTIALS.REGISTRAR)
@@ -17,6 +18,7 @@ test('Reconnect during application loading', async ({ browser }) => {
   await test.step('Begin loading application in offline mode', async () => {
     await mockNetworkConditions(page, 'offline')
     await page.goto(CLIENT_URL)
+    await expect(page.getByText('Installing application...')).toBeVisible()
   })
 
   await test.step('Reconnect to network', async () => {

--- a/e2e/testcases/offline/reconnect-during-application-loading.spec.ts
+++ b/e2e/testcases/offline/reconnect-during-application-loading.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test'
+import { CLIENT_URL, CREDENTIALS } from '../../constants'
+import { expectInUrl } from '../../utils'
+import { createPIN, getToken } from '../../helpers'
+import { mockNetworkConditions } from '../../mock-network-conditions'
+
+test('Reconnect during application loading', async ({ browser }) => {
+  const page = await browser.newPage()
+
+  await test.step('Prepare login', async () => {
+    const token = await getToken(CREDENTIALS.REGISTRAR)
+    await page.goto(`${CLIENT_URL}?token=${token}`, { waitUntil: 'commit' })
+    await page.waitForSelector('#pin-input, #appSpinner', { state: 'visible' })
+    await createPIN(page)
+  })
+
+  await test.step('Begin loading application in offline mode', async () => {
+    await mockNetworkConditions(page, 'offline')
+    await page.goto(CLIENT_URL)
+    await expect(page.getByText('Installing application...')).toBeVisible()
+  })
+
+  await test.step('Reconnect to network', async () => {
+    await mockNetworkConditions(page, 'default')
+  })
+
+  await test.step('Application should be visible', async () => {
+    await expect(page.getByText('Farajaland CRS')).toBeVisible({
+      timeout: 30000
+    })
+    await expectInUrl(page, 'assigned-to-you')
+  })
+})

--- a/e2e/testcases/offline/reconnect-during-application-loading.spec.ts
+++ b/e2e/testcases/offline/reconnect-during-application-loading.spec.ts
@@ -18,7 +18,6 @@ test('Reconnect during application loading', async ({ browser }) => {
   await test.step('Begin loading application in offline mode', async () => {
     await mockNetworkConditions(page, 'offline')
     await page.goto(CLIENT_URL)
-    await expect(page.getByText('Installing application...')).toBeVisible()
   })
 
   await test.step('Reconnect to network', async () => {

--- a/e2e/testcases/offline/reconnect-during-application-loading.spec.ts
+++ b/e2e/testcases/offline/reconnect-during-application-loading.spec.ts
@@ -17,9 +17,6 @@ test('Reconnect during application loading', async ({ browser }) => {
   await test.step('Begin loading application in offline mode', async () => {
     await mockNetworkConditions(page, 'offline')
     await page.goto(CLIENT_URL)
-    await expect(page.getByText('Installing application...')).toBeVisible({
-      timeout: 30000
-    })
   })
 
   await test.step('Reconnect to network', async () => {

--- a/e2e/testcases/offline/reconnect-during-application-loading.spec.ts
+++ b/e2e/testcases/offline/reconnect-during-application-loading.spec.ts
@@ -17,10 +17,13 @@ test('Reconnect during application loading', async ({ browser }) => {
   await test.step('Begin loading application in offline mode', async () => {
     await mockNetworkConditions(page, 'offline')
     await page.goto(CLIENT_URL)
-    await expect(page.getByText('Installing application...')).toBeVisible()
+    await expect(page.getByText('Installing application...')).toBeVisible({
+      timeout: 30000
+    })
   })
 
   await test.step('Reconnect to network', async () => {
+    await page.waitForTimeout(5000)
     await mockNetworkConditions(page, 'default')
   })
 


### PR DESCRIPTION
## Description

Core PR: https://github.com/opencrvs/opencrvs-core/pull/12995

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
