### PR TITLE
e2e testcase: Clearing field during 'Notify with edits'

### DIFF
--- a/e2e/testcases/birth/declarations/clear-field-after-notify-edit.spec.ts
+++ b/e2e/testcases/birth/declarations/clear-field-after-notify-edit.spec.ts
@@ -90,8 +90,8 @@ test('Cleared field values are removed after editing and re-notifying a declarat
     // The name was cleared, so the record can no longer be found by its title;
     // reopen it directly via the URL captured earlier.
     await page.goto(recordUrl)
-    await page.waitForLoadState('networkidle')
-    await page.getByText("You've been unassigned from the event")
+
+    await expect(page.getByLabel('Assign record')).toBeVisible()
     await ensureAssignedToUser(page, CREDENTIALS.COMMUNITY_LEADER)
     await switchEventTab(page, 'Record')
 

--- a/e2e/testcases/birth/declarations/clear-field-after-notify-edit.spec.ts
+++ b/e2e/testcases/birth/declarations/clear-field-after-notify-edit.spec.ts
@@ -22,6 +22,8 @@ test('Cleared field values are removed after editing and re-notifying a declarat
   const formattedChildName = formatName(childName)
   const childDob = { dd: '12', mm: '03', yyyy: '2015' }
   let dobValueBefore = ''
+  let nameValueBefore = ''
+  let recordUrl = ''
 
   await test.step('Login as Community Leader', async () => {
     await login(page, CREDENTIALS.COMMUNITY_LEADER)
@@ -45,23 +47,37 @@ test('Cleared field values are removed after editing and re-notifying a declarat
     await triggerDeclarationAction(page, 'Notify')
   })
 
-  await test.step('Open the notified record and capture the date of birth shown', async () => {
+  await test.step('Open the notified record and capture the values shown', async () => {
     await page.getByText('Recent').click()
     await openRecordByTitle(page, formattedChildName)
     await expect(page.getByTestId('status-value')).toHaveText('Notified')
-    await ensureAssignedToUser(page, CREDENTIALS.COMMUNITY_LEADER)
+    // Capture the record URL so it can be reopened after the name (used as the workqueue row title) has been cleared.
+    recordUrl = page.url()
 
+    await ensureAssignedToUser(page, CREDENTIALS.COMMUNITY_LEADER)
     await switchEventTab(page, 'Record')
+
     const dob = page.getByTestId('row-value-child.dob')
     await expect(dob).toContainText(childDob.yyyy)
     dobValueBefore = (await dob.innerText()).trim()
+
+    const name = page.getByTestId('row-value-child.name')
+    await expect(name).toContainText(childName.familyName)
+    nameValueBefore = (await name.innerText()).trim()
   })
 
-  await test.step('Edit the notification and clear the date of birth', async () => {
+  await test.step('Edit the notification and clear the date of birth and the (complex) name field', async () => {
     await selectAction(page, 'Edit')
 
     await page.getByTestId('change-button-child.dob').click()
+
+    // Clear the date of birth ...
     await fillDate(page, { dd: '', mm: '', yyyy: '' })
+
+    // ... and clear the child's name, a complex (multi-part) field, on the
+    // same page.
+    await page.locator('#firstname').fill('')
+    await page.locator('#surname').fill('')
 
     await page.getByRole('button', { name: 'Go to review' }).click()
   })
@@ -70,14 +86,22 @@ test('Cleared field values are removed after editing and re-notifying a declarat
     await triggerDeclarationAction(page, 'Notify with edits')
   })
 
-  await test.step('Record no longer shows the previously entered date of birth', async () => {
-    await openRecordByTitle(page, formattedChildName)
+  await test.step('Record no longer shows the previously entered date of birth or name', async () => {
+    // The name was cleared, so the record can no longer be found by its title;
+    // reopen it directly via the URL captured earlier.
+    await page.goto(recordUrl)
+    await page.waitForLoadState('networkidle')
+    await page.getByText("You've been unassigned from the event")
     await ensureAssignedToUser(page, CREDENTIALS.COMMUNITY_LEADER)
     await switchEventTab(page, 'Record')
 
-    // The cleared value must not persist: the date of birth row must no longer display the value entered before the edit.
+    // The cleared values must not persist: neither the date of birth nor the
+    // name row may still display the value entered before the edit.
     await expect(page.getByTestId('row-value-child.dob')).not.toHaveText(
       dobValueBefore
+    )
+    await expect(page.getByTestId('row-value-child.name')).not.toHaveText(
+      nameValueBefore
     )
   })
 })

--- a/e2e/testcases/birth/declarations/clear-field-after-notify-edit.spec.ts
+++ b/e2e/testcases/birth/declarations/clear-field-after-notify-edit.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test'
+import {
+  formatName,
+  goToSection,
+  login,
+  switchEventTab,
+  triggerDeclarationAction
+} from '../../../helpers'
+import { faker } from '@faker-js/faker'
+import { CREDENTIALS } from '../../../constants'
+import { ensureAssignedToUser, selectAction } from '../../../utils'
+import { fillDate } from '../helpers'
+import { openRecordByTitle } from '../../print-certificate/birth/helpers'
+
+test('Cleared field values are removed after editing and re-notifying a declaration', async ({
+  page
+}) => {
+  const childName = {
+    firstNames: faker.person.firstName(),
+    familyName: faker.person.lastName()
+  }
+  const formattedChildName = formatName(childName)
+  const childDob = { dd: '12', mm: '03', yyyy: '2015' }
+  let dobValueBefore = ''
+
+  await test.step('Login as Community Leader', async () => {
+    await login(page, CREDENTIALS.COMMUNITY_LEADER)
+  })
+
+  await test.step('Initiate birth declaration', async () => {
+    await page.click('#header-new-event')
+    await page.getByLabel('Birth').click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await page.getByRole('button', { name: 'Continue' }).click()
+  })
+
+  await test.step("Fill child's name and date of birth", async () => {
+    await page.locator('#firstname').fill(childName.firstNames)
+    await page.locator('#surname').fill(childName.familyName)
+    await fillDate(page, childDob)
+  })
+
+  await test.step('Continue to review and Notify', async () => {
+    await goToSection(page, 'review')
+    await triggerDeclarationAction(page, 'Notify')
+  })
+
+  await test.step('Open the notified record and capture the date of birth shown', async () => {
+    await page.getByText('Recent').click()
+    await openRecordByTitle(page, formattedChildName)
+    await expect(page.getByTestId('status-value')).toHaveText('Notified')
+    await ensureAssignedToUser(page, CREDENTIALS.COMMUNITY_LEADER)
+
+    await switchEventTab(page, 'Record')
+    const dob = page.getByTestId('row-value-child.dob')
+    await expect(dob).toContainText(childDob.yyyy)
+    dobValueBefore = (await dob.innerText()).trim()
+  })
+
+  await test.step('Edit the notification and clear the date of birth', async () => {
+    await selectAction(page, 'Edit')
+
+    await page.getByTestId('change-button-child.dob').click()
+    await fillDate(page, { dd: '', mm: '', yyyy: '' })
+
+    await page.getByRole('button', { name: 'Go to review' }).click()
+  })
+
+  await test.step('Notify again with the cleared field', async () => {
+    await triggerDeclarationAction(page, 'Notify with edits')
+  })
+
+  await test.step('Record no longer shows the previously entered date of birth', async () => {
+    await openRecordByTitle(page, formattedChildName)
+    await ensureAssignedToUser(page, CREDENTIALS.COMMUNITY_LEADER)
+    await switchEventTab(page, 'Record')
+
+    // The cleared value must not persist: the date of birth row must no longer display the value entered before the edit.
+    await expect(page.getByTestId('row-value-child.dob')).not.toHaveText(
+      dobValueBefore
+    )
+  })
+})

--- a/e2e/testcases/correction-birth/clear-field-after-correction.spec.ts
+++ b/e2e/testcases/correction-birth/clear-field-after-correction.spec.ts
@@ -1,0 +1,158 @@
+import { test, expect } from '@playwright/test'
+import { getToken, login, switchEventTab } from '../../helpers'
+import { faker } from '@faker-js/faker'
+import { CREDENTIALS } from '../../constants'
+import {
+  createDeclaration,
+  Declaration
+} from '../test-data/birth-declaration-with-mother-father'
+import { ensureAssignedToUser, expectInUrl, selectAction } from '../../utils'
+import {
+  formatV2ChildName,
+  getAdministrativeAreas,
+  getIdByName
+} from '../birth/helpers'
+import { openRecordByTitle } from '../print-certificate/birth/helpers'
+import { AddressType } from '@opencrvs/toolkit/events'
+
+test('Cleared field values are removed after correcting a registered birth record', async ({
+  page
+}) => {
+  const weightAtBirth = 3.2
+  const town = faker.location.city()
+  const residentialArea = faker.location.county()
+
+  let declaration: Declaration
+  let eventId: string
+  let weightValueBefore = ''
+  let recordUrl = ''
+
+  await test.step('Create and register a birth record via API', async () => {
+    const token = await getToken(CREDENTIALS.REGISTRAR)
+    const administrativeAreas = await getAdministrativeAreas(token)
+    const village = getIdByName(administrativeAreas, 'Klow')
+
+    const res = await createDeclaration(
+      token,
+      {
+        'child.weightAtBirth': weightAtBirth,
+        'child.birthLocation.privateHome': {
+          country: 'FAR',
+          addressType: AddressType.DOMESTIC,
+          administrativeArea: village,
+          streetLevelDetails: { town, residentialArea }
+        }
+      },
+      'REGISTER',
+      'PRIVATE_HOME'
+    )
+
+    declaration = res.declaration
+    eventId = res.eventId
+  })
+
+  await test.step('Login as Local Registrar', async () => {
+    await login(page, CREDENTIALS.REGISTRAR)
+  })
+
+  await test.step('Open the registered record and capture the values shown', async () => {
+    await page.getByRole('button', { name: 'Pending certification' }).click()
+    await openRecordByTitle(page, formatV2ChildName(declaration))
+
+    recordUrl = page.url()
+
+    await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
+    await switchEventTab(page, 'Record')
+
+    const weight = page.getByTestId('row-value-child.weightAtBirth')
+    await expect(weight).toContainText(weightAtBirth.toString())
+    weightValueBefore = (await weight.innerText()).trim()
+
+    const birthLocation = page.getByTestId(
+      'row-value-child.birthLocation.privateHome'
+    )
+    await expect(birthLocation).toContainText(town)
+    await expect(birthLocation).toContainText(residentialArea)
+  })
+
+  await test.step('Start correction and complete the onboarding steps', async () => {
+    await selectAction(page, 'Correct')
+
+    await page.locator('#requester____type').click()
+    await page.getByText('Informant (Mother)', { exact: true }).click()
+
+    await page.locator('#reason____option').click()
+    await page
+      .getByText('Myself or an agent made a mistake (Clerical error)', {
+        exact: true
+      })
+      .click()
+
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await page.getByRole('button', { name: 'Verified' }).click()
+
+    const path = require('path')
+    const attachmentPath = path.join(__dirname, '../test-data/image.png')
+    const inputFile = page.locator(
+      'input[name="documents____supportingDocs"][type="file"]'
+    )
+
+    await page.getByTestId('select__documents____supportingDocs').click()
+    await page.getByText('Affidavit', { exact: true }).click()
+    await inputFile.setInputFiles(attachmentPath)
+
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    await page
+      .locator('#fees____amount')
+      .fill(faker.number.int({ min: 1, max: 1000 }).toString())
+    await page.getByRole('button', { name: 'Continue' }).click()
+
+    await expectInUrl(page, `/events/request-correction/${eventId}/review`)
+  })
+
+  await test.step('Clear weight at birth and optional residential address fields (town, residential area)', async () => {
+    await page.getByTestId('change-button-child.weightAtBirth').click()
+
+    await page.locator('#child____weightAtBirth').fill('')
+
+    await page.getByTestId('text__town').fill('')
+    await page.locator('#residentialArea').fill('')
+
+    await page.getByRole('button', { name: 'Go to review' }).click()
+  })
+
+  await test.step('Submit the correction', async () => {
+    await page.getByRole('button', { name: 'Continue' }).click()
+    await expectInUrl(page, `/events/request-correction/${eventId}/summary`)
+
+    const correctionResponse = page.waitForResponse(
+      (res) =>
+        res.url().includes('event.actions.correction.approve.request') &&
+        res.ok()
+    )
+
+    await page.getByRole('button', { name: 'Correct' }).click()
+    await page.getByRole('button', { name: 'Confirm', exact: true }).click()
+
+    await correctionResponse
+  })
+
+  await test.step('Record no longer shows the previously entered weight or address details', async () => {
+    await page.goto(recordUrl)
+
+    await expect(page.getByLabel('Assign record')).toBeVisible()
+    await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
+    await switchEventTab(page, 'Record')
+
+    await expect(
+      page.getByTestId('row-value-child.weightAtBirth')
+    ).not.toHaveText(weightValueBefore)
+
+    const birthLocation = page.getByTestId(
+      'row-value-child.birthLocation.privateHome'
+    )
+    await expect(birthLocation).not.toContainText(town)
+    await expect(birthLocation).not.toContainText(residentialArea)
+  })
+})


### PR DESCRIPTION
## Description

core PR: https://github.com/opencrvs/opencrvs-core/pull/13031

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
