### PR TITLE
Add assertion for accepted/rejected correction properly appearing in 'Recent' workqueue

### DIFF
--- a/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
@@ -383,7 +383,6 @@ test.describe.serial('Correct record - 2', () => {
   test('2.9 Validate history in record audit', async ({ browser }) => {
     const page = await browser.newPage()
     test.step('2.9.0 Login', async () => {
-      const page = await browser.newPage()
       await login(page, CREDENTIALS.REGISTRAR)
       await searchFromSearchBar(page, formatV2ChildName(declaration))
     })

--- a/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
@@ -4,6 +4,7 @@ import {
   formatName,
   getToken,
   login,
+  searchFromSearchBar,
   uploadImage
 } from '../../helpers'
 import { faker } from '@faker-js/faker'
@@ -383,6 +384,7 @@ test.describe.serial('Correct record - 2', () => {
     test('2.9.0 Login', async ({ browser }) => {
       const page = await browser.newPage()
       await login(page, CREDENTIALS.REGISTRAR)
+      await searchFromSearchBar(page, formatV2ChildName(declaration))
     })
 
     test('2.9.1 Assign', async () => {

--- a/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
@@ -380,22 +380,23 @@ test.describe.serial('Correct record - 2', () => {
     })
   })
 
-  test.describe('2.9 Validate history in record audit', async () => {
-    test('2.9.0 Login', async ({ browser }) => {
+  test('2.9 Validate history in record audit', async ({ browser }) => {
+    const page = await browser.newPage()
+    test.step('2.9.0 Login', async () => {
       const page = await browser.newPage()
       await login(page, CREDENTIALS.REGISTRAR)
       await searchFromSearchBar(page, formatV2ChildName(declaration))
     })
 
-    test('2.9.1 Assign', async () => {
+    test.step('2.9.1 Assign', async () => {
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     })
 
-    test('2.9.2 Navigate to record audit', async () => {
+    test.step('2.9.2 Navigate to record audit', async () => {
       await page.getByRole('button', { name: 'Audit' }).click()
     })
 
-    test('2.9.3 Validate correction requested modal', async () => {
+    test.step('2.9.3 Validate correction requested modal', async () => {
       await page
         .getByRole('button', { name: 'Correction requested', exact: true })
         .click()
@@ -431,7 +432,7 @@ test.describe.serial('Correct record - 2', () => {
       await page.getByRole('button', { name: 'Next page' }).click()
     })
 
-    test('2.9.4 Validate correction rejected modal', async () => {
+    test.step('2.9.4 Validate correction rejected modal', async () => {
       await page
         .getByRole('button', { name: 'Correction rejected', exact: true })
         .click()

--- a/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
@@ -368,6 +368,15 @@ test.describe.serial('Correct record - 2', () => {
 
       await expectInUrl(page, `/events/${eventId}`)
     })
+
+    test("2.8.4 Rejected correction appears in the Registrar's 'Recent' workqueue", async () => {
+      await page.getByTestId('exit-event').click()
+      await page.getByText('Recent').click()
+
+      await expect(
+        page.getByRole('button', { name: formatV2ChildName(declaration) })
+      ).toBeVisible()
+    })
   })
 
   test.describe('2.9 Validate history in record audit', async () => {

--- a/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
+++ b/e2e/testcases/correction-birth/correct-birth-record-2.spec.ts
@@ -4,7 +4,6 @@ import {
   formatName,
   getToken,
   login,
-  searchFromSearchBar,
   uploadImage
 } from '../../helpers'
 import { faker } from '@faker-js/faker'
@@ -369,33 +368,23 @@ test.describe.serial('Correct record - 2', () => {
 
       await expectInUrl(page, `/events/${eventId}`)
     })
-
-    test("2.8.4 Rejected correction appears in the Registrar's 'Recent' workqueue", async () => {
-      await page.getByTestId('exit-event').click()
-      await page.getByText('Recent').click()
-
-      await expect(
-        page.getByRole('button', { name: formatV2ChildName(declaration) })
-      ).toBeVisible()
-    })
   })
 
-  test('2.9 Validate history in record audit', async ({ browser }) => {
-    const page = await browser.newPage()
-    test.step('2.9.0 Login', async () => {
+  test.describe('2.9 Validate history in record audit', async () => {
+    test('2.9.0 Login', async ({ browser }) => {
+      const page = await browser.newPage()
       await login(page, CREDENTIALS.REGISTRAR)
-      await searchFromSearchBar(page, formatV2ChildName(declaration))
     })
 
-    test.step('2.9.1 Assign', async () => {
+    test('2.9.1 Assign', async () => {
       await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
     })
 
-    test.step('2.9.2 Navigate to record audit', async () => {
+    test('2.9.2 Navigate to record audit', async () => {
       await page.getByRole('button', { name: 'Audit' }).click()
     })
 
-    test.step('2.9.3 Validate correction requested modal', async () => {
+    test('2.9.3 Validate correction requested modal', async () => {
       await page
         .getByRole('button', { name: 'Correction requested', exact: true })
         .click()
@@ -431,7 +420,7 @@ test.describe.serial('Correct record - 2', () => {
       await page.getByRole('button', { name: 'Next page' }).click()
     })
 
-    test.step('2.9.4 Validate correction rejected modal', async () => {
+    test('2.9.4 Validate correction rejected modal', async () => {
       await page
         .getByRole('button', { name: 'Correction rejected', exact: true })
         .click()

--- a/e2e/testcases/correction-birth/request-escalate-approve-correction.spec.ts
+++ b/e2e/testcases/correction-birth/request-escalate-approve-correction.spec.ts
@@ -311,4 +311,15 @@ test.describe
       page.getByRole('button', { name: 'Correction approved', exact: true })
     ).toBeVisible()
   })
+
+  test("Approved correction appears in the Registrar's 'Recent' workqueue", async () => {
+    await page.getByTestId('exit-event').click()
+    await page.getByText('Recent').click()
+
+    await expect(
+      page.getByRole('button', {
+        name: formatV2ChildName({ 'child.name': updatedChildDetails })
+      })
+    ).toBeVisible()
+  })
 })


### PR DESCRIPTION
## Description

Core PR: https://github.com/opencrvs/opencrvs-core/pull/13035

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
