### PR TITLE
e2e test: Fix '(Notify/Declare/Register) with edits' not being blocked by unmet conditionals

### DIFF
--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -406,6 +406,7 @@ export async function validateActionMenuButton(
     | 'Notify'
     | 'Approve'
     | 'Register'
+    | 'Notify with edits'
     | 'Declare with edits'
     | 'Register with edits',
   isEnabled = true

--- a/e2e/testcases/custom-actions-and-flags/death-attest-flow.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/death-attest-flow.spec.ts
@@ -9,14 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { expect, test } from '@playwright/test'
-import { faker } from '@faker-js/faker'
-import {
-  continueForm,
-  goToSection,
-  login,
-  triggerDeclarationAction,
-  validateActionMenuButton
-} from '../../helpers'
+import { getToken, login, validateActionMenuButton } from '../../helpers'
 import { CREDENTIALS } from '../../constants'
 import {
   ensureAssignedToUser,
@@ -24,77 +17,67 @@ import {
   selectAction
 } from '../../utils'
 import { openRecordByTitle } from '../print-certificate/birth/helpers'
+import { createDeclaration, Declaration } from '../test-data/death-declaration'
+import { ActionType } from '@opencrvs/toolkit/events'
 
 test('Death notified at a health facility is held for attestation, then reaches the registrar once attested', async ({
   browser
 }) => {
-  const deceasedName = {
-    firstname: faker.person.firstName('male'),
-    surname: faker.person.lastName('male')
-  }
-  const title = `${deceasedName.firstname} ${deceasedName.surname}`
+  let declaration: Declaration
+  let name: string
 
   const page = await browser.newPage()
 
-  await test.step('Hospital Official notifies a death at a health facility', async () => {
-    await login(page, CREDENTIALS.HOSPITAL_OFFICIAL)
+  await test.step('Hospital Official notifies a death at a health facility (via API)', async () => {
+    const token = await getToken(CREDENTIALS.HOSPITAL_OFFICIAL)
 
-    await page.click('#header-new-event')
-    await page.getByLabel('Death').click()
-    await page.getByRole('button', { name: 'Continue' }).click()
-    await page.getByRole('button', { name: 'Continue' }).click()
-
-    await page.locator('#firstname').fill(deceasedName.firstname)
-    await page.locator('#surname').fill(deceasedName.surname)
-    await continueForm(page)
-
-    await page.getByTestId('select__eventDetails____placeOfDeath').click()
-    await page.getByText('Health Institution', { exact: true }).click()
-    await page.locator('#eventDetails____deathLocation').fill('Klow Village')
-    await page.getByText('Klow Village Hospital').click()
-    await page.getByRole('button', { name: 'Continue' }).click()
-
-    await page.getByRole('button', { name: 'Continue' }).click()
-
-    await goToSection(page, 'review')
-    await triggerDeclarationAction(page, 'Notify')
-    await expect(page.getByText('Farajaland CRS')).toBeVisible()
+    // Notify a declaration with full details, so we can ensure that declare is blocked by the attestation-required flag, and not missing details.
+    const res = await createDeclaration(
+      token,
+      undefined,
+      ActionType.NOTIFY,
+      'HEALTH_FACILITY'
+    )
+    declaration = res.declaration
+    name = `${declaration['deceased.name'].firstname} ${declaration['deceased.name'].surname}`
   })
 
   await test.step('Record is held in the Hospital Official Pending attestation workqueue', async () => {
+    await login(page, CREDENTIALS.HOSPITAL_OFFICIAL)
     await navigateToWorkqueue(page, 'Pending attestation')
-    await expect(page.getByRole('button', { name: title })).toBeVisible()
+    await expect(page.getByRole('button', { name })).toBeVisible()
   })
 
-  // @TODO: Waiting for new hospital official edit scope with notifiedBy (instead of declaredBy)
-  await test.step.skip(
-    'While awaiting attestation the record can still be edited and re-notified, but not declared',
-    async () => {
-      await openRecordByTitle(page, title)
-      await ensureAssignedToUser(page, CREDENTIALS.HOSPITAL_OFFICIAL)
+  await test.step('User cannot "Declare with edits" a record that is pending attestation', async () => {
+    await page.getByRole('button', { name }).click()
 
-      await selectAction(page, 'Edit')
+    await expect(page.getByTestId('flags-value')).toContainText(
+      'Attestation required'
+    )
 
-      await page.getByTestId('change-button-deceased.gender').click()
-      await page.getByRole('button', { name: 'Continue' }).click()
-      await page.locator('#deceased____gender').click()
-      await page.getByText('Male', { exact: true }).click()
-      await page.getByRole('button', { name: 'Go to review' }).click()
+    await expect(page.getByTestId('status-value')).toContainText('Notified')
 
-      await validateActionMenuButton(page, 'Declare with edits', false)
+    await ensureAssignedToUser(page, CREDENTIALS.HOSPITAL_OFFICIAL)
+    await selectAction(page, 'Edit')
 
-      await triggerDeclarationAction(page, 'Notify with edits')
-      await expect(page.getByText('Farajaland CRS')).toBeVisible()
-    }
-  )
+    // Change the gender of the deceased
+    await page.getByTestId('change-button-deceased.gender').click()
+    await page.locator('#deceased____gender').click()
+    await page.getByText('Female', { exact: true }).click()
+    await page.getByRole('button', { name: 'Go to review' }).click()
+
+    // Re-notify should be allowed, but declare should be blocked by 'Attestation required' flag.
+    await validateActionMenuButton(page, 'Notify with edits', true)
+    await validateActionMenuButton(page, 'Declare with edits', false)
+  })
 
   await test.step('Health Administrator sees the record in Pending attestation and attests it', async () => {
     await login(page, CREDENTIALS.HEALTH_ADMINISTRATOR)
 
     await navigateToWorkqueue(page, 'Pending attestation')
-    await expect(page.getByRole('button', { name: title })).toBeVisible()
+    await expect(page.getByRole('button', { name })).toBeVisible()
 
-    await openRecordByTitle(page, title)
+    await openRecordByTitle(page, name)
     await ensureAssignedToUser(page, CREDENTIALS.HEALTH_ADMINISTRATOR)
 
     // The record shows the attestation-required flag before it is attested.
@@ -117,13 +100,13 @@ test('Death notified at a health facility is held for attestation, then reaches 
   await test.step('attestation-required flag is cleared and the record leaves Pending attestation', async () => {
     // The record is no longer awaiting attestation, so it drops out of the Pending attestation workqueue.
     await navigateToWorkqueue(page, 'Pending attestation')
-    await expect(page.getByRole('button', { name: title })).toBeHidden()
+    await expect(page.getByRole('button', { name })).toBeHidden()
   })
 
   await test.step('Record reaches the Registration Official Notifications workqueue', async () => {
     await login(page, CREDENTIALS.REGISTRAR)
 
     await navigateToWorkqueue(page, 'Notifications')
-    await expect(page.getByRole('button', { name: title })).toBeVisible()
+    await expect(page.getByRole('button', { name })).toBeVisible()
   })
 })

--- a/e2e/testcases/custom-actions-and-flags/death-attest-flow.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/death-attest-flow.spec.ts
@@ -9,12 +9,7 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { expect, test } from '@playwright/test'
-import {
-  getToken,
-  login,
-  triggerDeclarationAction,
-  validateActionMenuButton
-} from '../../helpers'
+import { getToken, login, validateActionMenuButton } from '../../helpers'
 import { CREDENTIALS } from '../../constants'
 import {
   ensureAssignedToUser,
@@ -75,8 +70,11 @@ test('Death notified at a health facility is held for attestation, then reaches 
     await validateActionMenuButton(page, 'Notify with edits', true)
     await validateActionMenuButton(page, 'Declare with edits', false)
 
+    // Exit and unassign
     await page.getByRole('button', { name: 'Action' }).click()
-    await page.getByRole('button', { name: '' }).click()
+    await page.getByText('Cancel edits').click()
+    await selectAction(page, 'Unassign')
+    await page.getByRole('button', { name: 'Unassign' }).click()
   })
 
   await test.step('Health Administrator sees the record in Pending attestation and attests it', async () => {

--- a/e2e/testcases/custom-actions-and-flags/death-attest-flow.spec.ts
+++ b/e2e/testcases/custom-actions-and-flags/death-attest-flow.spec.ts
@@ -9,7 +9,12 @@
  * Copyright (C) The OpenCRVS Authors located at https://github.com/opencrvs/opencrvs-core/blob/master/AUTHORS.
  */
 import { expect, test } from '@playwright/test'
-import { getToken, login, validateActionMenuButton } from '../../helpers'
+import {
+  getToken,
+  login,
+  triggerDeclarationAction,
+  validateActionMenuButton
+} from '../../helpers'
 import { CREDENTIALS } from '../../constants'
 import {
   ensureAssignedToUser,
@@ -69,6 +74,9 @@ test('Death notified at a health facility is held for attestation, then reaches 
     // Re-notify should be allowed, but declare should be blocked by 'Attestation required' flag.
     await validateActionMenuButton(page, 'Notify with edits', true)
     await validateActionMenuButton(page, 'Declare with edits', false)
+
+    await page.getByRole('button', { name: 'Action' }).click()
+    await page.getByRole('button', { name: '' }).click()
   })
 
   await test.step('Health Administrator sees the record in Pending attestation and attests it', async () => {

--- a/e2e/testcases/test-data/death-declaration.ts
+++ b/e2e/testcases/test-data/death-declaration.ts
@@ -25,7 +25,7 @@ async function getPlaceOfDeath(
     const locationId = getIdByName(locations, 'Klow Village Hospital')
 
     return {
-      'deceased.deathLocation': locationId,
+      'eventDetails.deathLocation': locationId,
       'eventDetails.deathLocationId': locationId
     }
   }
@@ -141,6 +141,28 @@ export async function createDeclaration(
   const annotation = {
     'review.comment': 'My comment',
     'review.signature': filename
+  }
+
+  if (action === ActionType.NOTIFY) {
+    const notifyRes = await client.event.actions.notify.request.mutate({
+      eventId: eventId,
+      transactionId: uuidv4(),
+      declaration,
+      annotation
+    })
+
+    const declareAction = notifyRes.actions.find(
+      (action: ActionDocument) => action.type === ActionType.NOTIFY
+    )
+
+    if (!declareAction || !('declaration' in declareAction)) {
+      throw new Error('Declaration info not found in action')
+    }
+
+    return {
+      eventId,
+      declaration: declareAction?.declaration as Declaration
+    }
   }
 
   const declareRes = await client.event.actions.declare.request.mutate({

--- a/src/events/death/index.ts
+++ b/src/events/death/index.ts
@@ -306,6 +306,16 @@ export const deathEvent = defineConfig({
         id: 'actions.edit'
       },
       flags: [{ id: 'validated', operation: 'remove' }],
+      conditionals: [
+        {
+          type: ConditionalType.ENABLE,
+          // Only Hospital Official should be able to edit records which are pending attestation
+          conditional: or(
+            not(flag('attestation-required')),
+            user.hasRole('HOSPITAL_CLERK')
+          )
+        }
+      ],
       dialogCopy: {
         notify: {
           id: 'event.death.action.edit.notify.copy',


### PR DESCRIPTION
## Description

Core PR: https://github.com/opencrvs/opencrvs-core/pull/13136

* Ensure that 'Declare with edits' is correctly disabled if conditions are not met ('Attestation required' flag is present)
* Config fix: disallow any role, except Hospital Official, to access 'Edit' flow of 'Attestation required' record

## Checklist

- [x] I have linked the correct Github issue under "Development"
- [x] I have tested the changes locally, and written appropriate tests
- [x] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [x] I have updated the GitHub issue status accordingly
