### PR TITLE
Fix 'Notifications' workqueue to only display records with status = EventStatus.enum.NOTIFIED 

### DIFF
--- a/e2e/testcases/archival/archive-and-unarchive.spec.ts
+++ b/e2e/testcases/archival/archive-and-unarchive.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from '@playwright/test'
+import { test, expect } from '@playwright/test'
 import { v4 as uuidv4 } from 'uuid'
 import { createClient } from '@opencrvs/toolkit/api'
 import {
@@ -25,8 +25,7 @@ import { ActionType } from '@opencrvs/toolkit/events'
 import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { openRecordByTitle } from '../print-certificate/birth/helpers'
 
-test.describe.serial('Basic Archival flow', () => {
-  let page: Page
+test('Basic Archival flow', async ({ page }) => {
   const declaration = {
     child: {
       name: {
@@ -86,26 +85,18 @@ test.describe.serial('Basic Archival flow', () => {
       }
     }
   }
-  test.beforeAll(async ({ browser }) => {
-    page = await browser.newPage()
-  })
-
-  test.afterAll(async () => {
-    await page.close()
-  })
-
-  test('Login as HO', async () => {
+  await test.step('Login as HO', async () => {
     await login(page, CREDENTIALS.HOSPITAL_OFFICIAL)
   })
 
-  test('Start creating new birth declaration', async () => {
+  await test.step('Start creating new birth declaration', async () => {
     await page.click('#header-new-event')
     await page.getByLabel('Birth').click()
     await page.getByRole('button', { name: 'Continue' }).click()
     await page.getByRole('button', { name: 'Continue' }).click()
   })
 
-  test('Fill child details', async () => {
+  await test.step('Fill child details', async () => {
     await page.locator('#firstname').fill(declaration.child.name.firstNames)
     await page.locator('#surname').fill(declaration.child.name.familyName)
     await page.locator('#child____gender').click()
@@ -147,7 +138,7 @@ test.describe.serial('Basic Archival flow', () => {
     await continueForm(page)
   })
 
-  test('Fill informant details', async () => {
+  await test.step('Fill informant details', async () => {
     await page.locator('#informant____relation').click()
     await page
       .getByText(declaration.informantType, {
@@ -160,7 +151,7 @@ test.describe.serial('Basic Archival flow', () => {
     await continueForm(page)
   })
 
-  test("Fill mother's details", async () => {
+  await test.step("Fill mother's details", async () => {
     await page.locator('#firstname').fill(declaration.mother.name.firstNames)
     await page.locator('#surname').fill(declaration.mother.name.familyName)
 
@@ -220,7 +211,7 @@ test.describe.serial('Basic Archival flow', () => {
     await continueForm(page)
   })
 
-  test("Fill father's details", async () => {
+  await test.step("Fill father's details", async () => {
     await page.locator('#firstname').fill(declaration.father.name.firstNames)
     await page.locator('#surname').fill(declaration.father.name.familyName)
 
@@ -253,11 +244,11 @@ test.describe.serial('Basic Archival flow', () => {
     await page.getByRole('button', { name: 'Continue' }).click()
   })
 
-  test('Go to review', async () => {
+  await test.step('Go to review', async () => {
     await goToSection(page, 'review')
   })
 
-  test('Fill up informant comment & signature', async () => {
+  await test.step('Fill up informant comment & signature', async () => {
     await page.locator('#review____comment').fill(faker.lorem.sentence())
     await page.getByRole('button', { name: 'Sign', exact: true }).click()
     await drawSignature(page, 'review____signature_canvas_element', false)
@@ -267,11 +258,11 @@ test.describe.serial('Basic Archival flow', () => {
       .click()
   })
 
-  test('Declare', async () => {
+  await test.step('Declare', async () => {
     await triggerDeclarationAction(page, 'Declare')
   })
 
-  test('Archival is not available for HO', async () => {
+  await test.step('Archival is not available for HO', async () => {
     await page.getByText('Recent').click()
     await openRecordByTitle(page, formatName(declaration.child.name))
 
@@ -284,15 +275,15 @@ test.describe.serial('Basic Archival flow', () => {
     ).not.toBeVisible()
   })
 
-  test('Logout', async () => {
+  await test.step('Logout', async () => {
     await logout(page)
   })
 
-  test('Login as RO', async () => {
+  await test.step('Login as RO', async () => {
     await login(page, CREDENTIALS.REGISTRATION_OFFICER)
   })
 
-  test('Navigate to the event overview page', async () => {
+  await test.step('Navigate to the event overview page', async () => {
     await page.getByText('Pending validation').click()
 
     // Expect not to see a quick action for Archival
@@ -303,13 +294,13 @@ test.describe.serial('Basic Archival flow', () => {
     await openRecordByTitle(page, formatName(declaration.child.name))
   })
 
-  test('Archive the declaration', async () => {
+  await test.step('Archive the declaration', async () => {
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
     await selectAction(page, 'Archive')
     await page.getByRole('button', { name: 'Archive', exact: true }).click()
   })
 
-  test('Archived declaration is not visible in workqueues', async () => {
+  await test.step('Archived declaration is not visible in workqueues', async () => {
     await page.getByRole('button', { name: 'Pending validation' }).click()
     await expect(
       page.getByRole('button', {
@@ -318,12 +309,12 @@ test.describe.serial('Basic Archival flow', () => {
     ).not.toBeVisible()
   })
 
-  test('Archived declaration can be found via search', async () => {
+  await test.step('Archived declaration can be found via search', async () => {
     await searchFromSearchBar(page, formatName(declaration.child.name))
     await expect(page.getByTestId('status-value')).toHaveText('Archived')
   })
 
-  test('Assert available actions', async () => {
+  await test.step('Assert available actions', async () => {
     await page.getByRole('button', { name: 'Action', exact: true }).click()
     const options = await page
       .locator('#action-Dropdown-Content li')
@@ -332,36 +323,32 @@ test.describe.serial('Basic Archival flow', () => {
   })
 })
 
-test.describe.serial('Archival of declaration pending validation', () => {
-  let page: Page
-  let token: string
+test('Archival of declaration pending validation', async ({ page }) => {
   let declaration: Declaration
 
-  test.beforeAll(async ({ browser }) => {
-    token = await getToken(CREDENTIALS.HOSPITAL_OFFICIAL)
+  await test.step('Initialise a declared birth record via API', async () => {
+    const token = await getToken(CREDENTIALS.HOSPITAL_OFFICIAL)
     const res = await createDeclaration(token, undefined, ActionType.DECLARE)
     declaration = res.declaration
-
-    page = await browser.newPage()
   })
 
-  test('Login as RO', async () => {
+  await test.step('Login as RO', async () => {
     await login(page, CREDENTIALS.REGISTRATION_OFFICER)
   })
 
-  test('Navigate to the event overview page', async () => {
+  await test.step('Navigate to the event overview page', async () => {
     await page.getByText('Pending validation').click()
 
     await openRecordByTitle(page, formatV2ChildName(declaration))
   })
 
-  test('Validate the declaration', async () => {
+  await test.step('Validate the declaration', async () => {
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
 
     await triggerDeclarationAction(page, 'Validate')
   })
 
-  test('Confirm the declaration is in "Pending registration" -workqueue', async () => {
+  await test.step('Confirm the declaration is in "Pending registration" -workqueue', async () => {
     await login(page, CREDENTIALS.REGISTRAR)
 
     await page.getByText('Pending registration').click()
@@ -371,7 +358,7 @@ test.describe.serial('Archival of declaration pending validation', () => {
     await expect(page.getByTestId('flags-value')).toHaveText('Validated')
   })
 
-  test('Archive the declaration', async () => {
+  await test.step('Archive the declaration', async () => {
     await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR)
 
     // @TODO
@@ -379,14 +366,14 @@ test.describe.serial('Archival of declaration pending validation', () => {
     await page.getByRole('button', { name: 'Archive', exact: true }).click()
   })
 
-  test('Archived declaration is not visible in workqueues', async () => {
+  await test.step('Archived declaration is not visible in workqueues', async () => {
     await page.getByRole('button', { name: 'Pending registration' }).click()
     await expect(
       page.getByRole('button', { name: formatV2ChildName(declaration) })
     ).not.toBeVisible()
   })
 
-  test('Archived declaration can be found via search', async () => {
+  await test.step('Archived declaration can be found via search', async () => {
     await page.locator('#searchText').fill(formatV2ChildName(declaration))
     await page.locator('#searchIconButton').click()
     await expect(

--- a/e2e/testcases/archival/basic-archival.spec.ts
+++ b/e2e/testcases/archival/basic-archival.spec.ts
@@ -16,7 +16,11 @@ import {
 import { faker } from '@faker-js/faker'
 import { CREDENTIALS, GATEWAY_HOST } from '../../constants'
 import { fillDate, formatV2ChildName } from '../birth/helpers'
-import { ensureAssignedToUser, selectAction } from '../../utils'
+import {
+  ensureAssignedToUser,
+  navigateToWorkqueue,
+  selectAction
+} from '../../utils'
 import { ActionType } from '@opencrvs/toolkit/events'
 import { createDeclaration, Declaration } from '../test-data/birth-declaration'
 import { openRecordByTitle } from '../print-certificate/birth/helpers'
@@ -467,29 +471,30 @@ test('Archival and unarchival of a notified declaration', async ({ page }) => {
   let declaration: Declaration
 
   await test.step('Initialise a notified birth record via API', async () => {
-    // LOCAL_REGISTRAR does not hold record.notify, so a Community Leader
-    // notifies it instead.
-    const communityLeaderToken = await getToken(CREDENTIALS.COMMUNITY_LEADER)
+    const hospitalOfficialToken = await getToken(CREDENTIALS.HOSPITAL_OFFICIAL)
 
     const notifyRes = await createDeclaration(
-      communityLeaderToken,
+      hospitalOfficialToken,
       undefined,
       ActionType.NOTIFY
     )
     declaration = notifyRes.declaration
   })
 
-  // A record that has only been notified (never declared) has no
-  // legalStatuses.DECLARED, so LOCAL_REGISTRAR's declaredIn-scoped
-  // record.archive/unarchive can't match and would be denied. REGISTRAR_GENERAL
-  // (NATIONAL_REGISTRAR) holds both scopes unrestricted, so use that role here.
-  await test.step('Login as Registrar General', async () => {
-    await login(page, CREDENTIALS.REGISTRAR_GENERAL)
+  await test.step('Login as Registration Officer', async () => {
+    await login(page, CREDENTIALS.REGISTRATION_OFFICER)
+  })
+
+  await test.step('Notified record appears in the Notifications work queue', async () => {
+    await navigateToWorkqueue(page, 'Notifications')
+    await expect(
+      page.getByRole('button', { name: formatV2ChildName(declaration) })
+    ).toBeVisible()
   })
 
   await test.step('Archive the notified declaration', async () => {
-    await searchFromSearchBar(page, formatV2ChildName(declaration))
-    await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR_GENERAL)
+    await openRecordByTitle(page, formatV2ChildName(declaration))
+    await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
 
     await expect(page.getByTestId('status-value')).toHaveText('Notified')
 
@@ -507,8 +512,17 @@ test('Archival and unarchival of a notified declaration', async ({ page }) => {
     await expect(page.getByTestId('status-value')).toHaveText('Archived')
   })
 
+  await test.step('Archived record no longer appears in the Notifications work queue', async () => {
+    await page.getByTestId('exit-event').click()
+    await navigateToWorkqueue(page, 'Notifications')
+    await expect(
+      page.getByRole('button', { name: formatV2ChildName(declaration) })
+    ).toBeHidden()
+  })
+
   await test.step('Unarchive the declaration', async () => {
-    await ensureAssignedToUser(page, CREDENTIALS.REGISTRAR_GENERAL)
+    await searchFromSearchBar(page, formatV2ChildName(declaration))
+    await ensureAssignedToUser(page, CREDENTIALS.REGISTRATION_OFFICER)
 
     await selectAction(page, 'Unarchive')
 
@@ -522,5 +536,13 @@ test('Archival and unarchival of a notified declaration', async ({ page }) => {
   await test.step('Unarchived declaration reverts to Notified status', async () => {
     await searchFromSearchBar(page, formatV2ChildName(declaration))
     await expect(page.getByTestId('status-value')).toHaveText('Notified')
+  })
+
+  await test.step('Unarchived record reappears in the Notifications workqueue', async () => {
+    await page.getByTestId('exit-event').click()
+    await navigateToWorkqueue(page, 'Notifications')
+    await expect(
+      page.getByRole('button', { name: formatV2ChildName(declaration) })
+    ).toBeVisible()
   })
 })

--- a/src/api/workqueue/workqueueConfig.ts
+++ b/src/api/workqueue/workqueueConfig.ts
@@ -81,9 +81,9 @@ export const Workqueues = defineWorkqueues([
     },
     query: {
       flags: {
-        anyOf: [InherentFlags.INCOMPLETE],
         noneOf: [InherentFlags.REJECTED, 'attestation-required']
       },
+      status: { type: 'exact', term: EventStatus.enum.NOTIFIED },
       updatedAtLocation: {
         type: 'within',
         location: user('administrativeAreaId')


### PR DESCRIPTION
## Description

Resolves: https://github.com/opencrvs/opencrvs-core/issues/13157

* Fix Notifications workqueue to use `status: { type: 'exact', term: EventStatus.enum.NOTIFIED },` instead of the `InherentFlags.INCOMPLETE`
* Edit testcase for archival of notified record to check that it correctly appears in 'Notifications' workqueue
* Refactor archival tests to use test.step instead of test.describe.serial, rename the testfile

## Checklist

- [ ] I have linked the correct Github issue under "Development"
- [ ] I have tested the changes locally, and written appropriate tests
- [ ] I have tested beyond the happy path (e.g. edge cases, failure paths)
- [ ] I have updated the changelog with this change (if applicable)
- [ ] I have updated the GitHub issue status accordingly
