### PR TITLE
feat: hide mother.dob and informant.phoneNo from hospital clerks

### DIFF
--- a/src/events/birth/forms/pages/informant.ts
+++ b/src/events/birth/forms/pages/informant.ts
@@ -556,7 +556,13 @@ export const informant = defineFormPage({
           )
         }
       ],
-      parent: field('informant.relation')
+      parent: field('informant.relation'),
+      conditionals: [
+        {
+          type: ConditionalType.SHOW,
+          conditional: not(user.hasRole('HOSPITAL_CLERK'))
+        }
+      ]
     },
     {
       id: 'informant.email',

--- a/src/events/birth/forms/pages/mother.ts
+++ b/src/events/birth/forms/pages/mother.ts
@@ -185,7 +185,8 @@ export const mother = defineFormPage({
             type: ConditionalType.SHOW,
             conditional: and(
               not(field('mother.dobUnknown').isEqualTo(true)),
-              requireMotherDetails
+              requireMotherDetails,
+              not(user.hasRole('HOSPITAL_CLERK'))
             )
           }
         ]


### PR DESCRIPTION
## What

Backports the `HOSPITAL_CLERK` visibility guards for `mother.dob` and `informant.phoneNo` from the 2.1.0 line (`opencrvs-core` `develop`, `packages/testland/src/events/birth/forms/pages/`) onto `release/2.0.1`.

- **`mother.dob`** — adds `not(user.hasRole('HOSPITAL_CLERK'))` as a third clause of the existing `SHOW` conditional, alongside `not(field('mother.dobUnknown').isEqualTo(true))` and `requireMotherDetails`.
- **`informant.phoneNo`** — adds a `SHOW` conditional with the same guard. The field previously had no `conditionals` block.

Net effect: hospital clerks no longer see the mother's date of birth or the informant's phone number on the birth declaration form.

## Why it applies cleanly to 2.0.1

- `user.hasRole(role: string)` is already exported by the pinned toolkit `2.0.1-rc.4b8c3e3` (`dist/commons/conditionals/conditionals.d.ts`).
- `HOSPITAL_CLERK` is a seeded role (`src/data-seeding/roles/roles.ts`).
- The exact idiom `not(user.hasRole('HOSPITAL_CLERK'))` is already used on this branch for the place-of-birth options in `src/events/birth/forms/pages/child.ts`.
- Both files already import `user` from `@opencrvs/toolkit/events` and `not` from `@opencrvs/toolkit/conditionals`, so no import changes were needed.

`src/events/birth/forms/pages/informant.ts` is byte-identical to the upstream version after this change.

## Out of scope

The 2.1.0 diff for these two files also contained an unrelated address change — `activeOnly: true` under `configuration` for `mother.address` and `informant.address` (upstream comment: *"Self-reported present-tense address (e.g. late registration years after birth), not tied to the event date"*). That is **not** included here; it would need a separate check that the 2.0.1 toolkit's address configuration accepts that key.

## Testing

- `npx tsc --noEmit` — clean
- `npx prettier --check` on both files — clean
- `npx eslint` on both files — clean
- `NO_MOSIP=false npx vitest run --exclude e2e` — 51/51 tests pass across 8 files

Not covered by automated tests: the actual form rendering for a `HOSPITAL_CLERK` user, which is worth a manual check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
